### PR TITLE
expand manifest to include tests, data files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,29 @@
+include MANIFEST.in
+include AUTHORS.md
+include LICENSE
+include README.md
+include setup.py
+
+# include most everything under solarforecastarbiter by default
+# better to package too much than not enough
+graft solarforecastarbiter
+
+graft docs
+prune docs/build
+prune docs/source/generated
+# all doc figures created by doc build
+prune docs/source/savefig
+
+global-exclude __pycache__
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude *.pyd
+global-exclude *.so
+global-exclude *~
+global-exclude .DS_Store
+global-exclude .git*
+global-exclude \#*
+global-exclude .ipynb_checkpoints
+
 include versioneer.py
 include solarforecastarbiter/_version.py
-include solarforecastarbiter/io/reference_observations/sfa_reference_sites.csv


### PR DESCRIPTION
Changes the manifest strategy so that all tests and data files are included by default. Styled after the pvlib python `MANIFEST.in`, which is styled after the pandas `MANIFEST.in`. The philosophy is better to include too much than not enough. 

Ran into this when trying to access NWP test data files for Denver workshop reference forecast notebook. 