### PR TITLE
add interval_length to datamodel.Observation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
     packages=find_packages(),

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -63,8 +63,8 @@ def site_metadata():
 def ac_power_observation_metadata(site_metadata):
     ac_power_meta = datamodel.Observation(
         name='Albuquerque Baseline AC Power', variable='ac_power',
-        value_type='instantaneous', interval_label='instant',
-        site=site_metadata, uncertainty=1)
+        value_type='instantaneous', interval_length=pd.Timedelta('5min'),
+        interval_label='instant', site=site_metadata, uncertainty=1)
     return ac_power_meta
 
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -190,6 +190,9 @@ class Observation:
     value_type : str
         The type of the data in the observation. Typically interval mean or
         instantaneous, but additional types may be defined for events.
+    interval_length : str
+        The length of time between consecutive data points, e.g. 5 minutes,
+        1 hour.
     interval_label : str
         Indicates if a time labels the beginning or the ending of an interval
         average, or indicates an instantaneous value, e.g. beginning, ending,
@@ -211,6 +214,7 @@ class Observation:
     name: str
     variable: str
     value_type: str
+    interval_length: str
     interval_label: str
     site: Site
     uncertainty: float
@@ -239,7 +243,7 @@ class Forecast:
         The difference between the issue time and the start of the first
         forecast interval, e.g. 1 hour.
     interval_length : pandas.Timedelta
-        The length of time that each data point represents, e.g. 5 minutes,
+        The length of time between consecutive data points, e.g. 5 minutes,
         1 hour.
     run_length : pandas.Timedelta
         The total length of a single issued forecast run, e.g. 1 hour.

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -190,7 +190,7 @@ class Observation:
     value_type : str
         The type of the data in the observation. Typically interval mean or
         instantaneous, but additional types may be defined for events.
-    interval_length : str
+    interval_length : pandas.Timedelta
         The length of time between consecutive data points, e.g. 5 minutes,
         1 hour.
     interval_label : str
@@ -214,7 +214,7 @@ class Observation:
     name: str
     variable: str
     value_type: str
-    interval_length: str
+    interval_length: pd.Timedelta
     interval_label: str
     site: Site
     uncertainty: float


### PR DESCRIPTION
Adds interval_length to datamodel.Observation. 

Removes python 3.6 from `setup.py` classifiers. This should have been removed when we decided on using `dataclass` in #14. 