### PR TITLE
add loss factors to datamodel.PVModelingParameters

### DIFF
--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -51,7 +51,7 @@ def site_metadata():
     """
     modeling_params = datamodel.FixedTiltModelingParameters(
         ac_capacity=.003, dc_capacity=.0035, temperature_coefficient=-0.003,
-        irradiance_loss_factor=1, dc_loss_factor=3, ac_loss_factor=0,
+        dc_loss_factor=3, ac_loss_factor=0,
         surface_tilt=30, surface_azimuth=180)
     metadata = datamodel.SolarPowerPlant(
         name='Albuquerque Baseline', latitude=35.05, longitude=-106.54,

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -51,6 +51,7 @@ def site_metadata():
     """
     modeling_params = datamodel.FixedTiltModelingParameters(
         ac_capacity=.003, dc_capacity=.0035, temperature_coefficient=-0.003,
+        irradiance_loss_factor=1, dc_loss_factor=3, ac_loss_factor=0,
         surface_tilt=30, surface_azimuth=180)
     metadata = datamodel.SolarPowerPlant(
         name='Albuquerque Baseline', latitude=35.05, longitude=-106.54,

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -83,11 +83,11 @@ class PVModelingParameters:
         Typically -0.002 to -0.005 per degree C.
     irradiance_loss_factor : float
         Applied to POA irradiance after reflection losses but before
-        spectral mismatch losses.
+        spectral mismatch losses in units of %. 0 = no loss.
     dc_loss_factor : float
-        Applied to DC current.
+        Applied to DC current in units of %. 0 = no loss.
     ac_loss_factor : float
-        Appled to inverter power output
+        Appled to inverter power output in units of %. 0 = no loss.
 
     See Also
     --------

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -81,9 +81,6 @@ class PVModelingParameters:
     temperature_coefficient : float
         The temperature coefficient of DC power in units of 1/C.
         Typically -0.002 to -0.005 per degree C.
-    irradiance_loss_factor : float
-        Applied to POA irradiance after reflection losses but before
-        spectral mismatch losses in units of %. 0 = no loss.
     dc_loss_factor : float
         Applied to DC current in units of %. 0 = no loss.
     ac_loss_factor : float
@@ -97,7 +94,6 @@ class PVModelingParameters:
     ac_capacity: float
     dc_capacity: float
     temperature_coefficient: float
-    irradiance_loss_factor: float
     dc_loss_factor: float
     ac_loss_factor: float
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -81,6 +81,13 @@ class PVModelingParameters:
     temperature_coefficient : float
         The temperature coefficient of DC power in units of 1/C.
         Typically -0.002 to -0.005 per degree C.
+    irradiance_loss_factor : float, default 0
+        Applied to POA irradiance after reflection losses but before
+        spectral mismatch losses.
+    dc_loss_factor : float, default 0
+        Applied to DC current.
+    ac_loss_factor : float, default 0
+        Appled to inverter power output
 
     See Also
     --------
@@ -90,6 +97,9 @@ class PVModelingParameters:
     ac_capacity: float
     dc_capacity: float
     temperature_coefficient: float
+    irradiance_loss_factor: float = 0.
+    dc_loss_factor: float = 0.
+    ac_loss_factor: float = 0.
 
 
 @dataclass(frozen=True)

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -81,12 +81,12 @@ class PVModelingParameters:
     temperature_coefficient : float
         The temperature coefficient of DC power in units of 1/C.
         Typically -0.002 to -0.005 per degree C.
-    irradiance_loss_factor : float, default 0
+    irradiance_loss_factor : float
         Applied to POA irradiance after reflection losses but before
         spectral mismatch losses.
-    dc_loss_factor : float, default 0
+    dc_loss_factor : float
         Applied to DC current.
-    ac_loss_factor : float, default 0
+    ac_loss_factor : float
         Appled to inverter power output
 
     See Also
@@ -97,9 +97,9 @@ class PVModelingParameters:
     ac_capacity: float
     dc_capacity: float
     temperature_coefficient: float
-    irradiance_loss_factor: float = 0.
-    dc_loss_factor: float = 0.
-    ac_loss_factor: float = 0.
+    irradiance_loss_factor: float
+    dc_loss_factor: float
+    ac_loss_factor: float
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
We decided a few weeks ago that we'd add support for simple loss factors to the PV system metadata. This PR will add the support.

However, it does not currently work due because `dataclass` does not allow one to use keyword arguments in a parent class and positional arguments in a child class. See [this stack overflow]q/a(https://stackoverflow.com/questions/51575931/class-inheritance-in-python-3-7-dataclasses) for more. 

@alorenzo175 thoughts on what do here? Loss factor mix-in? No defaults? 