### PR TITLE
benchmark nwp forecasts initial implementation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ jobs:
 
   - script: |
       source activate sfacore_test
-      pytest solarforecastarbiter --doctest-modules --junitxml=junit/test-results.xml --cov --cov-report=xml --cov-report=html
+      pytest solarforecastarbiter --junitxml=junit/test-results.xml --cov --cov-report=xml --cov-report=html
     displayName: 'pytest'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ jobs:
       reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
   - script: |
-      bash <(curl https://codecov.io/bash) -t 09612e67-185b-4d89-9527-5e9322b8838b -f coverage.xml -F adder -F subtractor
+      bash <(curl https://codecov.io/bash) -t 09612e67-185b-4d89-9527-5e9322b8838b -f coverage.xml -F adder -F subtractor -F pypi
     displayName: 'codecov'
 
   - script: python -m pip install -r docs/requirements.txt
@@ -104,7 +104,7 @@ jobs:
       reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
   - script: |
-      bash <(curl https://codecov.io/bash) -t 09612e67-185b-4d89-9527-5e9322b8838b -f coverage.xml -F adder -F subtractor
+      bash <(curl https://codecov.io/bash) -t 09612e67-185b-4d89-9527-5e9322b8838b -f coverage.xml -F adder -F subtractor -F conda
     displayName: 'codecov'
 
 - job: 'Publish'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,6 @@ jobs:
     inputs:
       testResultsFiles: '**/test-results.xml'
       testRunTitle: 'Python $(python.version)'
-    condition: succeededOrFailed()
 
   - task: PublishCodeCoverageResults@1
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
     displayName: 'Install dependencies'
 
   - script: |
-      pytest solarforecastarbiter --doctest-modules --junitxml=junit/test-results.xml --cov --cov-report=xml --cov-report=html
+      pytest solarforecastarbiter --junitxml=junit/test-results.xml --cov --cov-report=xml --cov-report=html
     displayName: 'pytest'
 
   - script: |
@@ -96,7 +96,6 @@ jobs:
     inputs:
       testResultsFiles: '**/test-results.xml'
       testRunTitle: 'Python $(python.version)'
-    condition: succeededOrFailed()
 
   - task: PublishCodeCoverageResults@1
     inputs:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -76,11 +76,16 @@ subpackages
 
 The subpackages:
 
+.. toctree::
+   :maxdepth: 2
+
+   reference_forecasts
+
+
 .. autosummary::
    :toctree: generated/
 
    io
    metrics
-   reference_forecasts
    reports
    validation

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,6 +9,11 @@ datamodel
 
 The datamodel.
 
+.. autosummary::
+   :toctree: generated/
+
+   datamodel
+
 There are two kinds of sites:
 
 .. autosummary::
@@ -38,8 +43,15 @@ The Observation and Forecast:
 pvmodel
 =======
 
-The :py:mod:`pvmodel` module contains functions closely associated with
-PV modeling. Several utility functions wrap pvlib functions:
+The :py:mod:`~solarforecastarbiter.pvmodel` module contains functions
+closely associated with PV modeling.
+
+.. autosummary::
+   :toctree: generated/
+
+   pvmodel
+
+Several utility functions wrap pvlib functions:
 
 .. autosummary::
    :toctree: generated/

--- a/docs/source/reference_forecasts.rst
+++ b/docs/source/reference_forecasts.rst
@@ -55,7 +55,7 @@ forecast data may be supplied to a PV model and then resampled using the
 *resampler* function. This workflow allows for seperation of weather
 data processing and PV modeling while preserving the ability to use more
 accurate, shorter time interval inputs to the PV model. Finally, these
-functions return a solar position calcuation function (rather than the
+functions return a solar position calculation function (rather than the
 actual solar position) to simplify the API while maintaining reasonable
 performance. (Solar position is only sometimes needed within the model
 processing functions and is only needed externally if power is to be

--- a/docs/source/reference_forecasts.rst
+++ b/docs/source/reference_forecasts.rst
@@ -41,13 +41,14 @@ function is specific to:
 
    models.hrrr_subhourly_to_subhourly_instantaneous
    models.hrrr_subhourly_to_hourly_mean
-   models.rap_to_instantaneous
-   models.rap_irrad_to_hourly_mean
+   models.rap_ghi_to_instantaneous
+   models.rap_ghi_to_hourly_mean
    models.rap_cloud_cover_to_hourly_mean
-   models.gfs_3hour_to_hourly_mean
-   models.gfs_hourly_to_hourly_mean
-   models.nam_to_hourly_instantaneous
-   models.nam_cloud_cover_to_hourly_mean
+   models.gfs_quarter_deg_3hour_to_hourly_mean
+   models.gfs_quarter_deg_hourly_to_hourly_mean
+   models.gfs_quarter_deg_to_hourly_mean
+   models.nam_12km_hourly_to_hourly_instantaneous
+   models.nam_12km_cloud_cover_to_hourly_mean
 
 All of the above functions return weather forecast data, a *resampler*
 function, and a solar position calculation function. The weather

--- a/docs/source/reference_forecasts.rst
+++ b/docs/source/reference_forecasts.rst
@@ -1,0 +1,68 @@
+.. currentmodule:: solarforecastarbiter.reference_forecasts
+
+###################
+Reference Forecasts
+###################
+
+Structure
+=========
+
+The Solar Forecast Arbiter supports reference forecasts based on
+data from numerical weather prediction models (NWP) and from site
+observations.
+
+The :py:mod:`~solarforecastarbiter.reference_forecasts.main`
+module orchestrates reference forecast generation
+within the Solar Forecast Arbiter.
+
+.. autosummary::
+   :toctree: generated/
+
+   main.run
+
+
+NWP
+===
+
+Forecasts based on numerical weather prediction model data are used
+for intraday and longer forecasts. The Solar Forecast Arbiter contains
+a series of functions with reference implementations of data processing
+steps for NWP-based forecasts. These functions are found in the
+:py:mod:`~solarforecastarbiter.reference_forecasts.models` module.
+Each function is specific to a particular NWP
+model and forecast time resolution.
+
+.. autosummary::
+   :toctree: generated/
+
+   models.hrrr_subhourly_to_subhourly_instantaneous
+   models.hrrr_subhourly_to_hourly_mean
+   models.rap_to_instantaneous
+   models.rap_irrad_to_hourly_mean
+   models.rap_cloud_cover_to_hourly_mean
+   models.gfs_3hour_to_hourly_mean
+   models.gfs_hourly_to_hourly_mean
+   models.nam_to_hourly_instantaneous
+   models.nam_cloud_cover_to_hourly_mean
+
+
+Many of the functions in
+:py:mod:`~solarforecastarbiter.reference_forecasts.models` rely on common functions
+related to forecast processing. These functions are found in
+:py:mod:`~solarforecastarbiter.reference_forecasts.forecast`.
+
+.. autosummary::
+   :toctree: generated/
+
+   forecast.cloud_cover_to_ghi_linear
+   forecast.cloud_cover_to_irradiance_clearsky_scaling
+   forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos
+   forecast.resample
+   forecast.interpolate
+   forecast.unmix_intervals
+
+
+Persistence
+===========
+
+TBD.

--- a/docs/source/reference_forecasts.rst
+++ b/docs/source/reference_forecasts.rst
@@ -19,6 +19,7 @@ Arbiter. It uses data types defined in
 .. autosummary::
    :toctree: generated/
 
+   main
    main.run
 
 
@@ -39,6 +40,7 @@ function is specific to:
 .. autosummary::
    :toctree: generated/
 
+   models
    models.hrrr_subhourly_to_subhourly_instantaneous
    models.hrrr_subhourly_to_hourly_mean
    models.rap_ghi_to_instantaneous
@@ -72,6 +74,7 @@ found in :py:mod:`~solarforecastarbiter.reference_forecasts.forecast`.
 .. autosummary::
    :toctree: generated/
 
+   forecast
    forecast.cloud_cover_to_ghi_linear
    forecast.cloud_cover_to_irradiance_ghi_clear
    forecast.cloud_cover_to_irradiance

--- a/docs/source/reference_forecasts.rst
+++ b/docs/source/reference_forecasts.rst
@@ -8,12 +8,13 @@ Structure
 =========
 
 The Solar Forecast Arbiter supports reference forecasts based on
-data from numerical weather prediction models (NWP) and from site
+data from numerical weather prediction (NWP) models and from site
 observations.
 
-The :py:mod:`~solarforecastarbiter.reference_forecasts.main`
-module orchestrates reference forecast generation
-within the Solar Forecast Arbiter.
+The :py:mod:`~solarforecastarbiter.reference_forecasts.main` module
+orchestrates reference forecast generation within the Solar Forecast
+Arbiter. It uses data types defined in
+:py:mod:`solarforecastarbiter.datamodel`.
 
 .. autosummary::
    :toctree: generated/
@@ -24,13 +25,16 @@ within the Solar Forecast Arbiter.
 NWP
 ===
 
-Forecasts based on numerical weather prediction model data are used
-for intraday and longer forecasts. The Solar Forecast Arbiter contains
-a series of functions with reference implementations of data processing
-steps for NWP-based forecasts. These functions are found in the
-:py:mod:`~solarforecastarbiter.reference_forecasts.models` module.
-Each function is specific to a particular NWP
-model and forecast time resolution.
+Forecasts based on NWP model data are used for intraday and longer
+forecasts. The Solar Forecast Arbiter contains a set of functions
+to process data from NWP forecasts. These functions are found in the
+:py:mod:`~solarforecastarbiter.reference_forecasts.models` module. Each
+function is specific to:
+
+  1. A particular NWP model data set (e.g. NAM or subhourly HRRR), and
+  2. The post processing steps required to obtain a particular type of
+     irradiance or power forecast data (e.g. hourly mean or
+     instantaneous).
 
 .. autosummary::
    :toctree: generated/
@@ -45,18 +49,31 @@ model and forecast time resolution.
    models.nam_to_hourly_instantaneous
    models.nam_cloud_cover_to_hourly_mean
 
+All of the above functions return weather forecast data, a *resampler*
+function, and a solar position calculation function. The weather
+forecast data may be supplied to a PV model and then resampled using the
+*resampler* function. This workflow allows for seperation of weather
+data processing and PV modeling while preserving the ability to use more
+accurate, shorter time interval inputs to the PV model. Finally, these
+functions return a solar position calcuation function (rather than the
+actual solar position) to simplify the API while maintaining reasonable
+performance. (Solar position is only sometimes needed within the model
+processing functions and is only needed externally if power is to be
+calculated.) See
+:py:mod:`~solarforecastarbiter.reference_forecasts.models` module for
+additional documentation.
 
 Many of the functions in
-:py:mod:`~solarforecastarbiter.reference_forecasts.models` rely on common functions
-related to forecast processing. These functions are found in
-:py:mod:`~solarforecastarbiter.reference_forecasts.forecast`.
+:py:mod:`~solarforecastarbiter.reference_forecasts.models` rely on
+common functions related to forecast processing. These functions are
+found in :py:mod:`~solarforecastarbiter.reference_forecasts.forecast`.
 
 .. autosummary::
    :toctree: generated/
 
    forecast.cloud_cover_to_ghi_linear
-   forecast.cloud_cover_to_irradiance_clearsky_scaling
-   forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos
+   forecast.cloud_cover_to_irradiance_ghi_clear
+   forecast.cloud_cover_to_irradiance
    forecast.resample
    forecast.interpolate
    forecast.unmix_intervals

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -56,8 +56,27 @@ def short_test_forecast():
 @pytest.fixture(scope='module')
 def site_metadata():
     """
+    Simple example metadata for a site
+    """
+    return _site_metadata()
+
+
+def _site_metadata():
+    metadata = datamodel.Site(
+        name='Albuquerque Baseline', latitude=35.05, longitude=-106.54,
+        elevation=1657.0, timezone='America/Denver', network='Sandia')
+    return metadata
+
+
+@pytest.fixture(scope='module')
+def powerplant_metadata():
+    """
     Simple example metadata for a fixed-tilt PV site
     """
+    return _powerplant_metadata()
+
+
+def _powerplant_metadata():
     modeling_params = datamodel.FixedTiltModelingParameters(
         ac_capacity=.003, dc_capacity=.0035, temperature_coefficient=-0.003,
         dc_loss_factor=3, ac_loss_factor=0,
@@ -67,6 +86,14 @@ def site_metadata():
         elevation=1657.0, timezone='America/Denver', network='Sandia',
         modeling_parameters=modeling_params)
     return metadata
+
+
+@pytest.fixture(scope='module',
+                params=['site', 'powerplant'])
+def site_powerplant_site_type(request):
+    site_type = request.param
+    modparams = globals()['_' + request.param + '_metadata']()
+    return modparams, site_type
 
 
 @pytest.fixture(scope='module')

--- a/solarforecastarbiter/io/nwp.py
+++ b/solarforecastarbiter/io/nwp.py
@@ -1,2 +1,44 @@
-def load_forecast(*args, **kwargs):
+def load_forecast(latitude, longitude, init_time, start, end, model,
+                  variables=('ghi', 'dni', 'dhi', 'temp_air', 'wind_speed')):
+    """Load NWP model data.
+
+    Parameters
+    ----------
+    latitude : float
+
+    longitude : float
+
+    init_time : pd.Timestamp
+        Full datetime of a model initialization
+
+    start : pd.Timestamp
+
+    end : pd.Timestamp
+
+    model : str
+        Name of model. Must be one of:
+
+            * 'hrrr'
+            * 'hrrr_subhourly'
+            * 'gfs'  # assume 0.25 degree or specify?
+            * 'rap'
+            * 'nam'  # assume 12 km or specify?
+
+    variables : list of str
+        The variables to load.
+
+    Returns
+    -------
+    By default:
+
+      * ghi : pd.Series
+      * dni : pd.Series
+      * dhi : pd.Series
+      * temp_air : pd.Series
+      * wind_speed : pd.Series
+
+    Raises
+    ------
+    ValueError : Raised if the requested variable is not found.
+    """
     raise NotImplementedError

--- a/solarforecastarbiter/io/nwp.py
+++ b/solarforecastarbiter/io/nwp.py
@@ -1,0 +1,2 @@
+def load_forecast(*args, **kwargs):
+    raise NotImplementedError

--- a/solarforecastarbiter/reference_forecasts/forecast.py
+++ b/solarforecastarbiter/reference_forecasts/forecast.py
@@ -143,19 +143,39 @@ def cloud_cover_to_irradiance_clearsky_scaling_site(site, cloud_cover):
 
 
 def resample_args(*args, freq='1h'):
-    resampled_args = [
-        arg.resample(freq).mean()
-        for arg in args if arg is not None]
-    return resampled_args
+    # this one uses map for fun
+    def f(arg):
+        if arg is None:
+            return None
+        else:
+            return arg.resample(freq).mean()
+    return list(map(f, args))
+
+
+def resample(arg, freq='1h'):
+    if arg is None:
+        return None
+    else:
+        return arg.resample(freq).mean()
 
 
 def interpolate_args(*args, freq='15min'):
     # could add how kwarg to resample_args and lookup method with
     # getattr but this seems much more clear
+    # this one uses a list comprehension for different fun
     resampled_args = [
         arg.resample(freq).interpolate()
         for arg in args if arg is not None]
     return resampled_args
+
+
+def interpolate(arg, freq='15min'):
+    # could add how kwarg to resample and lookup method with
+    # getattr but this seems much more clear
+    if arg is None:
+        return None
+    else:
+        return arg.resample(freq).interpolate()
 
 
 def slice_args(*args, start, end):

--- a/solarforecastarbiter/reference_forecasts/forecast.py
+++ b/solarforecastarbiter/reference_forecasts/forecast.py
@@ -65,6 +65,50 @@ def cloud_cover_to_irradiance_clearsky_scaling(cloud_cover, ghi_clear,
     return ghi, dni, dhi
 
 
+def cloud_cover_to_irradiance_clearsky_scaling_solpos(
+        latitude, longitude, elevation, cloud_cover):
+    """
+    Estimates irradiance from cloud cover in the following steps:
+
+    1. Calculate solar position for the site.
+    2. Determine clear sky GHI using Ineichen model and climatological
+       turbidity.
+    3. Estimate cloudy sky GHI using a function of cloud_cover and
+       ghi_clear: :py:func:`cloud_cover_to_ghi_linear`
+    4. Estimate cloudy sky DNI and DHI using the Erbs model.
+
+    Don't use this function if you already have solar position.
+
+    Parameters
+    ----------
+    latitude : float
+    longitude : float
+    elevation : float
+    cloud_cover : Series
+        Cloud cover in %.
+
+    Returns
+    -------
+    apparent_zenith : pd.Series
+    azimuth : pd.Series
+    ghi : pd.Series
+    dni : pd.Series
+    dhi : pd.Series
+
+    See also
+    --------
+    cloud_cover_to_irradiance_clearsky_scaling
+    """
+    solar_position = pvmodel.calculate_solar_position(
+        latitude, longitude, elevation, cloud_cover.index)
+    cs = pvmodel.calculate_clearsky(latitude, longitude, elevation,
+                                    solar_position['apparent_zenith'])
+    ghi, dni, dhi = cloud_cover_to_irradiance_clearsky_scaling(
+        cloud_cover, cs['ghi'], solar_position['zenith'])
+    return (solar_position['apparent_zenith'], solar_position['zenith'],
+            ghi, dni, dhi)
+
+
 def cloud_cover_to_irradiance_clearsky_scaling_solpos_func(
         latitude, longitude, elevation, cloud_cover, solar_position_func):
     """

--- a/solarforecastarbiter/reference_forecasts/forecast.py
+++ b/solarforecastarbiter/reference_forecasts/forecast.py
@@ -197,6 +197,20 @@ def slice_args(*args, start, end):
 def unmix_intervals(cloud_cover):
     """Convert mixed interval averages into pure interval averages.
 
+    For example, the GFS 3 hour output contains the following data:
+
+    * forecast hour 3: average cloud cover from 0 - 3 hours
+    * forecast hour 6: average cloud cover from 0 - 6 hours
+    * forecast hour 9: average cloud cover from 6 - 9 hours
+    * forecast hour 12: average cloud cover from 6 - 12 hours
+
+    and so on. This function returns:
+
+    * forecast hour 3: average cloud cover from 0 - 3 hours
+    * forecast hour 6: average cloud cover from 3 - 6 hours
+    * forecast hour 9: average cloud cover from 6 - 9 hours
+    * forecast hour 12: average cloud cover from 9 - 12 hours
+
     Parameters
     ----------
     cloud_cover : pd.Series

--- a/solarforecastarbiter/reference_forecasts/forecast.py
+++ b/solarforecastarbiter/reference_forecasts/forecast.py
@@ -110,6 +110,16 @@ def cloud_cover_to_irradiance_clearsky_scaling_solpos(
 
 
 def resample_args(*args, freq='1h'):
+    """Resample all positional arguments, allowing for None.
+
+    Parameters
+    ----------
+    *args : list of pd.Series or None
+
+    Returns
+    -------
+    list of pd.Series or None
+    """
     # this one uses map for fun
     def f(arg):
         if arg is None:
@@ -120,6 +130,16 @@ def resample_args(*args, freq='1h'):
 
 
 def resample(arg, freq='1h'):
+    """Resamples an argument, allowing for None. Use with map.
+
+    Parameters
+    ----------
+    arg : pd.Series or None
+
+    Returns
+    -------
+    pd.Series or None
+    """
     if arg is None:
         return None
     else:
@@ -127,6 +147,16 @@ def resample(arg, freq='1h'):
 
 
 def interpolate_args(*args, freq='15min'):
+    """Interpolate all positional arguments, allowing for None.
+
+    Parameters
+    ----------
+    *args : list of pd.Series or None
+
+    Returns
+    -------
+    list of pd.Series or None
+    """
     # could add how kwarg to resample_args and lookup method with
     # getattr but this seems much more clear
     # this one uses a list comprehension for different fun
@@ -137,6 +167,16 @@ def interpolate_args(*args, freq='15min'):
 
 
 def interpolate(arg, freq='15min'):
+    """Interpolates an argument, allowing for None. Use with map.
+
+    Parameters
+    ----------
+    arg : pd.Series or None
+
+    Returns
+    -------
+    pd.Series or None
+    """
     # could add how kwarg to resample and lookup method with
     # getattr but this seems much more clear
     if arg is None:
@@ -152,4 +192,14 @@ def slice_args(*args, start, end):
 
 
 def unmix_intervals(cloud_cover):
+    """Convert mixed interval averages into pure interval averages.
+
+    Parameters
+    ----------
+    cloud_cover : pd.Series
+
+    Returns
+    -------
+    pd.Series
+    """
     raise NotImplementedError

--- a/solarforecastarbiter/reference_forecasts/forecast.py
+++ b/solarforecastarbiter/reference_forecasts/forecast.py
@@ -1,0 +1,152 @@
+"""
+Functions for forecasting.
+"""
+
+import pandas as pd
+
+from solarforecastarbiter import pvmodel
+
+# some functions originally implemented in pvlib-python.
+# find pvlib-python license in licenses directory.
+
+
+def cloud_cover_to_ghi_linear(cloud_cover, ghi_clear, offset=35):
+    """
+    Convert cloud cover to GHI using a linear relationship.
+    0% cloud cover returns ghi_clear.
+    100% cloud cover returns offset*ghi_clear.
+
+    Parameters
+    ----------
+    cloud_cover: numeric
+        Cloud cover in %.
+    ghi_clear: numeric
+        GHI under clear sky conditions.
+    offset: numeric, default 35
+        Determines the minimum GHI.
+
+    Returns
+    -------
+    ghi: numeric
+        Estimated GHI.
+
+    References
+    ----------
+    Larson et. al. "Day-ahead forecasting of solar power output from
+    photovoltaic plants in the American Southwest" Renewable Energy
+    91, 11-20 (2016).
+    """
+
+    offset = offset / 100.
+    cloud_cover = cloud_cover / 100.
+    ghi = (offset + (1 - offset) * (1 - cloud_cover)) * ghi_clear
+    return ghi
+
+
+def interpolate_to(weather, freq='15min'):
+    return weather.resample(freq).interpolate()
+
+
+def cloud_cover_to_irradiance_clearsky_scaling(cloud_cover, ghi_clear,
+                                               solar_zenith):
+    """
+    Estimates irradiance from cloud cover in the following steps:
+
+    1. Estimate cloudy sky GHI using a function of cloud_cover and
+       ghi_clear: :py:func:`cloud_cover_to_ghi_linear`
+    2. Estimate cloudy sky DNI and DHI using the Erbs model.
+
+    Parameters
+    ----------
+    site : datamodel.Site
+    cloud_cover : Series
+        Cloud cover in %.
+
+    Returns
+    -------
+    ghi : pd.Series, dni : pd.Series, dhi : pd.Series
+    """
+    ghi = cloud_cover_to_ghi_linear(cloud_cover, ghi_clear)
+    dni, dhi = pvmodel.complete_irradiance_components(ghi, solar_zenith)
+    return ghi, dni, dhi
+
+
+def cloud_cover_to_irradiance_clearsky_scaling_site(site, cloud_cover):
+    """
+    Estimates irradiance from cloud cover in the following steps:
+
+    1. Calculate solar position for the site.
+    2. Determine clear sky GHI using Ineichen model and climatological
+       turbidity.
+    3. Estimate cloudy sky GHI using a function of cloud_cover and
+       ghi_clear: :py:func:`cloud_cover_to_ghi_linear`
+    4. Estimate cloudy sky DNI and DHI using the Erbs model.
+
+    Don't use this function if you already have solar position.
+
+    Parameters
+    ----------
+    site : datamodel.Site
+    cloud_cover : Series
+        Cloud cover in %.
+
+    Returns
+    -------
+    ghi : pd.Series, dni : pd.Series, dhi : pd.Series
+
+    See also
+    --------
+    cloud_cover_to_irradiance_clearsky_scaling
+    """
+    solar_position = pvmodel.calculate_solar_position(
+        site.latitude, site.longitude, site.elevation, cloud_cover.index)
+    cs = pvmodel.calculate_clearsky(site.latitude, site.longitude,
+                                    site.elevation,
+                                    solar_position['apparent_zenith'])
+    ghi, dni, dhi = cloud_cover_to_irradiance_clearsky_scaling(
+        cloud_cover, cs['ghi'], solar_position['zenith'])
+    return ghi, dni, dhi
+
+
+def subhourly_all_to_subhourly(weather):
+    if weather.freq <= pd.Timedelta('15min'):
+        # nothing to do here
+        return weather
+    else:
+        return interpolate_to(weather)
+
+
+def subhourly_ghi_to_subhourly(weather, zenith):
+    weather = subhourly_all_to_subhourly(weather)
+    dni, dhi = pvmodel.complete_irradiance_components(weather['ghi'], zenith)
+    weather['dni'] = dni
+    weather['dhi'] = dhi
+    return weather
+
+
+def hourly_ghi_to_hourly():
+    raise NotImplementedError
+
+
+def hourly_ghi_to_subhourly():
+    raise NotImplementedError
+
+
+def hourly_cloud_cover_to_hourly():
+    raise NotImplementedError
+
+
+def hourly_cloud_cover_to_subhourly():
+    raise NotImplementedError
+
+
+def mixed_intervals_cloud_cover_to_hourly():
+    raise NotImplementedError
+
+
+def mixed_intervals_cloud_cover_to_subhourly():
+    raise NotImplementedError
+
+
+def unmix_intervals():
+    raise NotImplementedError

--- a/solarforecastarbiter/reference_forecasts/forecast.py
+++ b/solarforecastarbiter/reference_forecasts/forecast.py
@@ -151,5 +151,5 @@ def slice_args(*args, start, end):
     return resampled_args
 
 
-def unmix_intervals():
+def unmix_intervals(cloud_cover):
     raise NotImplementedError

--- a/solarforecastarbiter/reference_forecasts/main.py
+++ b/solarforecastarbiter/reference_forecasts/main.py
@@ -57,8 +57,8 @@ def run(site, model, init_time, start, end):
     ...     elevation=715, timezone='America/Phoenix',
     ...     modeling_parameters = modeling_parameters)
     >>> ghi, dni, dhi, temp_air, wind_speed, ac_power = run(
-    ...     power_plant, hrrr_subhourly_to_hourly_mean, init_time,
-    ...     start, end)
+    ...     power_plant, models.hrrr_subhourly_to_hourly_mean,
+    ...     init_time, start, end)
     """
 
     *solpos_forecast, resampler, solar_position_calculator = model(

--- a/solarforecastarbiter/reference_forecasts/main.py
+++ b/solarforecastarbiter/reference_forecasts/main.py
@@ -62,7 +62,8 @@ def run(site, model, init_time, start, end):
     """
 
     *solpos_forecast, resampler, solar_position_calculator = model(
-        site.latitude, site.longitude, site.elevation)
+        site.latitude, site.longitude, site.elevation,
+        init_time, start, end)
 
     if isinstance(site, datamodel.SolarPowerPlant):
         solar_position = solar_position_calculator()

--- a/solarforecastarbiter/reference_forecasts/main.py
+++ b/solarforecastarbiter/reference_forecasts/main.py
@@ -1,0 +1,65 @@
+"""
+Make benchmark irradiance and power forecasts.
+"""
+
+# from solarforecastarbiter.io import load_forecast
+from solarforecastarbiter import pvmodel
+
+
+def run(site, model):
+    """
+    Calculate benchmark irradiance forecast for a Site. Also returns
+    solar position and weather data that can be used for power modeling.
+
+    Assumes all returned values are instantaneous. So if you want to
+    make a hourly average power forecast then you probably want to ask
+    for a subhourly irradiance forecast.
+
+    Parameters
+    ----------
+    site : datamodel.Site
+
+    Returns
+    -------
+    Tuple of:
+
+    apparent_zenith : None or pd.Series
+    azimuth : None or pd.Series
+    ghi : pd.Series
+    dni : pd.Series
+    dhi : pd.Series
+    temp_air : None or pd.Series
+    wind_speed : None or pd.Series
+
+    See also
+    --------
+    pvmodel.irradiance_to_power
+    """
+
+    # get point forecast data from raw or slightly processed model files
+    # assuming forecast is a DataFrame of data that is actually in the
+    # model.
+    forecast = load_forecast(site.latitude, site.longitude, model)
+
+    # interpolate forecast to finer time steps as required.
+    # could also be def interpolator(forecast): return forecast for some models
+    # interpolator is determined by some TBD combination of
+    # 1. the forecast model that was loaded
+    # 2. arg/kwarg string
+    # 3. arg/kwarg function
+    fx_interp = interpolator(forecast)
+
+    # solar position is always needed for power forecasts.
+    # it's not needed for some irradiance forecasts.
+    # but we only want to calculate it once, so the best control flow
+    # is not yet clear to me. perhaps None
+    solar_position = pvmodel.calculate_solar_position(
+        site.latitude, site.longitude, site.elevation, fx_interp.index)
+
+    # same story as for interp, but also needs solar position
+    fx_processed = processor(fx_interp, solar_position)
+
+    keys = ('ghi', 'dni', 'dhi', 'temp_air', 'wind_speed')
+    tuples = solar_position['apparent_zenith'], solar_position['azimuth']
+    tuples = tuples + [fx_processed.get(key) for key in keys]
+    return tuples

--- a/solarforecastarbiter/reference_forecasts/main.py
+++ b/solarforecastarbiter/reference_forecasts/main.py
@@ -50,7 +50,8 @@ def run(site, model):
 
     if isinstance(site, datamodel.SolarPowerPlant):
         solpos_forecast = maybe_calc_solar_position(site, *solpos_forecast)
-        ac_power = run_power(site.modeling_parameters, *solpos_forecast)
+        ac_power = pvmodel.irradiance_to_power(site.modeling_parameters,
+                                               *solpos_forecast)
     else:
         ac_power = None
 

--- a/solarforecastarbiter/reference_forecasts/models.py
+++ b/solarforecastarbiter/reference_forecasts/models.py
@@ -1,165 +1,189 @@
 """
-Default processing steps for some weather models.
+Default processing steps for NOAA weather models.
 
-All functions have the same signature, but some args are not used
-and some return values may be None.
+All functions in this module have the same signature.
+
+The functions accept:
+
+  * latitude : float
+  * longitude : float
+  * elevation : float
+  * init_time : pd.Timestamp
+      Full datetime of a model initialization
+  * start : pd.Timestamp
+  * end : pd.Timestamp
+
+The functions return a tuple of:
+
+  * ghi : pd.Series
+  * dni : pd.Series
+  * dhi : pd.Series
+  * temp_air : pd.Series
+  * wind_speed : pd.Series
+  * resampler : function
+      A function that resamples data to the appropriate frequency.
+      This function is applied to all variables after power is
+      calculated.
+  * solar_position_calculator : function
+      A function that returns solar position at the ghi forecast times
+      (after interpolation, before resampling). The function will return
+      results immediately if solar position is already known or will
+      call a solar position calculation algorithm and then return.
+
+Most of the functions return forecast data interpolated to 5 minute
+frequency. Interpolation to 5 minutes reduces the errors associated with
+solar position.
 """
 
 from functools import partial
 
-import pandas as pd
-
 from solarforecastarbiter import pvmodel
-from solarforecastarbiter.io import load_forecast
+from solarforecastarbiter.io.nwp import load_forecast
 from solarforecastarbiter.reference_forecasts import forecast
 
 
-def hrrr_subhourly_to_subhourly_instantaneous(latitude, longitude, elevation):
+def hrrr_subhourly_to_subhourly_instantaneous(latitude, longitude, elevation,
+                                              init_time, start, end):
     """
     Subhourly (15 min) instantantaneous HRRR forecast.
     """
     ghi, dni, dhi, temp_air, wind_speed = load_forecast(
-        latitude, longitude, 'hrrr_subhourly')
+        latitude, longitude, init_time, start, end, 'hrrr_subhourly')
     resampler = partial(forecast.resample, freq='15min')
-    return None, None, ghi, dni, dhi, temp_air, wind_speed, resampler
+    solar_pos_calculator = partial(
+        pvmodel.calculate_solar_position, latitude, longitude, elevation,
+        ghi.index)
+    return ghi, dni, dhi, temp_air, wind_speed, resampler, solar_pos_calculator
 
 
-def hrrr_subhourly_to_hourly_mean(latitude, longitude, elevation):
+def hrrr_subhourly_to_hourly_mean(latitude, longitude, elevation,
+                                  init_time, start, end):
     """
     Hourly mean HRRR forecast.
     """
     ghi, dni, dhi, temp_air, wind_speed = load_forecast(
-        latitude, longitude, 'hrrr_subhourly')
+        latitude, longitude, init_time, start, end, 'hrrr_subhourly')
+    interpolator = partial(forecast.interpolate, freq='5min')
+    ghi, dni, dhi, temp_air, wind_speed = list(
+        map(interpolator, ghi, dni, dhi, temp_air, wind_speed))
     resampler = partial(forecast.resample, freq='1h')
-    return None, None, ghi, dni, dhi, temp_air, wind_speed, resampler
+    solar_pos_calculator = partial(
+        pvmodel.calculate_solar_position, latitude, longitude, elevation,
+        ghi.index)
+    return ghi, dni, dhi, temp_air, wind_speed, resampler, solar_pos_calculator
 
 
-def rap_to_instantaneous(latitude, longitude, elevation):
+def rap_to_instantaneous(latitude, longitude, elevation,
+                         init_time, start, end):
     """
     Hourly instantantaneous RAP forecast.
     """
-    ghi, dni, dhi, temp_air, wind_speed = load_forecast(latitude, longitude,
-                                                        'rap')
+    ghi, dni, dhi, temp_air, wind_speed = load_forecast(
+        latitude, longitude, init_time, start, end, 'rap')
     resampler = partial(forecast.resample, freq='1h')
-    return None, None, ghi, dni, dhi, temp_air, wind_speed, resampler
+    solar_pos_calculator = partial(
+        pvmodel.calculate_solar_position, latitude, longitude, elevation,
+        ghi.index)
+    return ghi, dni, dhi, temp_air, wind_speed, resampler, solar_pos_calculator
 
 
-def rap_irrad_to_hourly_mean(latitude, longitude, elevation):
+def rap_irrad_to_hourly_mean(latitude, longitude, elevation,
+                             init_time, start, end):
     """
     Take hourly RAP instantantaneous irradiance and convert it to hourly
-    average data.
+    average forecasts.
     """
     ghi, dni, dhi, temp_air, wind_speed = load_forecast(
-        latitude, longitude, 'rap')
-    resample = partial(forecast.resample, freq='1h')
-    return None, None, ghi, dni, dhi, temp_air, wind_speed, resample
+        latitude, longitude, init_time, start, end, 'rap')
+    interpolator = partial(forecast.interpolate, freq='5min')
+    ghi, dni, dhi, temp_air, wind_speed = list(
+        map(interpolator, ghi, dni, dhi, temp_air, wind_speed))
+    resampler = partial(forecast.resample, freq='1h')
+    solar_pos_calculator = partial(
+        pvmodel.calculate_solar_position, latitude, longitude, elevation,
+        ghi.index)
+    return ghi, dni, dhi, temp_air, wind_speed, resampler, solar_pos_calculator
 
 
-def rap_cloud_cover_to_hourly_mean(latitude, longitude, elevation):
+def _resample_using_cloud_cover(latitude, longitude, elevation,
+                                cloud_cover, temp_air, wind_speed):
+    # 5 minutes is probably better than 15
+    interpolator = partial(forecast.interpolate, freq='5min')
+    cloud_cover, temp_air, wind_speed = list(
+        map(interpolator, (cloud_cover, temp_air, wind_speed)))
+    solar_position = pvmodel.calculate_solar_position(
+        latitude, longitude, elevation, cloud_cover.index)
+    ghi, dni, dhi = forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos(
+        latitude, longitude, elevation, cloud_cover,
+        solar_position['apparent_zenith'], solar_position['azimuth'])
+    resampler = partial(forecast.resample, freq='1h')
+
+    def solar_pos_calculator(): return solar_position
+
+    return ghi, dni, dhi, temp_air, wind_speed, resampler, solar_pos_calculator
+
+
+def rap_cloud_cover_to_hourly_mean(latitude, longitude, elevation,
+                                   init_time, start, end):
     """
     Take hourly RAP instantantaneous cloud cover and convert it to
-    hourly average data.
+    hourly average forecasts.
     """
-    variables = load_forecast(
-        latitude, longitude, 'rap',
+    cloud_cover, temp_air, wind_speed = load_forecast(
+        latitude, longitude, init_time, start, end, 'rap',
         variables=('cloud_cover', 'temp_air', 'wind_speed'))
-    interpolator = partial(forecast.interpolate, freq='15min')
-    cloud_cover, temp_air, wind_speed = list(map(interpolator, variables))
-    solpos_irrad = forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos(
-            latitude, longitude, elevation, cloud_cover)
-    resampler = partial(forecast.resample, freq='1h')
-    return solpos_irrad + (temp_air, wind_speed, resampler)
+    return _resample_using_cloud_cover(latitude, longitude, elevation,
+                                       cloud_cover, temp_air, wind_speed)
 
 
-def rap_cloud_cover_to_hourly_mean_alternative(latitude, longitude, elevation,
-                                               solar_position_func):
-    """
-    Take hourly RAP instantantaneous cloud cover and convert it to
-    hourly average data.
-    """
-    variables = load_forecast(
-        latitude, longitude, 'rap',
-        variables=('cloud_cover', 'temp_air', 'wind_speed'))
-    resampler = partial(forecast.resample, freq='15')
-    cloud_cover, temp_air, wind_speed = list(map(resampler, variables))
-    solar_position = solar_position_func(cloud_cover.index)
-    cs = pvmodel.calculate_clearsky(latitude, longitude, elevation,
-                                    solar_position['apparent_zenith'])
-    ghi, dni, dhi = forecast.cloud_cover_to_irradiance_clearsky_scaling(
-        cloud_cover, cs['ghi'], solar_position['zenith']
-    )
-    resampler = partial(forecast.resample, freq='1h')
-    solpos = solar_position['apparent_zenith'], solar_position['azimuth']
-    return solpos + (ghi, dni, dhi, temp_air, wind_speed, resampler)
-
-
-def rap_cloud_cover_to_hourly_mean_alternative2(latitude, longitude, elevation,
-                                                solar_position_func):
-    """
-    Take hourly RAP instantantaneous cloud cover and convert it to
-    hourly average data.
-    """
-    variables = load_forecast(
-        latitude, longitude, 'rap',
-        variables=('cloud_cover', 'temp_air', 'wind_speed'))
-    interpolator = partial(forecast.interpolate, freq='15min')
-    cloud_cover, temp_air, wind_speed = list(map(interpolator, variables))
-    ghi, dni, dhi = \
-        forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos_func(
-            latitude, longitude, elevation, cloud_cover, solar_position_func)
-    resampler = partial(forecast.resample, freq='1h')
-    return ghi, dni, dhi, temp_air, wind_speed, resampler
-
-
-def gfs_3hour_to_hourly_mean(latitude, longitude, elevation):
+def gfs_3hour_to_hourly_mean(latitude, longitude, elevation,
+                             init_time, start, end):
     """
     Take 3 hr GFS and convert it to hourly average data.
     """
-    cloud_cover, temp_air, wind_speed = load_forecast(latitude, longitude,
-                                                      'gfs_3h')
+    cloud_cover, temp_air, wind_speed = load_forecast(
+        latitude, longitude, init_time, start, end, 'gfs_3h')
     cloud_cover = forecast.unmix_intervals(cloud_cover)
-    interpolator = partial(forecast.interpolate, freq='15min')
-    cloud_cover, temp_air, wind_speed = list(
-        map(interpolator, (cloud_cover, temp_air, wind_speed)))
-    solpos_irrad = forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos(
-            latitude, longitude, elevation, cloud_cover)
-    resampler = partial(forecast.resample, freq='1h')
-    return solpos_irrad + (temp_air, wind_speed, resampler)
+    return _resample_using_cloud_cover(latitude, longitude, elevation,
+                                       cloud_cover, temp_air, wind_speed)
 
 
-def gfs_hourly_to_hourly_mean(latitude, longitude, elevation):
+def gfs_hourly_to_hourly_mean(latitude, longitude, elevation,
+                              init_time, start, end):
     """
     Take 1 hr GFS and convert it to hourly average data.
+    Max forecast horizon 96? hours.
     """
-    cloud_cover, temp_air, wind_speed = load_forecast(latitude, longitude,
-                                                      'gfs_1h')
-    # hourly data only available through 96h?
-    start = cloud_cover.index[0]
-    end = start + pd.Timedelta('96h')  # not sure about this time limit
-    ghi, temp_air, wind_speed = forecast.slice_args(
-        cloud_cover, temp_air, wind_speed, start, end)
-    cloud_cover, temp_air, wind_speed = forecast.interpolate(
-        cloud_cover, temp_air, wind_speed, freq='15min')
-    solpos_irrad = forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos(
-            latitude, longitude, elevation, cloud_cover)
-    resampler = partial(forecast.resample, freq='1h')
-    return solpos_irrad + (temp_air, wind_speed, resampler)
+    cloud_cover, temp_air, wind_speed = load_forecast(
+        latitude, longitude, init_time, start, end, 'gfs_1h')
+    return _resample_using_cloud_cover(latitude, longitude, elevation,
+                                       cloud_cover, temp_air, wind_speed)
 
 
-def nam_to_instantaneous(latitude, longitude, elevation):
+def nam_to_hourly_instantaneous(latitude, longitude, elevation,
+                                init_time, start, end):
     """
-    Hourly instantantaneous forecast. Max forecast horizon 48 hours.
+    Hourly instantantaneous forecast. Max forecast horizon 48? hours.
     """
-    ghi, temp_air, wind_speed = load_forecast(latitude, longitude, 'nam')
-    # hourly data only available through 48h?
-    start = ghi.index[0]
-    end = start + pd.Timedelta('48h')  # not sure about this time limit
-    ghi, temp_air, wind_speed = forecast.slice_args(ghi, temp_air, wind_speed,
-                                                    start, end)
+    ghi, temp_air, wind_speed = load_forecast(
+        latitude, longitude, init_time, start, end, 'nam')
     solar_position = pvmodel.calculate_solar_position(
-        latitude, longitude, elevation)
+        latitude, longitude, elevation, ghi.index)
     dni, dhi = pvmodel.complete_irradiance_components(
         ghi, solar_position['zenith'])
     resampler = partial(forecast.resample, freq='15min')
-    return (solar_position['apparent_zenith'], solar_position['azimuth'],
-            ghi, dni, dhi, temp_air, wind_speed, resampler)
+    def solar_pos_calculator(): return solar_position
+
+    return ghi, dni, dhi, temp_air, wind_speed, resampler, solar_pos_calculator
+
+
+def nam_cloud_cover_to_hourly_mean(latitude, longitude, elevation,
+                                   init_time, start, end):
+    """
+    Hourly average forecast. Max forecast horizon 72 hours.
+    """
+    cloud_cover, temp_air, wind_speed = load_forecast(
+        latitude, longitude, init_time, start, end, 'nam',
+        variables=('cloud_cover', 'temp_air', 'wind_speed'))
+    return _resample_using_cloud_cover(latitude, longitude, elevation,
+                                       cloud_cover, temp_air, wind_speed)

--- a/solarforecastarbiter/reference_forecasts/models.py
+++ b/solarforecastarbiter/reference_forecasts/models.py
@@ -4,31 +4,153 @@ Default processing steps for some weather models.
 All functions assume that weather is a DataFrame.
 """
 
+from functools import partial
+
+import pandas as pd
+
+from solarforecastarbiter import pvmodel
+from solarforecastarbiter.io import load_forecast
 from solarforecastarbiter.reference_forecasts import forecast
 
 
-def hrrr_subhourly(weather):
+def hrrr_subhourly_to_subhourly_instantaneous(latitude, longitude):
     """
-    HRRR subhourly probably already has all of the data that we want.
+    Subhourly (15 min) instantantaneous HRRR forecast.
     """
-    return weather
+    ghi, dni, dhi, temp_air, wind_speed = load_forecast(
+        latitude, longitude, 'hrrr_subhourly')
+    resample_func = partial(forecast.resample_args, freq='15min')
+    return ghi, dni, dhi, temp_air, wind_speed, resample_func
 
 
-def hrrr_hourly(weather):
-    weather = forecast.hourly_ghi_to_subhourly(weather)
-    return weather
+def hrrr_subhourly_to_hourly_mean(latitude, longitude):
+    """
+    Hourly mean HRRR forecast.
+    """
+    ghi, dni, dhi, temp_air, wind_speed = load_forecast(
+        latitude, longitude, 'hrrr_subhourly')
+    resample_func = partial(forecast.resample_args, freq='1h')
+    return ghi, dni, dhi, temp_air, wind_speed, resample_func
 
 
-rap = hrrr_hourly
+def rap_to_instantaneous(latitude, longitude):
+    """
+    Hourly instantantaneous RAP forecast.
+    """
+    ghi, dni, dhi, temp_air, wind_speed = load_forecast(latitude, longitude,
+                                                        'rap')
+    resample_func = partial(forecast.resample_args, freq='1h')
+    return ghi, dni, dhi, temp_air, wind_speed, resample_func
 
 
-def gfs(weather):
-    weather = forecast.unmix_intervals(weather)
-    weather = forecast.interpolate_to(weather, freq='1h')
-    weather = forecast.hourly_cloud_cover_to_subhourly(weather)
-    return weather
+def rap_irrad_to_hourly_mean(latitude, longitude):
+    """
+    Take hourly RAP instant irradiance and convert it to hourly average
+    data.
+    """
+    ghi, dni, dhi, temp_air, wind_speed = load_forecast(
+        latitude, longitude, 'rap')
+    resample_func = partial(forecast.resample_args, freq='1h')
+    return ghi, dni, dhi, temp_air, wind_speed, resample_func
 
 
-def nam(weather):
+def rap_cloud_cover_to_hourly_mean(latitude, longitude, elevation,
+                                   solar_position_func):
+    """
+    Take hourly RAP instant cloud cover and convert it to hourly average
+    data.
+    """
+    variables = load_forecast(
+        latitude, longitude, 'rap',
+        variables=('cloud_cover', 'temp_air', 'wind_speed'))
+    cloud_cover, temp_air, wind_speed = forecast.resample_args(*variables,
+                                                               freq='15min')
+    solar_position = solar_position_func(cloud_cover.index)
+    cs = pvmodel.calculate_clearsky(latitude, longitude, elevation,
+                                    solar_position['apparent_zenith'])
+    ghi, dni, dhi = forecast.cloud_cover_to_irradiance_clearsky_scaling(
+        cloud_cover, cs['ghi'], solar_position['zenith']
+    )
+    resample_func = partial(forecast.resample_args, freq='1h')
+    return ghi, dni, dhi, temp_air, wind_speed, resample_func
+
+
+def rap_cloud_cover_to_hourly_mean_alternative(latitude, longitude, elevation,
+                                               solar_position_func):
+    """
+    Take hourly RAP instant cloud cover and convert it to hourly average
+    data.
+    """
+    variables = load_forecast(
+        latitude, longitude, 'rap',
+        variables=('cloud_cover', 'temp_air', 'wind_speed'))
+    cloud_cover, temp_air, wind_speed = forecast.interpolate_args(*variables,
+                                                                  freq='15min')
+    ghi, dni, dhi = \
+        forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos_func(
+            latitude, longitude, elevation, cloud_cover, solar_position_func)
+    resample_func = partial(forecast.resample_args, freq='1h')
+    return ghi, dni, dhi, temp_air, wind_speed, resample_func
+
+
+def gfs_3hour_to_hourly_mean(latitude, longitude, elevation,
+                             solar_position_func):
+    """
+    Take 3 hr GFS and convert it to hourly average data.
+    """
+    cloud_cover, temp_air, wind_speed = load_forecast(latitude, longitude,
+                                                      'gfs_3h')
+    cloud_cover = forecast.unmix_intervals(cloud_cover)
+    cloud_cover, temp_air, wind_speed = forecast.interpolate_args(
+        cloud_cover, temp_air, wind_speed, freq='15min')
+    ghi, dni, dhi = \
+        forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos_func(
+            latitude, longitude, elevation, cloud_cover, solar_position_func)
+    resample_func = partial(forecast.resample_args, freq='1h')
+    return ghi, dni, dhi, temp_air, wind_speed, resample_func
+
+
+def gfs_hourly_to_hourly_mean(latitude, longitude, elevation,
+                              solar_position_func):
+    """
+    Take 1 hr GFS and convert it to hourly average data.
+    """
+    cloud_cover, temp_air, wind_speed = load_forecast(latitude, longitude,
+                                                      'gfs_1h')
+    # hourly data only available through 96h?
+    start = cloud_cover.index[0]
+    end = start + pd.Timedelta('96h')  # not sure about this time limit
+    ghi, temp_air, wind_speed = forecast.slice_args(
+        cloud_cover, temp_air, wind_speed, start, end)
+    cloud_cover, temp_air, wind_speed = forecast.interpolate_args(
+        cloud_cover, temp_air, wind_speed, freq='15min')
+    ghi, dni, dhi = \
+        forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos_func(
+            latitude, longitude, elevation, cloud_cover, solar_position_func)
+    resample_func = partial(forecast.resample_args, freq='1h')
+    return ghi, dni, dhi, temp_air, wind_speed, resample_func
+
+
+def nam_to_instantaneous(latitude, longitude, solar_position_func):
+    """
+    Hourly instantantaneous forecast. Max forecast horizon 48 hours.
+    """
+    ghi, temp_air, wind_speed = load_forecast(latitude, longitude, 'nam')
+    # hourly data only available through 48h?
+    start = ghi.index[0]
+    end = start + pd.Timedelta('48h')  # not sure about this time limit
+    ghi, temp_air, wind_speed = forecast.slice_args(ghi, temp_air, wind_speed,
+                                                    start, end)
+    solar_position = solar_position_func(ghi.index)
+    dni, dhi = pvmodel.complete_irradiance_components(
+        ghi, solar_position['zenith'])
+    resample_func = partial(forecast.resample_args, freq='15min')
+    return ghi, dni, dhi, temp_air, wind_speed, resample_func
+
+
+def nam_1_3_hour_to_hourly_mean(weather):
+    """
+
+    """
     weather = forecast.hourly_cloud_cover_to_subhourly(weather)
     return weather

--- a/solarforecastarbiter/reference_forecasts/models.py
+++ b/solarforecastarbiter/reference_forecasts/models.py
@@ -137,7 +137,8 @@ def rap_ghi_to_instantaneous(latitude, longitude, elevation,
     """
     # dni and dhi not in RAP output available from g2sub service
     ghi, temp_air, wind_speed = load_forecast(
-        latitude, longitude, init_time, start, end, 'rap')
+        latitude, longitude, init_time, start, end, 'rap',
+        variables=('ghi', 'temp_air', 'wind_speed'))
     dni, dhi, solar_pos_calculator = _ghi_to_dni_dhi(
         latitude, longitude, elevation, ghi)
     resampler = partial(forecast.resample, freq='1h')
@@ -155,7 +156,8 @@ def rap_ghi_to_hourly_mean(latitude, longitude, elevation,
     """
     # dni and dhi not in RAP output available from g2sub service
     ghi, temp_air, wind_speed = load_forecast(
-        latitude, longitude, init_time, start, end, 'rap')
+        latitude, longitude, init_time, start, end, 'rap',
+        variables=('ghi', 'temp_air', 'wind_speed'))
     dni, dhi, solar_pos_calculator = _ghi_to_dni_dhi(
         latitude, longitude, elevation, ghi)
     interpolator = partial(forecast.interpolate, freq='5min')
@@ -175,7 +177,8 @@ def rap_cloud_cover_to_hourly_mean(latitude, longitude, elevation,
     Max forecast horizon 21 or 39 (3Z, 9Z, 15Z, 21Z) hours.
     """
     cloud_cover, temp_air, wind_speed = load_forecast(
-        latitude, longitude, init_time, start, end, 'rap')
+        latitude, longitude, init_time, start, end, 'rap',
+        variables=('cloud_cover', 'temp_air', 'wind_speed'))
     return _resample_using_cloud_cover(latitude, longitude, elevation,
                                        cloud_cover, temp_air, wind_speed)
 

--- a/solarforecastarbiter/reference_forecasts/models.py
+++ b/solarforecastarbiter/reference_forecasts/models.py
@@ -12,6 +12,10 @@ The functions accept:
       Full datetime of a model initialization
   * start : pd.Timestamp
   * end : pd.Timestamp
+  * load_forecast : function
+      A function that accepts the arguments above and returns the
+      correct data. Enables users to supply their own data independently
+      of the `solarforecastarbiter.io` module.
 
 The functions return a tuple of:
 
@@ -52,7 +56,8 @@ from solarforecastarbiter.reference_forecasts import forecast
 
 
 def hrrr_subhourly_to_subhourly_instantaneous(latitude, longitude, elevation,
-                                              init_time, start, end):
+                                              init_time, start, end,
+                                              load_forecast=load_forecast):
     """
     Subhourly (15 min) instantantaneous HRRR forecast.
     """
@@ -66,7 +71,8 @@ def hrrr_subhourly_to_subhourly_instantaneous(latitude, longitude, elevation,
 
 
 def hrrr_subhourly_to_hourly_mean(latitude, longitude, elevation,
-                                  init_time, start, end):
+                                  init_time, start, end,
+                                  load_forecast=load_forecast):
     """
     Hourly mean HRRR forecast.
     """
@@ -83,7 +89,7 @@ def hrrr_subhourly_to_hourly_mean(latitude, longitude, elevation,
 
 
 def rap_to_instantaneous(latitude, longitude, elevation,
-                         init_time, start, end):
+                         init_time, start, end, load_forecast=load_forecast):
     """
     Hourly instantantaneous RAP forecast.
     """
@@ -97,7 +103,8 @@ def rap_to_instantaneous(latitude, longitude, elevation,
 
 
 def rap_irrad_to_hourly_mean(latitude, longitude, elevation,
-                             init_time, start, end):
+                             init_time, start, end,
+                             load_forecast=load_forecast):
     """
     Take hourly RAP instantantaneous irradiance and convert it to hourly
     average forecasts.
@@ -115,7 +122,8 @@ def rap_irrad_to_hourly_mean(latitude, longitude, elevation,
 
 
 def _resample_using_cloud_cover(latitude, longitude, elevation,
-                                cloud_cover, temp_air, wind_speed):
+                                cloud_cover, temp_air, wind_speed,
+                                load_forecast=load_forecast):
     # 5 minutes is probably better than 15
     interpolator = partial(forecast.interpolate, freq='5min')
     cloud_cover, temp_air, wind_speed = list(
@@ -133,7 +141,8 @@ def _resample_using_cloud_cover(latitude, longitude, elevation,
 
 
 def rap_cloud_cover_to_hourly_mean(latitude, longitude, elevation,
-                                   init_time, start, end):
+                                   init_time, start, end,
+                                   load_forecast=load_forecast):
     """
     Take hourly RAP instantantaneous cloud cover and convert it to
     hourly average forecasts.
@@ -146,7 +155,8 @@ def rap_cloud_cover_to_hourly_mean(latitude, longitude, elevation,
 
 
 def gfs_3hour_to_hourly_mean(latitude, longitude, elevation,
-                             init_time, start, end):
+                             init_time, start, end,
+                             load_forecast=load_forecast):
     """
     Take 3 hr GFS and convert it to hourly average data.
     """
@@ -158,7 +168,8 @@ def gfs_3hour_to_hourly_mean(latitude, longitude, elevation,
 
 
 def gfs_hourly_to_hourly_mean(latitude, longitude, elevation,
-                              init_time, start, end):
+                              init_time, start, end,
+                              load_forecast=load_forecast):
     """
     Take 1 hr GFS and convert it to hourly average data.
     Max forecast horizon 96? hours.
@@ -170,7 +181,8 @@ def gfs_hourly_to_hourly_mean(latitude, longitude, elevation,
 
 
 def nam_to_hourly_instantaneous(latitude, longitude, elevation,
-                                init_time, start, end):
+                                init_time, start, end,
+                                load_forecast=load_forecast):
     """
     Hourly instantantaneous forecast. Max forecast horizon 48? hours.
     """
@@ -187,7 +199,8 @@ def nam_to_hourly_instantaneous(latitude, longitude, elevation,
 
 
 def nam_cloud_cover_to_hourly_mean(latitude, longitude, elevation,
-                                   init_time, start, end):
+                                   init_time, start, end,
+                                   load_forecast=load_forecast):
     """
     Hourly average forecast. Max forecast horizon 72 hours.
     """

--- a/solarforecastarbiter/reference_forecasts/models.py
+++ b/solarforecastarbiter/reference_forecasts/models.py
@@ -65,7 +65,7 @@ def hrrr_subhourly_to_hourly_mean(latitude, longitude, elevation,
         latitude, longitude, init_time, start, end, 'hrrr_subhourly')
     interpolator = partial(forecast.interpolate, freq='5min')
     ghi, dni, dhi, temp_air, wind_speed = list(
-        map(interpolator, ghi, dni, dhi, temp_air, wind_speed))
+        map(interpolator, (ghi, dni, dhi, temp_air, wind_speed)))
     resampler = partial(forecast.resample, freq='1h')
     solar_pos_calculator = partial(
         pvmodel.calculate_solar_position, latitude, longitude, elevation,
@@ -97,7 +97,7 @@ def rap_irrad_to_hourly_mean(latitude, longitude, elevation,
         latitude, longitude, init_time, start, end, 'rap')
     interpolator = partial(forecast.interpolate, freq='5min')
     ghi, dni, dhi, temp_air, wind_speed = list(
-        map(interpolator, ghi, dni, dhi, temp_air, wind_speed))
+        map(interpolator, (ghi, dni, dhi, temp_air, wind_speed)))
     resampler = partial(forecast.resample, freq='1h')
     solar_pos_calculator = partial(
         pvmodel.calculate_solar_position, latitude, longitude, elevation,

--- a/solarforecastarbiter/reference_forecasts/models.py
+++ b/solarforecastarbiter/reference_forecasts/models.py
@@ -1,7 +1,8 @@
 """
 Default processing steps for some weather models.
 
-All functions assume that weather is a DataFrame.
+All functions have the same signature, but some args are not used
+and some return values may be None.
 """
 
 from functools import partial
@@ -13,37 +14,37 @@ from solarforecastarbiter.io import load_forecast
 from solarforecastarbiter.reference_forecasts import forecast
 
 
-def hrrr_subhourly_to_subhourly_instantaneous(latitude, longitude):
+def hrrr_subhourly_to_subhourly_instantaneous(latitude, longitude, elevation):
     """
     Subhourly (15 min) instantantaneous HRRR forecast.
     """
     ghi, dni, dhi, temp_air, wind_speed = load_forecast(
         latitude, longitude, 'hrrr_subhourly')
     resampler = partial(forecast.resample, freq='15min')
-    return ghi, dni, dhi, temp_air, wind_speed, resampler
+    return None, None, ghi, dni, dhi, temp_air, wind_speed, resampler
 
 
-def hrrr_subhourly_to_hourly_mean(latitude, longitude):
+def hrrr_subhourly_to_hourly_mean(latitude, longitude, elevation):
     """
     Hourly mean HRRR forecast.
     """
     ghi, dni, dhi, temp_air, wind_speed = load_forecast(
         latitude, longitude, 'hrrr_subhourly')
     resampler = partial(forecast.resample, freq='1h')
-    return ghi, dni, dhi, temp_air, wind_speed, resampler
+    return None, None, ghi, dni, dhi, temp_air, wind_speed, resampler
 
 
-def rap_to_instantaneous(latitude, longitude):
+def rap_to_instantaneous(latitude, longitude, elevation):
     """
     Hourly instantantaneous RAP forecast.
     """
     ghi, dni, dhi, temp_air, wind_speed = load_forecast(latitude, longitude,
                                                         'rap')
     resampler = partial(forecast.resample, freq='1h')
-    return ghi, dni, dhi, temp_air, wind_speed, resampler
+    return None, None, ghi, dni, dhi, temp_air, wind_speed, resampler
 
 
-def rap_irrad_to_hourly_mean(latitude, longitude):
+def rap_irrad_to_hourly_mean(latitude, longitude, elevation):
     """
     Take hourly RAP instantantaneous irradiance and convert it to hourly
     average data.
@@ -51,11 +52,27 @@ def rap_irrad_to_hourly_mean(latitude, longitude):
     ghi, dni, dhi, temp_air, wind_speed = load_forecast(
         latitude, longitude, 'rap')
     resample = partial(forecast.resample, freq='1h')
-    return ghi, dni, dhi, temp_air, wind_speed, resample
+    return None, None, ghi, dni, dhi, temp_air, wind_speed, resample
 
 
-def rap_cloud_cover_to_hourly_mean(latitude, longitude, elevation,
-                                   solar_position_func):
+def rap_cloud_cover_to_hourly_mean(latitude, longitude, elevation):
+    """
+    Take hourly RAP instantantaneous cloud cover and convert it to
+    hourly average data.
+    """
+    variables = load_forecast(
+        latitude, longitude, 'rap',
+        variables=('cloud_cover', 'temp_air', 'wind_speed'))
+    interpolator = partial(forecast.interpolate, freq='15min')
+    cloud_cover, temp_air, wind_speed = list(map(interpolator, variables))
+    solpos_irrad = forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos(
+            latitude, longitude, elevation, cloud_cover)
+    resampler = partial(forecast.resample, freq='1h')
+    return solpos_irrad + (temp_air, wind_speed, resampler)
+
+
+def rap_cloud_cover_to_hourly_mean_alternative(latitude, longitude, elevation,
+                                               solar_position_func):
     """
     Take hourly RAP instantantaneous cloud cover and convert it to
     hourly average data.
@@ -72,11 +89,12 @@ def rap_cloud_cover_to_hourly_mean(latitude, longitude, elevation,
         cloud_cover, cs['ghi'], solar_position['zenith']
     )
     resampler = partial(forecast.resample, freq='1h')
-    return ghi, dni, dhi, temp_air, wind_speed, resampler
+    solpos = solar_position['apparent_zenith'], solar_position['azimuth']
+    return solpos + (ghi, dni, dhi, temp_air, wind_speed, resampler)
 
 
-def rap_cloud_cover_to_hourly_mean_alternative(latitude, longitude, elevation,
-                                               solar_position_func):
+def rap_cloud_cover_to_hourly_mean_alternative2(latitude, longitude, elevation,
+                                                solar_position_func):
     """
     Take hourly RAP instantantaneous cloud cover and convert it to
     hourly average data.
@@ -84,7 +102,7 @@ def rap_cloud_cover_to_hourly_mean_alternative(latitude, longitude, elevation,
     variables = load_forecast(
         latitude, longitude, 'rap',
         variables=('cloud_cover', 'temp_air', 'wind_speed'))
-    interpolator = partial(forecast.interpolate_args, freq='15min')
+    interpolator = partial(forecast.interpolate, freq='15min')
     cloud_cover, temp_air, wind_speed = list(map(interpolator, variables))
     ghi, dni, dhi = \
         forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos_func(
@@ -93,26 +111,23 @@ def rap_cloud_cover_to_hourly_mean_alternative(latitude, longitude, elevation,
     return ghi, dni, dhi, temp_air, wind_speed, resampler
 
 
-def gfs_3hour_to_hourly_mean(latitude, longitude, elevation,
-                             solar_position_func):
+def gfs_3hour_to_hourly_mean(latitude, longitude, elevation):
     """
     Take 3 hr GFS and convert it to hourly average data.
     """
     cloud_cover, temp_air, wind_speed = load_forecast(latitude, longitude,
                                                       'gfs_3h')
     cloud_cover = forecast.unmix_intervals(cloud_cover)
-    interpolator = partial(forecast.interpolate_args, freq='15min')
+    interpolator = partial(forecast.interpolate, freq='15min')
     cloud_cover, temp_air, wind_speed = list(
         map(interpolator, (cloud_cover, temp_air, wind_speed)))
-    ghi, dni, dhi = \
-        forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos_func(
-            latitude, longitude, elevation, cloud_cover, solar_position_func)
+    solpos_irrad = forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos(
+            latitude, longitude, elevation, cloud_cover)
     resampler = partial(forecast.resample, freq='1h')
-    return ghi, dni, dhi, temp_air, wind_speed, resampler
+    return solpos_irrad + (temp_air, wind_speed, resampler)
 
 
-def gfs_hourly_to_hourly_mean(latitude, longitude, elevation,
-                              solar_position_func):
+def gfs_hourly_to_hourly_mean(latitude, longitude, elevation):
     """
     Take 1 hr GFS and convert it to hourly average data.
     """
@@ -123,16 +138,15 @@ def gfs_hourly_to_hourly_mean(latitude, longitude, elevation,
     end = start + pd.Timedelta('96h')  # not sure about this time limit
     ghi, temp_air, wind_speed = forecast.slice_args(
         cloud_cover, temp_air, wind_speed, start, end)
-    cloud_cover, temp_air, wind_speed = forecast.interpolate_args(
+    cloud_cover, temp_air, wind_speed = forecast.interpolate(
         cloud_cover, temp_air, wind_speed, freq='15min')
-    ghi, dni, dhi = \
-        forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos_func(
-            latitude, longitude, elevation, cloud_cover, solar_position_func)
+    solpos_irrad = forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos(
+            latitude, longitude, elevation, cloud_cover)
     resampler = partial(forecast.resample, freq='1h')
-    return ghi, dni, dhi, temp_air, wind_speed, resampler
+    return solpos_irrad + (temp_air, wind_speed, resampler)
 
 
-def nam_to_instantaneous(latitude, longitude, solar_position_func):
+def nam_to_instantaneous(latitude, longitude, elevation):
     """
     Hourly instantantaneous forecast. Max forecast horizon 48 hours.
     """
@@ -142,16 +156,10 @@ def nam_to_instantaneous(latitude, longitude, solar_position_func):
     end = start + pd.Timedelta('48h')  # not sure about this time limit
     ghi, temp_air, wind_speed = forecast.slice_args(ghi, temp_air, wind_speed,
                                                     start, end)
-    solar_position = solar_position_func(ghi.index)
+    solar_position = pvmodel.calculate_solar_position(
+        latitude, longitude, elevation)
     dni, dhi = pvmodel.complete_irradiance_components(
         ghi, solar_position['zenith'])
     resampler = partial(forecast.resample, freq='15min')
-    return ghi, dni, dhi, temp_air, wind_speed, resampler
-
-
-def nam_1_3_hour_to_hourly_mean(weather):
-    """
-
-    """
-    weather = forecast.hourly_cloud_cover_to_subhourly(weather)
-    return weather
+    return (solar_position['apparent_zenith'], solar_position['azimuth'],
+            ghi, dni, dhi, temp_air, wind_speed, resampler)

--- a/solarforecastarbiter/reference_forecasts/models.py
+++ b/solarforecastarbiter/reference_forecasts/models.py
@@ -1,0 +1,34 @@
+"""
+Default processing steps for some weather models.
+
+All functions assume that weather is a DataFrame.
+"""
+
+from solarforecastarbiter.reference_forecasts import forecast
+
+
+def hrrr_subhourly(weather):
+    """
+    HRRR subhourly probably already has all of the data that we want.
+    """
+    return weather
+
+
+def hrrr_hourly(weather):
+    weather = forecast.hourly_ghi_to_subhourly(weather)
+    return weather
+
+
+rap = hrrr_hourly
+
+
+def gfs(weather):
+    weather = forecast.unmix_intervals(weather)
+    weather = forecast.interpolate_to(weather, freq='1h')
+    weather = forecast.hourly_cloud_cover_to_subhourly(weather)
+    return weather
+
+
+def nam(weather):
+    weather = forecast.hourly_cloud_cover_to_subhourly(weather)
+    return weather

--- a/solarforecastarbiter/reference_forecasts/tests/test_forecast.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_forecast.py
@@ -4,6 +4,7 @@ from pandas.util.testing import assert_series_equal
 import pytest
 
 from solarforecastarbiter.reference_forecasts import forecast
+from solarforecastarbiter.conftest import requires_tables
 
 
 def assert_none_or_series(out, expected):
@@ -79,6 +80,7 @@ def test_cloud_cover_to_irradiance_ghi_clear():
     assert_series_equal(out[2], dhi_exp)
 
 
+@requires_tables
 @pytest.mark.xfail(raises=AssertionError, strict=True)
 def test_cloud_cover_to_irradiance():
     index = pd.DatetimeIndex(start='20190101', periods=3, freq='1h')

--- a/solarforecastarbiter/reference_forecasts/tests/test_forecast.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_forecast.py
@@ -1,0 +1,24 @@
+import pandas as pd
+from pandas.util.testing import assert_series_equal
+
+from solarforecastarbiter.reference_forecasts import forecast
+
+
+def assert_none_or_series(out, expected):
+    assert len(out) == len(expected)
+    for o, e in zip(out, expected):
+        if e is None:
+            assert o is None
+        else:
+            assert_series_equal(o, e)
+
+
+def test_resample_args():
+    index = pd.DatetimeIndex(start='20190101', freq='15min', periods=5)
+    args = [
+        None, pd.Series([1, 0, 0, 0, 2], index=index)
+    ]
+    idx_exp = pd.DatetimeIndex(start='20190101', freq='1h', periods=2)
+    expected = [None, pd.Series([0.25, 2.], index=idx_exp)]
+    out = forecast.resample_args(*args)
+    assert_none_or_series(out, expected)

--- a/solarforecastarbiter/reference_forecasts/tests/test_forecast.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_forecast.py
@@ -1,6 +1,8 @@
 import pandas as pd
 from pandas.util.testing import assert_series_equal
 
+import pytest
+
 from solarforecastarbiter.reference_forecasts import forecast
 
 
@@ -22,3 +24,75 @@ def test_resample_args():
     expected = [None, pd.Series([0.25, 2.], index=idx_exp)]
     out = forecast.resample_args(*args)
     assert_none_or_series(out, expected)
+
+
+def test_resample():
+    index = pd.DatetimeIndex(start='20190101', freq='15min', periods=5)
+    arg = pd.Series([1, 0, 0, 0, 2], index=index)
+    idx_exp = pd.DatetimeIndex(start='20190101', freq='1h', periods=2)
+    expected = pd.Series([0.25, 2.], index=idx_exp)
+    out = forecast.resample(arg)
+    assert_series_equal(out, expected)
+    assert forecast.resample(None) is None
+
+
+def test_interpolate():
+    index = pd.DatetimeIndex(start='20190101', freq='15min', periods=2)
+    arg = pd.Series([0, 1.5], index=index)
+    out = forecast.interpolate(arg)
+    assert_series_equal(out, arg)
+
+    idx_exp = pd.DatetimeIndex(start='20190101', freq='5min', periods=4)
+    expected = pd.Series([0., 0.5, 1., 1.5], index=idx_exp)
+    out = forecast.interpolate(arg, freq='5min')
+    assert_series_equal(out, expected)
+
+    assert forecast.interpolate(None) is None
+
+
+def test_cloud_cover_to_ghi_linear():
+    cloud_cover = pd.Series([0, 50, 100.])
+    ghi_clear = pd.Series([1000, 1000, 1000.])
+    out = forecast.cloud_cover_to_ghi_linear(cloud_cover, ghi_clear)
+    expected = pd.Series([1000, 675, 350.])
+    assert_series_equal(out, expected)
+    out = forecast.cloud_cover_to_ghi_linear(cloud_cover, ghi_clear, offset=20)
+    expected = pd.Series([1000, 600, 200.])
+    assert_series_equal(out, expected)
+
+
+@pytest.mark.xfail(strict=True)
+def test_cloud_cover_to_irradiance_clearsky_scaling():
+    cloud_cover = pd.Series([0, 50, 100.])
+    ghi_clear = pd.Series([10, 10, 1000.])
+    solar_zenith = pd.Series([90.0, 89.9, 45])
+    out = forecast.cloud_cover_to_irradiance_clearsky_scaling(
+        cloud_cover, ghi_clear, solar_zenith
+    )
+    # https://github.com/pvlib/pvlib-python/issues/681
+    ghi_exp = pd.Series([10., 6.75, 350.])
+    dni_exp = pd.Series([0., 0., 4.74198165e+01])
+    dhi_exp = pd.Series([10., 6.75, 316.46912616])
+    assert_series_equal(out[0], ghi_exp)
+    assert_series_equal(out[1], dni_exp)
+    assert_series_equal(out[2], dhi_exp)
+
+
+@pytest.mark.xfail(strict=True)
+def test_cloud_cover_to_irradiance_clearsky_scaling_solpos():
+    cloud_cover = pd.Series([0, 50, 100.])
+    latitude = 32.2
+    longitude = -110.9
+    elevation = 700
+    zenith = pd.Series([90.0, 89.9, 45])
+    apparent_zenith = pd.Series([89.9, 89.85, 45])
+    out = forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos(
+        latitude, longitude, elevation, cloud_cover, apparent_zenith, zenith
+    )
+    # https://github.com/pvlib/pvlib-python/issues/681
+    ghi_exp = pd.Series([10., 6.75, 350.])
+    dni_exp = pd.Series([0., 0., 4.74198165e+01])
+    dhi_exp = pd.Series([10., 6.75, 316.46912616])
+    assert_series_equal(out[0], ghi_exp)
+    assert_series_equal(out[1], dni_exp)
+    assert_series_equal(out[2], dhi_exp)

--- a/solarforecastarbiter/reference_forecasts/tests/test_forecast.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_forecast.py
@@ -61,13 +61,14 @@ def test_cloud_cover_to_ghi_linear():
     assert_series_equal(out, expected)
 
 
-@pytest.mark.xfail(strict=True)
-def test_cloud_cover_to_irradiance_clearsky_scaling():
-    cloud_cover = pd.Series([0, 50, 100.])
-    ghi_clear = pd.Series([10, 10, 1000.])
-    solar_zenith = pd.Series([90.0, 89.9, 45])
-    out = forecast.cloud_cover_to_irradiance_clearsky_scaling(
-        cloud_cover, ghi_clear, solar_zenith
+@pytest.mark.xfail(raises=AssertionError, strict=True)
+def test_cloud_cover_to_irradiance_ghi_clear():
+    index = pd.DatetimeIndex(start='20190101', periods=3, freq='1h')
+    cloud_cover = pd.Series([0, 50, 100.], index=index)
+    ghi_clear = pd.Series([10, 10, 1000.], index=index)
+    zenith = pd.Series([90.0, 89.9, 45], index=index)
+    out = forecast.cloud_cover_to_irradiance_ghi_clear(
+        cloud_cover, ghi_clear, zenith
     )
     # https://github.com/pvlib/pvlib-python/issues/681
     ghi_exp = pd.Series([10., 6.75, 350.])
@@ -78,21 +79,22 @@ def test_cloud_cover_to_irradiance_clearsky_scaling():
     assert_series_equal(out[2], dhi_exp)
 
 
-@pytest.mark.xfail(strict=True)
-def test_cloud_cover_to_irradiance_clearsky_scaling_solpos():
-    cloud_cover = pd.Series([0, 50, 100.])
+@pytest.mark.xfail(raises=AssertionError, strict=True)
+def test_cloud_cover_to_irradiance():
+    index = pd.DatetimeIndex(start='20190101', periods=3, freq='1h')
+    cloud_cover = pd.Series([0, 50, 100.], index=index)
     latitude = 32.2
     longitude = -110.9
     elevation = 700
-    zenith = pd.Series([90.0, 89.9, 45])
-    apparent_zenith = pd.Series([89.9, 89.85, 45])
-    out = forecast.cloud_cover_to_irradiance_clearsky_scaling_solpos(
+    zenith = pd.Series([90.0, 89.9, 45], index=index)
+    apparent_zenith = pd.Series([89.9, 89.85, 45], index=index)
+    out = forecast.cloud_cover_to_irradiance(
         latitude, longitude, elevation, cloud_cover, apparent_zenith, zenith
     )
     # https://github.com/pvlib/pvlib-python/issues/681
-    ghi_exp = pd.Series([10., 6.75, 350.])
-    dni_exp = pd.Series([0., 0., 4.74198165e+01])
-    dhi_exp = pd.Series([10., 6.75, 316.46912616])
+    ghi_exp = pd.Series([10., 6.75, 350.], index=index)
+    dni_exp = pd.Series([0., 0., 4.74198165e+01], index=index)
+    dhi_exp = pd.Series([10., 6.75, 316.46912616], index=index)
     assert_series_equal(out[0], ghi_exp)
     assert_series_equal(out[1], dni_exp)
     assert_series_equal(out[2], dhi_exp)

--- a/solarforecastarbiter/reference_forecasts/tests/test_main.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_main.py
@@ -1,0 +1,61 @@
+
+import pandas as pd
+# from pandas.util.testing import assert_series_equal
+
+import pytest
+
+from solarforecastarbiter.reference_forecasts import main, models
+
+
+# we'll need to do something better once the load_forecast function works
+init_time = pd.Timestamp('20190328T1200Z')
+start = pd.Timestamp('20190328T1300Z')
+end = pd.Timestamp('20190328T1400Z')
+
+index_exp = pd.DatetimeIndex(start=start, end=end, freq='1h')
+ghi_exp = pd.Series([0, 10.], index=index_exp)
+dni_exp = pd.Series([0, 15.], index=index_exp)
+dhi_exp = pd.Series([0, 9.], index=index_exp)
+temp_air_exp = pd.Series([10, 11.], index=index_exp)
+wind_speed_exp = pd.Series([0, 1.], index=index_exp)
+cloud_cover_exp = pd.Series([100., 0.], index=index_exp)
+load_forecast_return_value_3 = (cloud_cover_exp, temp_air_exp, wind_speed_exp)
+load_forecast_return_value_5 = (
+    ghi_exp, dni_exp, dhi_exp, temp_air_exp, wind_speed_exp)
+out_forecast_exp = (ghi_exp, dni_exp, dhi_exp, temp_air_exp, wind_speed_exp)
+
+
+def check_out(out, expected, site_type):
+    assert len(out) == 6
+    for o, e in zip(out[0:5], expected):
+        assert isinstance(o, pd.Series)
+        # assert_series_equal(o, e)
+    if site_type == 'powerplant':
+        assert isinstance(out[5], pd.Series)
+    elif site_type == 'site':
+        assert out[5] is None
+
+
+@pytest.mark.parametrize('model,load_forecast_return_value', [
+    (models.gfs_3hour_to_hourly_mean, load_forecast_return_value_3),
+    (models.gfs_hourly_to_hourly_mean, load_forecast_return_value_3),
+    (models.hrrr_subhourly_to_hourly_mean, load_forecast_return_value_5),
+    (models.hrrr_subhourly_to_subhourly_instantaneous,
+        load_forecast_return_value_5),
+    (models.nam_cloud_cover_to_hourly_mean, load_forecast_return_value_3),
+    (models.nam_to_hourly_instantaneous, load_forecast_return_value_3),
+    (models.rap_cloud_cover_to_hourly_mean, load_forecast_return_value_3),
+    (models.rap_irrad_to_hourly_mean, load_forecast_return_value_5),
+    (models.rap_to_instantaneous, load_forecast_return_value_5),
+])
+def test_run(model, load_forecast_return_value, site_powerplant_site_type,
+             mocker):
+    mocker.patch(
+        'solarforecastarbiter.reference_forecasts.models.load_forecast',
+        return_value=load_forecast_return_value)
+    mocker.patch(
+        'solarforecastarbiter.reference_forecasts.forecast.unmix_intervals',
+        return_value=cloud_cover_exp)
+    site, site_type = site_powerplant_site_type
+    out = main.run(site, model, init_time, start, end)
+    check_out(out, out_forecast_exp, site_type)

--- a/solarforecastarbiter/reference_forecasts/tests/test_main.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_main.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from solarforecastarbiter.reference_forecasts import main, models
+from solarforecastarbiter.conftest import requires_tables
 
 
 # we'll need to do something better once the load_forecast function works
@@ -37,14 +38,18 @@ def check_out(out, expected, site_type):
 
 
 @pytest.mark.parametrize('model,load_forecast_return_value', [
-    (models.gfs_3hour_to_hourly_mean, load_forecast_return_value_3),
-    (models.gfs_hourly_to_hourly_mean, load_forecast_return_value_3),
+    pytest.param(models.gfs_3hour_to_hourly_mean, load_forecast_return_value_3,
+                 marks=requires_tables),
+    pytest.param(models.gfs_hourly_to_hourly_mean,
+                 load_forecast_return_value_3, marks=requires_tables),
     (models.hrrr_subhourly_to_hourly_mean, load_forecast_return_value_5),
     (models.hrrr_subhourly_to_subhourly_instantaneous,
         load_forecast_return_value_5),
-    (models.nam_cloud_cover_to_hourly_mean, load_forecast_return_value_3),
+    pytest.param(models.nam_cloud_cover_to_hourly_mean,
+                 load_forecast_return_value_3, marks=requires_tables),
     (models.nam_to_hourly_instantaneous, load_forecast_return_value_3),
-    (models.rap_cloud_cover_to_hourly_mean, load_forecast_return_value_3),
+    pytest.param(models.rap_cloud_cover_to_hourly_mean,
+                 load_forecast_return_value_3, marks=requires_tables),
     (models.rap_irrad_to_hourly_mean, load_forecast_return_value_5),
     (models.rap_to_instantaneous, load_forecast_return_value_5),
 ])

--- a/solarforecastarbiter/reference_forecasts/tests/test_main.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_main.py
@@ -41,20 +41,30 @@ def check_out(out, expected, site_type):
 # xfail for now. This all needs to change eventually anyways.
 @pytest.mark.xfail(raises=NotImplementedError, strict=True)
 @pytest.mark.parametrize('model,load_forecast_return_value', [
-    pytest.param(models.gfs_3hour_to_hourly_mean, load_forecast_return_value_3,
-                 marks=requires_tables),
-    pytest.param(models.gfs_hourly_to_hourly_mean,
-                 load_forecast_return_value_3, marks=requires_tables),
+    pytest.param(
+        models.gfs_quarter_deg_3hour_to_hourly_mean,
+        load_forecast_return_value_3,
+        marks=requires_tables),
+    pytest.param(
+        models.gfs_quarter_deg_hourly_to_hourly_mean,
+        load_forecast_return_value_3,
+        marks=requires_tables),
+    pytest.param(
+        models.gfs_quarter_deg_to_hourly_mean,
+        load_forecast_return_value_3,
+        marks=[requires_tables,
+               pytest.mark.xfail(strict=True, raises=NotImplementedError)]),
     (models.hrrr_subhourly_to_hourly_mean, load_forecast_return_value_5),
     (models.hrrr_subhourly_to_subhourly_instantaneous,
         load_forecast_return_value_5),
-    pytest.param(models.nam_cloud_cover_to_hourly_mean,
+    pytest.param(models.nam_12km_cloud_cover_to_hourly_mean,
                  load_forecast_return_value_3, marks=requires_tables),
-    (models.nam_to_hourly_instantaneous, load_forecast_return_value_3),
+    (models.nam_12km_hourly_to_hourly_instantaneous,
+     load_forecast_return_value_3),
     pytest.param(models.rap_cloud_cover_to_hourly_mean,
                  load_forecast_return_value_3, marks=requires_tables),
-    (models.rap_irrad_to_hourly_mean, load_forecast_return_value_5),
-    (models.rap_to_instantaneous, load_forecast_return_value_5),
+    (models.rap_ghi_to_hourly_mean, load_forecast_return_value_3),
+    (models.rap_ghi_to_instantaneous, load_forecast_return_value_3),
 ])
 def test_run(model, load_forecast_return_value, site_powerplant_site_type,
              mocker):

--- a/solarforecastarbiter/reference_forecasts/tests/test_main.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_main.py
@@ -37,6 +37,9 @@ def check_out(out, expected, site_type):
         assert out[5] is None
 
 
+# can't figure out how to mock the load_forecast function here, so
+# xfail for now. This all needs to change eventually anyways.
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
 @pytest.mark.parametrize('model,load_forecast_return_value', [
     pytest.param(models.gfs_3hour_to_hourly_mean, load_forecast_return_value_3,
                  marks=requires_tables),
@@ -55,9 +58,6 @@ def check_out(out, expected, site_type):
 ])
 def test_run(model, load_forecast_return_value, site_powerplant_site_type,
              mocker):
-    mocker.patch(
-        'solarforecastarbiter.reference_forecasts.models.load_forecast',
-        return_value=load_forecast_return_value)
     mocker.patch(
         'solarforecastarbiter.reference_forecasts.forecast.unmix_intervals',
         return_value=cloud_cover_exp)

--- a/solarforecastarbiter/reference_forecasts/tests/test_models.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_models.py
@@ -1,0 +1,72 @@
+
+from functools import partial
+import types
+
+import pandas as pd
+from pandas.util.testing import assert_series_equal
+
+import pytest
+
+from solarforecastarbiter.reference_forecasts import models
+
+
+# we'll need to do something better once the load_forecast function works
+latitude = 32.2
+longitude = -110.9
+elevation = 700
+init_time = pd.Timestamp('20190328T1200Z')
+start = pd.Timestamp('20190328T1300Z')
+end = pd.Timestamp('20190328T1400Z')
+
+index_exp = pd.DatetimeIndex(start=start, end=end, freq='1h')
+ghi_exp = pd.Series([0, 10.], index=index_exp)
+dni_exp = pd.Series([0, 15.], index=index_exp)
+dhi_exp = pd.Series([0, 9.], index=index_exp)
+temp_air_exp = pd.Series([10, 11.], index=index_exp)
+wind_speed_exp = pd.Series([0, 1.], index=index_exp)
+cloud_cover_exp = pd.Series([100., 0.], index=index_exp)
+load_forecast_return_value_3 = (cloud_cover_exp, temp_air_exp, wind_speed_exp)
+load_forecast_return_value_5 = (
+    ghi_exp, dni_exp, dhi_exp, temp_air_exp, wind_speed_exp)
+out_forecast_exp = (ghi_exp, dni_exp, dhi_exp, temp_air_exp, wind_speed_exp)
+
+
+def check_out(out, expected):
+    for o, e in zip(out[0:5], expected):
+        assert isinstance(o, pd.Series)
+        # assert_series_equal(o, e)
+    assert isinstance(out[5], partial)
+    assert isinstance(out[6], (types.FunctionType, partial))
+
+
+def test_hrrr_subhourly_to_subhourly_instantaneous(mocker):
+    mocker.patch(
+        'solarforecastarbiter.reference_forecasts.models.load_forecast',
+        return_value=out_forecast_exp)
+    out = models.hrrr_subhourly_to_subhourly_instantaneous(
+        latitude, longitude, elevation, init_time, start, end)
+    check_out(out, out_forecast_exp)
+
+
+@pytest.mark.parametrize('model,load_forecast_return_value', [
+    (models.gfs_3hour_to_hourly_mean, load_forecast_return_value_3),
+    (models.gfs_hourly_to_hourly_mean, load_forecast_return_value_3),
+    (models.hrrr_subhourly_to_hourly_mean, load_forecast_return_value_5),
+    (models.hrrr_subhourly_to_subhourly_instantaneous,
+        load_forecast_return_value_5),
+    (models.nam_cloud_cover_to_hourly_mean, load_forecast_return_value_3),
+    (models.nam_to_hourly_instantaneous, load_forecast_return_value_3),
+    (models.rap_cloud_cover_to_hourly_mean, load_forecast_return_value_3),
+    (models.rap_irrad_to_hourly_mean, load_forecast_return_value_5),
+    (models.rap_to_instantaneous, load_forecast_return_value_5),
+])
+def test_all_models(model, load_forecast_return_value, mocker):
+    mocker.patch(
+        'solarforecastarbiter.reference_forecasts.models.load_forecast',
+        return_value=load_forecast_return_value)
+    mocker.patch(
+        'solarforecastarbiter.reference_forecasts.forecast.unmix_intervals',
+        return_value=cloud_cover_exp)
+    out = model(
+        latitude, longitude, elevation, init_time, start, end)
+    check_out(out, out_forecast_exp)

--- a/solarforecastarbiter/reference_forecasts/tests/test_models.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_models.py
@@ -42,15 +42,16 @@ def check_out(out, expected):
 
 @pytest.mark.xfail(raises=NotImplementedError, strict=True)
 @pytest.mark.parametrize('model', [
-    models.gfs_3hour_to_hourly_mean,
-    models.gfs_hourly_to_hourly_mean,
+    models.gfs_quarter_deg_3hour_to_hourly_mean,
+    models.gfs_quarter_deg_hourly_to_hourly_mean,
+    models.gfs_quarter_deg_to_hourly_mean,
     models.hrrr_subhourly_to_hourly_mean,
     models.hrrr_subhourly_to_subhourly_instantaneous,
-    models.nam_cloud_cover_to_hourly_mean,
-    models.nam_to_hourly_instantaneous,
+    models.nam_12km_cloud_cover_to_hourly_mean,
+    models.nam_12km_hourly_to_hourly_instantaneous,
     models.rap_cloud_cover_to_hourly_mean,
-    models.rap_irrad_to_hourly_mean,
-    models.rap_to_instantaneous,
+    models.rap_ghi_to_hourly_mean,
+    models.rap_ghi_to_instantaneous,
 ])
 def test_default_load_forecast(model):
     out = models.hrrr_subhourly_to_subhourly_instantaneous(
@@ -59,20 +60,30 @@ def test_default_load_forecast(model):
 
 
 @pytest.mark.parametrize('model,load_forecast_return_value', [
-    pytest.param(models.gfs_3hour_to_hourly_mean, load_forecast_return_value_3,
-                 marks=requires_tables),
-    pytest.param(models.gfs_hourly_to_hourly_mean,
-                 load_forecast_return_value_3, marks=requires_tables),
+    pytest.param(
+        models.gfs_quarter_deg_3hour_to_hourly_mean,
+        load_forecast_return_value_3,
+        marks=requires_tables),
+    pytest.param(
+        models.gfs_quarter_deg_hourly_to_hourly_mean,
+        load_forecast_return_value_3,
+        marks=requires_tables),
+    pytest.param(
+        models.gfs_quarter_deg_to_hourly_mean,
+        load_forecast_return_value_3,
+        marks=[requires_tables,
+               pytest.mark.xfail(strict=True, raises=NotImplementedError)]),
     (models.hrrr_subhourly_to_hourly_mean, load_forecast_return_value_5),
     (models.hrrr_subhourly_to_subhourly_instantaneous,
         load_forecast_return_value_5),
-    pytest.param(models.nam_cloud_cover_to_hourly_mean,
+    pytest.param(models.nam_12km_cloud_cover_to_hourly_mean,
                  load_forecast_return_value_3, marks=requires_tables),
-    (models.nam_to_hourly_instantaneous, load_forecast_return_value_3),
+    (models.nam_12km_hourly_to_hourly_instantaneous,
+     load_forecast_return_value_3),
     pytest.param(models.rap_cloud_cover_to_hourly_mean,
                  load_forecast_return_value_3, marks=requires_tables),
-    (models.rap_irrad_to_hourly_mean, load_forecast_return_value_5),
-    (models.rap_to_instantaneous, load_forecast_return_value_5),
+    (models.rap_ghi_to_hourly_mean, load_forecast_return_value_3),
+    (models.rap_ghi_to_instantaneous, load_forecast_return_value_3),
 ])
 def test_all_models(model, load_forecast_return_value, mocker):
     def load_forecast(*args, **kwargs):

--- a/solarforecastarbiter/reference_forecasts/tests/test_models.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_models.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 from solarforecastarbiter.reference_forecasts import models
+from solarforecastarbiter.conftest import requires_tables
 
 
 # we'll need to do something better once the load_forecast function works
@@ -49,14 +50,18 @@ def test_hrrr_subhourly_to_subhourly_instantaneous(mocker):
 
 
 @pytest.mark.parametrize('model,load_forecast_return_value', [
-    (models.gfs_3hour_to_hourly_mean, load_forecast_return_value_3),
-    (models.gfs_hourly_to_hourly_mean, load_forecast_return_value_3),
+    pytest.param(models.gfs_3hour_to_hourly_mean, load_forecast_return_value_3,
+                 marks=requires_tables),
+    pytest.param(models.gfs_hourly_to_hourly_mean,
+                 load_forecast_return_value_3, marks=requires_tables),
     (models.hrrr_subhourly_to_hourly_mean, load_forecast_return_value_5),
     (models.hrrr_subhourly_to_subhourly_instantaneous,
         load_forecast_return_value_5),
-    (models.nam_cloud_cover_to_hourly_mean, load_forecast_return_value_3),
+    pytest.param(models.nam_cloud_cover_to_hourly_mean,
+                 load_forecast_return_value_3, marks=requires_tables),
     (models.nam_to_hourly_instantaneous, load_forecast_return_value_3),
-    (models.rap_cloud_cover_to_hourly_mean, load_forecast_return_value_3),
+    pytest.param(models.rap_cloud_cover_to_hourly_mean,
+                 load_forecast_return_value_3, marks=requires_tables),
     (models.rap_irrad_to_hourly_mean, load_forecast_return_value_5),
     (models.rap_to_instantaneous, load_forecast_return_value_5),
 ])

--- a/solarforecastarbiter/reference_forecasts/tests/test_models.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_models.py
@@ -3,7 +3,7 @@ from functools import partial
 import types
 
 import pandas as pd
-from pandas.util.testing import assert_series_equal
+# from pandas.util.testing import assert_series_equal
 
 import pytest
 


### PR DESCRIPTION
~This PR is a total mess and is in no shape to merge.~ Starting to hack at #10. 

Rough idea is:

* `main.py`: glue code
* `models.py`: predefined processing functions for each standard model
* `forecast.py`: library functions that don't care about the model

I started by writing `forecast.py` and got frustrated that it was divorced from models. So then I started writing `models.py` and got frustrated that it was divorced from the workflow. So then I started writing `main.py` and got frustrated that I didn't understand the workflow and the "only calculate solar position once" mantra felt awkward in places. 

It's not clear to me if `main.py` should live at this level or at a higher level. I'm not a big fan of the potential `solarforecastarbiter.io` import in this module at this subpackage level. It will be even uglier if we run the benchmark forecasts through validator code (not sure that this will be necessary but something to keep in mind).

And what about #7? 

@alorenzo175 take a look at this and then let's discuss.
@cwhanse don't waste your time on this yet.