### PR TITLE
Add deterministic metrics

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -255,10 +255,20 @@ Class for communicating with the Solar Forecast Arbiter API.
 Metrics
 =======
 
+Functions to compute forecast performance metrics.
+
 .. autosummary::
    :toctree: generated/
 
-   metrics
+   metrics.deterministic.mean_absolute
+   metrics.deterministic.mean_bias
+   metrics.deterministic.root_mean_square
+   metrics.deterministic.normalized_root_mean_square
+   metrics.deterministic.centered_root_mean_square
+   metrics.deterministic.mean_absolute_percentage
+   metrics.deterministic.forecast_skill
+   metrics.deterministic.pearson_correlation_coeff
+   metrics.deterministic.coeff_determination
 
 
 Reports

--- a/docs/source/whatsnew/1.0.0b.rst
+++ b/docs/source/whatsnew/1.0.0b.rst
@@ -8,7 +8,7 @@ This is the first 1.0 beta release.
 
 API Changes
 ~~~~~~~~~~~
-* Add deterministic forecast performance metrics
+* Add deterministic forecast performance metrics (:pull:`171`)
 
 
 Enhancements

--- a/docs/source/whatsnew/1.0.0b.rst
+++ b/docs/source/whatsnew/1.0.0b.rst
@@ -8,6 +8,7 @@ This is the first 1.0 beta release.
 
 API Changes
 ~~~~~~~~~~~
+* Add deterministic forecast performance metrics
 
 
 Enhancements

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -2,6 +2,18 @@
 
 import numpy as np
 
+__all__ = [
+    "mean_absolute",
+    "mean_bias",
+    "root_mean_square",
+    "mean_absolute_percentage",
+    "normalized_root_mean_square",
+    "forecast_skill",
+    "pearson_correlation_coeff",
+    "coeff_determination",
+    "centered_root_mean_square",
+]
+
 
 def mean_absolute(y_true, y_pred):
     """Mean absolute error (MAE).

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -1,0 +1,197 @@
+"""Deterministic forecast error metrics."""
+
+import numpy as np
+
+
+def mean_absolute(y_true, y_pred):
+    """Mean absolute error (MAE).
+
+    Parameters
+    ----------
+    y_true : array-like
+        True values.
+    y_pred : array-like
+        Predicted values.
+
+    Returns
+    -------
+    mae : float
+        The MAE between the true and predicted values.
+    """
+
+    return np.mean(np.abs(y_true - y_pred))
+
+
+def mean_bias(y_true, y_pred):
+    """Mean bias error (MBE).
+
+    Parameters
+    ----------
+    y_true : array-like
+        True values.
+    y_pred : array-like
+        Predicted values.
+
+    Returns
+    -------
+    mbe : float
+        The MBE between the true and predicted values.
+
+    """
+
+    return np.mean(y_pred - y_true)
+
+
+def root_mean_square(y_true, y_pred):
+    """Root mean square error (RMSE).
+
+    Parameters
+    ----------
+    y_true : array-like
+        True values.
+    y_pred : array-like
+        Predicted values.
+
+    Returns
+    -------
+    rmse : float
+        The RMSE between the true and predicted values.
+
+    """
+
+    return np.sqrt(np.mean((y_true - y_pred) ** 2))
+
+
+def mean_absolute_percentage(y_true, y_pred):
+    """Mean absolute percentage error (MAPE).
+
+    Parameters
+    ----------
+    y_true : array-like
+        True values.
+    y_pred : array-like
+        Predicted values.
+
+    Returns
+    -------
+    mape : float
+        The MAPE [%] between the true and predicted values.
+
+    """
+
+    return np.mean(np.abs((y_true - y_pred) / y_true)) * 100.0
+
+
+def normalized_root_mean_square(y_true, y_pred, y_norm):
+    """Normalized root mean square error (NRMSE).
+
+    Parameters
+    ----------
+    y_true : array-like
+        True values.
+    y_pred : array-like
+        Predicted values.
+    y_norm : float
+        Normalized factor, in the same units as y_true and y_pred.
+
+    Returns
+    -------
+    nrmse : float
+        The NRMSE [%] between the true and predicted values.
+
+    """
+
+    return root_mean_square(y_true, y_pred) / y_norm * 100.0
+
+
+def forecast_skill(y_true, y_pred, y_ref):
+    """Forecast skill (s).
+
+    Parameters
+    ----------
+    y_true : array-like
+        True values.
+    y_pred : array-like
+        Predicted values.
+    y_ref: array_like
+        Reference forecast values.
+
+    Returns
+    -------
+    s : float
+        The forecast skill [-] between the true and predicted values compared
+        to a reference forecast.
+
+    """
+
+    rmse_pred = root_mean_square(y_true, y_pred)
+    rmse_ref = root_mean_square(y_true, y_ref)
+    return 1.0 - rmse_pred / rmse_ref
+
+
+def pearson_correlation_coeff(y_true, y_pred):
+    """Pearson correlation coefficient (r).
+
+    Parameters
+    ----------
+    y_true : array-like
+        True values.
+    y_pred : array-like
+        Predicted values.
+
+    Returns
+    -------
+    r : float
+        The correlation coefficient (r [-]) between the true and predicted
+        values.
+
+    """
+
+    x1 = y_pred - np.mean(y_pred)
+    x2 = y_true - np.mean(y_true)
+    return np.sum(x1 * x2) / (np.sqrt(np.sum(x1 ** 2)) * np.sqrt(np.sum(x2 ** 2)))
+
+
+def coeff_determination(y_true, y_pred):
+    """Coefficient of determination (R^2).
+
+    Parameters
+    ----------
+    y_true : array-like
+        True values.
+    y_pred : array-like
+        Predicted values.
+
+    Returns
+    -------
+    r2 : float
+        The coefficient of determination (R^2 [-]) between the true and
+        predicted values.
+
+    """
+
+    ss_res = np.sum((y_true - y_pred) ** 2)
+    ss_tot = np.sum((y_true - np.mean(y_true)) ** 2)
+    return 1.0 - ss_res / ss_tot
+
+
+def centered_root_mean_square(y_true, y_pred):
+    """Centered (unbiased) root mean square error (CRMSE):
+
+    Parameters
+    ----------
+    y_true : array-like
+        True values.
+    y_pred : array-like
+        Predicted values.
+
+    Returns
+    -------
+    crmse : float
+        The CRMSE between the true and predicted values.
+
+    """
+
+    return np.sqrt(np.mean(
+        ((y_pred - np.mean(y_pred)) - (y_true - np.mean(y_true))) ** 2
+    ))

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -161,7 +161,9 @@ def pearson_correlation_coeff(y_true, y_pred):
 
     x1 = y_pred - np.mean(y_pred)
     x2 = y_true - np.mean(y_true)
-    return np.sum(x1 * x2) / (np.sqrt(np.sum(x1 ** 2)) * np.sqrt(np.sum(x2 ** 2)))
+    return np.sum(x1 * x2) / (
+        np.sqrt(np.sum(x1 ** 2)) * np.sqrt(np.sum(x2 ** 2))
+    )
 
 
 def coeff_determination(y_true, y_pred):

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -8,7 +8,8 @@ from solarforecastarbiter.metrics import deterministic
     (np.array([0, 1, 2]), np.array([0, 1, 1]), 1 / 3),
 ])
 def test_mae(y_true, y_pred, value):
-    assert deterministic.mean_absolute(y_true, y_pred) == value
+    mae = deterministic.mean_absolute(y_true, y_pred)
+    assert mae == value
 
 
 @pytest.mark.parametrize("y_true,y_pred,value", [
@@ -16,7 +17,8 @@ def test_mae(y_true, y_pred, value):
     (np.array([0, 1, 2]), np.array([1, 0, 2]), 0.0),
 ])
 def test_mbe(y_true, y_pred, value):
-    assert deterministic.mean_bias(y_true, y_pred) == value
+    mbe = deterministic.mean_bias(y_true, y_pred)
+    assert mbe == value
 
 
 @pytest.mark.parametrize("y_true,y_pred,value", [
@@ -24,7 +26,8 @@ def test_mbe(y_true, y_pred, value):
     (np.array([0, 1]), np.array([1, 2]), 1.0),
 ])
 def test_rmse(y_true, y_pred, value):
-    assert deterministic.root_mean_square(y_true, y_pred) == value
+    rmse = deterministic.root_mean_square(y_true, y_pred)
+    assert rmse == value
 
 
 @pytest.mark.parametrize("y_true,y_pred,value", [
@@ -32,7 +35,8 @@ def test_rmse(y_true, y_pred, value):
     (np.array([2, 2]), np.array([3, 3]), 50.0),
 ])
 def test_mape(y_true, y_pred, value):
-    assert deterministic.mean_absolute_percentage(y_true, y_pred) == value
+    mape = deterministic.mean_absolute_percentage(y_true, y_pred)
+    assert mape == value
 
 
 @pytest.mark.parametrize("y_true,y_pred,y_norm,value", [
@@ -42,17 +46,39 @@ def test_mape(y_true, y_pred, value):
     (np.array([0, 1]), np.array([1, 2]), 100.0, 1.0),
 ])
 def test_nrmse(y_true, y_pred, y_norm, value):
-    assert deterministic.normalized_root_mean_square(y_true, y_pred, y_norm) == value
+    nrmse = deterministic.normalized_root_mean_square(y_true, y_pred, y_norm)
+    assert nrmse == value
+
 
 @pytest.mark.parametrize("y_true,y_pred,y_ref,value", [
     (np.array([0, 1]), np.array([0, 2]), np.array([0, 2]), 1.0 - 1.0 / 1.0),
     (np.array([0, 1]), np.array([0, 2]), np.array([0, 3]), 1.0 - 1.0 / 2.0),
 ])
 def test_skill(y_true, y_pred, y_ref, value):
-    assert deterministic.forecast_skill(y_true, y_pred, y_ref) == value
+    s = deterministic.forecast_skill(y_true, y_pred, y_ref)
+    assert s == value
 
-# Pearson corr coeff (r) [-]
 
-# Coeff of deterministation (R^2) [-]
+@pytest.mark.parametrize("y_true,y_pred,value", [
+    (np.array([0, 1]), np.array([0, 1]), 1.0),
+    (np.array([1, 2]), np.array([-1, -2]), -1.0),
+])
+def test_r(y_true, y_pred, value):
+    r = deterministic.pearson_correlation_coeff(y_true, y_pred)
+    assert pytest.approx(r) == value
 
-# CRMSE
+
+@pytest.mark.parametrize("y_true,y_pred,value", [
+    (np.array([0, 1]), np.array([0, 1]), 1.0),
+])
+def test_r2(y_true, y_pred, value):
+    r2 = deterministic.coeff_determination(y_true, y_pred)
+    assert pytest.approx(r2) == value
+
+
+@pytest.mark.parametrize("y_true,y_pred,value", [
+    (np.array([0, 1]), np.array([0, 1]), 0.0),
+])
+def test_crmse(y_true, y_pred, value):
+    crmse = deterministic.centered_root_mean_square(y_true, y_pred)
+    assert crmse == value

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -1,6 +1,35 @@
+import pytest
 import numpy as np
+import pandas as pd
 from solarforecastarbiter.metrics import deterministic
 
+
+@pytest.fixture()
+def test_df():
+    n = 100
+    t = np.linspace(0, 8 * np.pi, n)
+    ts = pd.date_range("2017-01-01 00:00:00", freq="1h", periods=n)
+    return pd.DataFrame(index=ts, data={
+        "true": np.sin(t),
+        "perfect": np.sin(t),
+        "overpredict": np.sin(t) + 0.1,
+        "underpredict": np.sin(t) - 0.1,
+    })
+
+def test_mae(test_df):
+    assert deterministic.mean_absolute(test_df["true"], test_df["perfect"]) == 0.0
+    assert deterministic.mean_absolute(test_df["true"], test_df["overpredict"]) > 0.0
+    assert deterministic.mean_absolute(test_df["true"], test_df["underpredict"]) > 0.0
+
+def test_mbe(test_df):
+    assert deterministic.mean_bias(test_df["true"], test_df["perfect"]) == 0.0
+    assert deterministic.mean_bias(test_df["true"], test_df["overpredict"]) > 0.0
+    assert deterministic.mean_bias(test_df["true"], test_df["underpredict"]) < 0.0
+
+def test_rmse(test_df):
+    assert deterministic.root_mean_square(test_df["true"], test_df["perfect"]) == 0.0
+    assert deterministic.root_mean_square(test_df["true"], test_df["overpredict"]) > 0.0
+    assert deterministic.root_mean_square(test_df["true"], test_df["underpredict"]) > 0.0
 
 def test_deterministic_metrics():
 

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -1,0 +1,51 @@
+import numpy as np
+from solarforecastarbiter.metrics import deterministic
+
+
+def test_deterministic_metrics():
+
+    # synthetic data for testing
+    n = 10
+    y_true = np.random.randn(n)
+    y_pred = np.random.randn(n)
+    y_ref = np.random.randn(n)
+    y_norm = 1.0
+
+    mae = deterministic.mean_absolute(y_true, y_pred)
+    mbe = deterministic.mean_bias(y_true, y_pred)
+    rmse = deterministic.root_mean_square(y_true, y_pred)
+    crmse = deterministic.centered_root_mean_square(y_true, y_pred)
+    nrmse = deterministic.normalized_root_mean_square(y_true, y_pred, y_norm)
+    mape = deterministic.mean_absolute_percentage(y_true, y_pred)
+    s = deterministic.forecast_skill(y_true, y_pred, y_ref)
+    r = deterministic.pearson_correlation_coeff(y_true, y_pred)
+    r2 = deterministic.coeff_determination(y_true, y_pred)
+
+    # scalar metrics
+    assert isinstance(mae, float)
+    assert isinstance(mbe, float)
+    assert isinstance(rmse, float)
+    assert isinstance(crmse, float)
+    assert isinstance(nrmse, float)
+    assert isinstance(mape, float)
+    assert isinstance(s, float)
+    assert isinstance(r, float)
+    assert isinstance(r2, float)
+
+    # non-negative metrics
+    assert mae >= 0.0
+    assert rmse >= 0.0
+    assert mape >= 0.0
+    assert nrmse >= 0.0
+
+    # bounded metrics
+    assert r >= -1.0
+    assert r <= 1.0
+    assert r2 <= 1.0
+
+    # known results
+    s = deterministic.forecast_skill(y_true, y_pred, y_pred)
+    assert s == 0.0
+
+    r2 = deterministic.coeff_determination(y_true, y_true)
+    assert r2 == 1.0

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -1,80 +1,35 @@
 import pytest
 import numpy as np
-import pandas as pd
 from solarforecastarbiter.metrics import deterministic
 
 
-@pytest.fixture()
-def test_df():
-    n = 100
-    t = np.linspace(0, 8 * np.pi, n)
-    ts = pd.date_range("2017-01-01 00:00:00", freq="1h", periods=n)
-    return pd.DataFrame(index=ts, data={
-        "true": np.sin(t),
-        "perfect": np.sin(t),
-        "overpredict": np.sin(t) + 0.1,
-        "underpredict": np.sin(t) - 0.1,
-    })
+@pytest.mark.parametrize("y_true,y_pred,value", [
+    (np.array([0, 1, 2]), np.array([0, 1, 2]), 0.0),
+    (np.array([0, 1, 2]), np.array([0, 1, 1]), 1 / 3),
+])
+def test_mae(y_true, y_pred, value):
+    assert deterministic.mean_absolute(y_true, y_pred) == value
 
-def test_mae(test_df):
-    assert deterministic.mean_absolute(test_df["true"], test_df["perfect"]) == 0.0
-    assert deterministic.mean_absolute(test_df["true"], test_df["overpredict"]) > 0.0
-    assert deterministic.mean_absolute(test_df["true"], test_df["underpredict"]) > 0.0
 
-def test_mbe(test_df):
-    assert deterministic.mean_bias(test_df["true"], test_df["perfect"]) == 0.0
-    assert deterministic.mean_bias(test_df["true"], test_df["overpredict"]) > 0.0
-    assert deterministic.mean_bias(test_df["true"], test_df["underpredict"]) < 0.0
+@pytest.mark.parametrize("y_true,y_pred,value", [
+    (np.array([0, 1, 2]), np.array([0, 1, 2]), 0.0),
+    (np.array([0, 1, 2]), np.array([1, 0, 2]), 0.0),
+])
+def test_mbe(y_true, y_pred, value):
+    assert deterministic.mean_bias(y_true, y_pred) == value
 
-def test_rmse(test_df):
-    assert deterministic.root_mean_square(test_df["true"], test_df["perfect"]) == 0.0
-    assert deterministic.root_mean_square(test_df["true"], test_df["overpredict"]) > 0.0
-    assert deterministic.root_mean_square(test_df["true"], test_df["underpredict"]) > 0.0
 
-def test_deterministic_metrics():
+@pytest.mark.parametrize("y_true,y_pred,value", [
+    (np.array([0, 1, 2]), np.array([0, 1, 2]), 0.0),
+    (np.array([0, 1]), np.array([1, 2]), 1.0),
+])
+def test_rmse(y_true, y_pred, value):
+    assert deterministic.root_mean_square(y_true, y_pred) == value
 
-    # synthetic data for testing
-    n = 10
-    y_true = np.random.randn(n)
-    y_pred = np.random.randn(n)
-    y_ref = np.random.randn(n)
-    y_norm = 1.0
 
-    mae = deterministic.mean_absolute(y_true, y_pred)
-    mbe = deterministic.mean_bias(y_true, y_pred)
-    rmse = deterministic.root_mean_square(y_true, y_pred)
-    crmse = deterministic.centered_root_mean_square(y_true, y_pred)
-    nrmse = deterministic.normalized_root_mean_square(y_true, y_pred, y_norm)
-    mape = deterministic.mean_absolute_percentage(y_true, y_pred)
-    s = deterministic.forecast_skill(y_true, y_pred, y_ref)
-    r = deterministic.pearson_correlation_coeff(y_true, y_pred)
-    r2 = deterministic.coeff_determination(y_true, y_pred)
-
-    # scalar metrics
-    assert isinstance(mae, float)
-    assert isinstance(mbe, float)
-    assert isinstance(rmse, float)
-    assert isinstance(crmse, float)
-    assert isinstance(nrmse, float)
-    assert isinstance(mape, float)
-    assert isinstance(s, float)
-    assert isinstance(r, float)
-    assert isinstance(r2, float)
-
-    # non-negative metrics
-    assert mae >= 0.0
-    assert rmse >= 0.0
-    assert mape >= 0.0
-    assert nrmse >= 0.0
-
-    # bounded metrics
-    assert r >= -1.0
-    assert r <= 1.0
-    assert r2 <= 1.0
-
-    # known results
-    s = deterministic.forecast_skill(y_true, y_pred, y_pred)
-    assert s == 0.0
-
-    r2 = deterministic.coeff_determination(y_true, y_true)
-    assert r2 == 1.0
+@pytest.mark.parametrize("y_true,y_pred,value", [
+    (np.array([1, 1]), np.array([2, 2]), 100.0),
+    (np.array([2, 2]), np.array([3, 3]), 50.0),
+])
+def test_mape(y_true, y_pred, value):
+    assert deterministic.mean_absolute_percentage(y_true, y_pred) == value

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -20,7 +20,7 @@ def test_mbe(y_true, y_pred, value):
 
 
 @pytest.mark.parametrize("y_true,y_pred,value", [
-    (np.array([0, 1, 2]), np.array([0, 1, 2]), 0.0),
+    (np.array([0, 1]), np.array([0, 1]), 0.0),
     (np.array([0, 1]), np.array([1, 2]), 1.0),
 ])
 def test_rmse(y_true, y_pred, value):
@@ -33,3 +33,26 @@ def test_rmse(y_true, y_pred, value):
 ])
 def test_mape(y_true, y_pred, value):
     assert deterministic.mean_absolute_percentage(y_true, y_pred) == value
+
+
+@pytest.mark.parametrize("y_true,y_pred,y_norm,value", [
+    (np.array([0, 1, 2]), np.array([0, 1, 2]), 1.0, 0.0),
+    (np.array([0, 1, 2]), np.array([0, 1, 2]), 55.0, 0.0),
+    (np.array([0, 1]), np.array([1, 2]), 1.0, 100.0),
+    (np.array([0, 1]), np.array([1, 2]), 100.0, 1.0),
+])
+def test_nrmse(y_true, y_pred, y_norm, value):
+    assert deterministic.normalized_root_mean_square(y_true, y_pred, y_norm) == value
+
+@pytest.mark.parametrize("y_true,y_pred,y_ref,value", [
+    (np.array([0, 1]), np.array([0, 2]), np.array([0, 2]), 1.0 - 1.0 / 1.0),
+    (np.array([0, 1]), np.array([0, 2]), np.array([0, 3]), 1.0 - 1.0 / 2.0),
+])
+def test_skill(y_true, y_pred, y_ref, value):
+    assert deterministic.forecast_skill(y_true, y_pred, y_ref) == value
+
+# Pearson corr coeff (r) [-]
+
+# Coeff of deterministation (R^2) [-]
+
+# CRMSE

--- a/solarforecastarbiter/reports/metrics.py
+++ b/solarforecastarbiter/reports/metrics.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 
+from solarforecastarbiter.metrics import deterministic
 from solarforecastarbiter import datamodel
 from solarforecastarbiter.validation.quality_mapping import \
     convert_mask_into_dataframe
@@ -82,30 +83,47 @@ def loop_forecasts_calculate_metrics(report, processed_fxobs):
 def calculate_metrics(forecast_observation, fx_values, obs_values):
     metrics = defaultdict(dict)
     metrics['name'] = forecast_observation.forecast.name
-    if fx_values.empty:
-        diff = pd.Series(index=obs_values.index)
-    elif obs_values.empty:
-        diff = pd.Series(index=fx_values.index)
+
+    if fx_values.empty or obs_values.emtpy:
+        for category in ["total", "month", "day", "hour"]:
+            for metric in ["mae", "mbe", "rmse"]:
+                metrics[category][metric] = np.nan
     else:
-        diff = fx_values - obs_values
-    metrics['total']['mae'] = diff.abs().mean()
-    _rmse = diff.aggregate(rmse)
-    metrics['total']['rmse'] = _rmse
-    metrics['total']['mbe'] = diff.mean()
-    metrics['day']['mae'] = diff.abs().groupby(lambda x: x.date).mean()
-    _rmse = diff.groupby(lambda x: x.date).aggregate(rmse)
-    metrics['day']['rmse'] = _rmse
-    metrics['day']['mbe'] = diff.groupby(lambda x: x.date).mean()
-    metrics['month']['mae'] = diff.abs().groupby(lambda x: x.month).mean()
-    _rmse = diff.groupby(lambda x: x.month).aggregate(rmse)
-    metrics['month']['rmse'] = _rmse
-    metrics['month']['mbe'] = diff.groupby(lambda x: x.month).mean()
-    metrics['hour']['mae'] = diff.abs().groupby(lambda x: x.hour).mean()
-    _rmse = diff.groupby(lambda x: x.hour).aggregate(rmse)
-    metrics['hour']['rmse'] = _rmse
-    metrics['hour']['mbe'] = diff.groupby(lambda x: x.hour).mean()
+        df = pd.concat([obs_values, fx_values], axis=1)
+        df.columns = ["obs_values", "fx_values"]
+
+        metrics["total"]["mae"] = deterministic.mean_absolute(df.obs_values, df.fx_values)
+        metrics["total"]["mbe"] = deterministic.mean_bias(df.obs_values, df.fx_values)
+        metrics["total"]["rmse"] = deterministic.root_mean_square(df.obs_values, df.fx_values)
+
+        # monthly metrics
+        mae, mbe, rmse = [], [], []
+        for _, group in df.groupby(df.index.month):
+            mae.append(deterministic.mean_absolute(df.obs_values, df.fx_values))
+            mbe.append(deterministic.mean_bias(df.obs_values, df.fx_values))
+            rmse.append(deterministic.root_mean_square(df.obs_values, df.fx_values))
+        metrics["month"]["mae"] = mae
+        metrics["month"]["mbe"] = mbe
+        metrics["month"]["rmse"] = rmse
+
+        # daily metrics
+        mae, mbe, rmse = [], [], []
+        for _, group in df.groupby(df.index.date):
+            mae.append(deterministic.mean_absolute(df.obs_values, df.fx_values))
+            mbe.append(deterministic.mean_bias(df.obs_values, df.fx_values))
+            rmse.append(deterministic.root_mean_square(df.obs_values, df.fx_values))
+        metrics["day"]["mae"] = mae
+        metrics["day"]["mbe"] = mbe
+        metrics["day"]["rmse"] = rmse
+
+        # hourly metrics
+        mae, mbe, rmse = [], [], []
+        for _, group in df.groupby(df.index.hour):
+            mae.append(deterministic.mean_absolute(df.obs_values, df.fx_values))
+            mbe.append(deterministic.mean_bias(df.obs_values, df.fx_values))
+            rmse.append(deterministic.root_mean_square(df.obs_values, df.fx_values))
+        metrics["hour"]["mae"] = mae
+        metrics["hour"]["mbe"] = mbe
+        metrics["hour"]["rmse"] = rmse
+
     return metrics
-
-
-def rmse(diff):
-    return np.sqrt((diff * diff).mean())

--- a/solarforecastarbiter/reports/metrics.py
+++ b/solarforecastarbiter/reports/metrics.py
@@ -4,7 +4,7 @@ https://github.com/SolarArbiter/solarforecastarbiter-core/pull/102
 """
 from collections import defaultdict
 
-
+import numpy as np
 import pandas as pd
 
 
@@ -82,65 +82,71 @@ def loop_forecasts_calculate_metrics(report, processed_fxobs):
 def calculate_metrics(forecast_observation, fx_values, obs_values):
     metrics = defaultdict(dict)
     metrics['name'] = forecast_observation.forecast.name
-    df = pd.concat([obs_values, fx_values], axis=1)
-    df.columns = ["obs_values", "fx_values"]
 
-    metrics["total"]["mae"] = deterministic.mean_absolute(
-        df.obs_values, df.fx_values
-    )
-    metrics["total"]["mbe"] = deterministic.mean_bias(
-        df.obs_values, df.fx_values
-    )
-    metrics["total"]["rmse"] = deterministic.root_mean_square(
-        df.obs_values, df.fx_values
-    )
+    if fx_values.empty or obs_values.empty:
+        for category in ["total", "month", "day", "hour"]:
+            for metric in ["mae", "mbe", "rmse"]:
+                metrics[category][metric] = np.nan
+    else:
+        df = pd.concat([obs_values, fx_values], axis=1)
+        df.columns = ["obs_values", "fx_values"]
 
-    # monthly metrics
-    mae, mbe, rmse = [], [], []
-    for _, group in df.groupby(df.index.month):
-        mae.append(
-            deterministic.mean_absolute(df.obs_values, df.fx_values)
+        metrics["total"]["mae"] = deterministic.mean_absolute(
+            df.obs_values, df.fx_values
         )
-        mbe.append(
-            deterministic.mean_bias(df.obs_values, df.fx_values)
+        metrics["total"]["mbe"] = deterministic.mean_bias(
+            df.obs_values, df.fx_values
         )
-        rmse.append(
-            deterministic.root_mean_square(df.obs_values, df.fx_values)
+        metrics["total"]["rmse"] = deterministic.root_mean_square(
+            df.obs_values, df.fx_values
         )
-    metrics["month"]["mae"] = mae
-    metrics["month"]["mbe"] = mbe
-    metrics["month"]["rmse"] = rmse
 
-    # daily metrics
-    mae, mbe, rmse = [], [], []
-    for _, group in df.groupby(df.index.date):
-        mae.append(
-            deterministic.mean_absolute(df.obs_values, df.fx_values)
-        )
-        mbe.append(
-            deterministic.mean_bias(df.obs_values, df.fx_values)
-        )
-        rmse.append(
-            deterministic.root_mean_square(df.obs_values, df.fx_values)
-        )
-    metrics["day"]["mae"] = mae
-    metrics["day"]["mbe"] = mbe
-    metrics["day"]["rmse"] = rmse
+        # monthly metrics
+        mae, mbe, rmse = [], [], []
+        for _, group in df.groupby(df.index.month):
+            mae.append(
+                deterministic.mean_absolute(df.obs_values, df.fx_values)
+            )
+            mbe.append(
+                deterministic.mean_bias(df.obs_values, df.fx_values)
+            )
+            rmse.append(
+                deterministic.root_mean_square(df.obs_values, df.fx_values)
+            )
+        metrics["month"]["mae"] = mae
+        metrics["month"]["mbe"] = mbe
+        metrics["month"]["rmse"] = rmse
 
-    # hourly metrics
-    mae, mbe, rmse = [], [], []
-    for _, group in df.groupby(df.index.hour):
-        mae.append(
-            deterministic.mean_absolute(df.obs_values, df.fx_values)
-        )
-        mbe.append(
-            deterministic.mean_bias(df.obs_values, df.fx_values)
-        )
-        rmse.append(
-            deterministic.root_mean_square(df.obs_values, df.fx_values)
-        )
-    metrics["hour"]["mae"] = mae
-    metrics["hour"]["mbe"] = mbe
-    metrics["hour"]["rmse"] = rmse
+        # daily metrics
+        mae, mbe, rmse = [], [], []
+        for _, group in df.groupby(df.index.date):
+            mae.append(
+                deterministic.mean_absolute(df.obs_values, df.fx_values)
+            )
+            mbe.append(
+                deterministic.mean_bias(df.obs_values, df.fx_values)
+            )
+            rmse.append(
+                deterministic.root_mean_square(df.obs_values, df.fx_values)
+            )
+        metrics["day"]["mae"] = mae
+        metrics["day"]["mbe"] = mbe
+        metrics["day"]["rmse"] = rmse
+
+        # hourly metrics
+        mae, mbe, rmse = [], [], []
+        for _, group in df.groupby(df.index.hour):
+            mae.append(
+                deterministic.mean_absolute(df.obs_values, df.fx_values)
+            )
+            mbe.append(
+                deterministic.mean_bias(df.obs_values, df.fx_values)
+            )
+            rmse.append(
+                deterministic.root_mean_square(df.obs_values, df.fx_values)
+            )
+        metrics["hour"]["mae"] = mae
+        metrics["hour"]["mbe"] = mbe
+        metrics["hour"]["rmse"] = rmse
 
     return metrics


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #114.
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Add (standalone) functions for computing deterministic forecast error metrics to the `metrics` subpackage, including adding tests and updating the `reports` subpackage to use the functions. There are other metrics and functionality to be added to the `metrics` subpackage, but those will be addressed in future PRs.

Also, the commits from this PR could be squashed prior to merging.
