### PR TITLE
Add a dedicated timeout to the aiohttp client

### DIFF
--- a/solarforecastarbiter/io/fetch/__init__.py
+++ b/solarforecastarbiter/io/fetch/__init__.py
@@ -39,8 +39,9 @@ async def run_in_executor(func, *args, **kwargs):
 
 def make_session():
     """Make an aiohttp session"""
-    conn = aiohttp.TCPConnector(limit_per_host=5)
-    s = aiohttp.ClientSession(read_timeout=60, conn_timeout=60, connector=conn)
+    conn = aiohttp.TCPConnector(limit_per_host=20)
+    timeout = aiohttp.ClientTimeout(total=60, connect=10, sock_read=30)
+    s = aiohttp.ClientSession(connector=conn, timeout=timeout)
     return s
 
 

--- a/solarforecastarbiter/io/fetch/nwp.py
+++ b/solarforecastarbiter/io/fetch/nwp.py
@@ -381,6 +381,7 @@ async def files_to_retrieve(session, model, modelpath, init_time):
         while True:
             # is the next file ready?
             try:
+                logger.debug('Calling HEAD %s', next_model_url)
                 async with session.head(
                         next_model_url, raise_for_status=True) as r:
                     if first_file_modified_at is None:
@@ -389,6 +390,7 @@ async def files_to_retrieve(session, model, modelpath, init_time):
                         logger.debug('First file was available at %s %s',
                                      first_file_modified_at,
                                      model.get('member', ''))
+                logger.debug('HEAD returned %s', next_model_url)
             except aiohttp.ClientResponseError as e:
                 if e.status == 404:  # Not found
                     logger.debug(

--- a/solarforecastarbiter/io/fetch/nwp.py
+++ b/solarforecastarbiter/io/fetch/nwp.py
@@ -370,6 +370,7 @@ async def files_to_retrieve(session, model, modelpath, init_time):
     simple_model = _simple_model(model)
     first_file_modified_at = None
     for next_params in possible_params:
+        logger.debug('Checking if file is available for %s', next_params)
         filename = get_filename(modelpath, init_time, next_params)
         if filename.exists():
             yield next_params
@@ -661,6 +662,7 @@ async def _run_loop(session, model, modelpath, chunksize, once, use_tmp):
             gribdir = modelpath
         async for params in files_to_retrieve(session, model, gribdir,
                                               inittime):
+            logger.debug('Processing parameters %s', params)
             fetch_tasks.add(asyncio.create_task(
                 fetch_grib_files(session, params, gribdir, inittime,
                                  chunksize)))


### PR DESCRIPTION
For fetching nwp forecasts. This has been running for 3 weeks with no issues or pod restarts.