### PR TITLE
add codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,29 @@
+codecov:
+  ci:
+    - dev.azure.com
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  status:
+    patch:
+      default:
+        target: 100%
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
+    project:
+      default: false
+      library:
+        target: auto
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
+        paths:
+          - "solarforecastarbiter/(\w+/)?[^/]+\.py$"
+      tests:
+        target: 95%
+        paths:
+          - "solarforecastarbiter/**/tests/.*"
+
+comment: off

--- a/.coverage.rc
+++ b/.coverage.rc
@@ -1,0 +1,3 @@
+[run]
+source=solarforecastarbiter
+omit=solarforecastarbiter/_version.py

--- a/README.md
+++ b/README.md
@@ -18,7 +18,12 @@ pip install -r requirements.txt -r requirements-test.txt
 pip install -e .
 ```
 
-If everything worked, you should be able to run `pytest solarforecastarbiter`
+If everything worked, you should be able to run
+
+```
+pytest solarforecastarbiter
+flake8 solarforecastarbiter
+```
 
 
 # Architecture

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://dev.azure.com/solararbiter/solarforecastarbiter/_apis/build/status/SolarArbiter.solarforecastarbiter-core?branchName=master)](https://dev.azure.com/solararbiter/solarforecastarbiter/_build/latest?definitionId=1&branchName=master)
 [![Coverage](https://img.shields.io/azure-devops/coverage/solararbiter/solarforecastarbiter/1/master.svg)](https://dev.azure.com/solararbiter/solarforecastarbiter/_build/latest?definitionId=1&branchName=master)
+[![codecov](https://codecov.io/gh/solararbiter/solarforecastarbiter-core/branch/master/graph/badge.svg)](https://codecov.io/gh/solararbiter/solarforecastarbiter-core)
 
 # solarforecastarbiter-core
 Core Solar Forecast Arbiter data gathering, validation, processing, and

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,10 @@ jobs:
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
       reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
+  - script: |
+      bash <(curl https://codecov.io/bash) -t 09612e67-185b-4d89-9527-5e9322b8838b -f coverage.xml -F adder -F subtractor
+    displayName: 'codecov'
+
 - job: 'Publish'
   dependsOn: 'Test'
   pool:


### PR DESCRIPTION
following

https://blog.codecov.io/2019/01/24/new-in-codecov-4-4-3/
https://github.com/codecov/example-azure-pipelines

The pvlib travis config pip installs codecov instead. I don't know why the azure spec is different. https://github.com/pvlib/pvlib-python/blob/master/.travis.yml#L82-L86

starting with the pvlib .codecov.yml file. not sure if the nested test spec will work (`- "solarforecastarbiter/**/tests/.*"`)