### PR TITLE
use setuptools on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,6 @@ python:
       - requirements: docs/requirements.txt
       - method: pip
         path: .
-   system_packages: true
+   system_packages: false
 sphinx:
   fail_on_warning: false

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ python:
    install:
       - requirements: requirements.txt
       - requirements: docs/requirements.txt
-      - method: pip
+      - method: setuptools
         path: .
    system_packages: false
 sphinx:


### PR DESCRIPTION
Unfortunately, RTD calls `pip install .` with `--ignore-installed`, effectively ignoring the requirements file specs for anything that's loosely spec'ed in `setup.py`. The work around is to use `setuptools` instead.

See https://github.com/rtfd/readthedocs.org/issues/3025 for more.

Builds on my fork: https://wholmgren-solarforecastarbiter-core.readthedocs.io/en/latest/