### PR TITLE
better nwp error handling and remove files in loop

### DIFF
--- a/solarforecastarbiter/io/fetch/nwp.py
+++ b/solarforecastarbiter/io/fetch/nwp.py
@@ -287,17 +287,15 @@ async def get_with_retries(get_func, *args, retries=5, **kwargs):
             logger.warning('Request to %s failed with code %s, retrying',
                            e.request_info.url, e.status)
             retried += 1
-            if retried >= retries:
-                raise ValueError('Too many retries')
-            await asyncio.sleep(60)
         except aiohttp.ClientError:
             logger.warning('Request failed in connection, retrying')
             retried += 1
-            if retried >= retries:
-                raise ValueError('Too many retries')
-            await asyncio.sleep(60)
         else:
             return res
+
+        if retried >= retries:
+            raise ValueError('Too many retries')
+        await asyncio.sleep(60)
 
 
 def _simple_model(model):

--- a/solarforecastarbiter/io/fetch/nwp.py
+++ b/solarforecastarbiter/io/fetch/nwp.py
@@ -674,8 +674,7 @@ async def _run_loop(session, model, modelpath, chunksize, once, use_tmp):
             except Exception:
                 raise
         if use_tmp:
-            del gribdir
-            del _tmpdir
+            _tmpdir.cleanup()
         if once:
             break
         else:

--- a/solarforecastarbiter/io/fetch/nwp.py
+++ b/solarforecastarbiter/io/fetch/nwp.py
@@ -666,7 +666,8 @@ async def _run_loop(session, model, modelpath, chunksize, once):
         fetch_tasks = set()
         finalpath = (modelpath / inittime.strftime('%Y/%m/%d/%H') /
                      model['filename'])
-        async for params in files_to_retrieve(session, model, modelpath,
+        tmpdir = tempfile.TemporaryDirectory()
+        async for params in files_to_retrieve(session, model, tmpdir,
                                               inittime):
             fetch_tasks.add(asyncio.create_task(
                 fetch_grib_files(session, params, modelpath, inittime,
@@ -684,6 +685,7 @@ async def _run_loop(session, model, modelpath, chunksize, once):
                 # remove grib files
                 for file_ in files:
                     UNLINK_QUEUE.put_nowait(file_)
+        del tmpdir
         if once:
             break
         else:

--- a/solarforecastarbiter/io/fetch/tests/test_nwp.py
+++ b/solarforecastarbiter/io/fetch/tests/test_nwp.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+
 import aiohttp
 from asynctest import CoroutineMock, MagicMock
 import pandas as pd
@@ -106,7 +109,7 @@ async def test_files_to_retrieve(mocker, mock_sleep):
     session.head.return_value.__aenter__.return_value.headers.__getitem__.return_value = '20190101T0000Z'  # NOQA
 
     params = [p async for p in nwp.files_to_retrieve(
-        session, nwp.RAP, pd.Timestamp('20190409T1200Z'))]
+        session, nwp.RAP, Path('/'), pd.Timestamp('20190409T1200Z'))]
     assert len(params) == 22
 
 
@@ -135,7 +138,8 @@ async def test_files_to_retrieve_ends_after_no_new(mocker, mock_sleep):
             new=CoroutineMock())
     checknext.return_value = False
 
-    params = [p async for p in nwp.files_to_retrieve(session, model, init)]
+    params = [p async for p in nwp.files_to_retrieve(session, model, Path('/'),
+                                                     init)]
 
     assert len(params) == 22
     assert checknext.await_count == 10
@@ -166,7 +170,8 @@ async def test_files_to_retrieve_cut_short(mocker, mock_sleep):
             'solarforecastarbiter.io.fetch.nwp.check_next_inittime',
             new=CoroutineMock())
     checknext.return_value = True
-    params = [p async for p in nwp.files_to_retrieve(session, model, init)]
+    params = [p async for p in nwp.files_to_retrieve(session, model, Path('/'),
+                                                     init)]
     assert len(params) == 10
 
 


### PR DESCRIPTION
NFS can cause all kinds of issues especially for GEFS that needs to download and remove thousands of files. So add better error logging, add the option to use /tmp to save the grib files, and execute the wgrib2 code in the worker process instead of the main thread