### PR TITLE
convert resampled obs, fx to site tz

### DIFF
--- a/docs/source/whatsnew/1.0.0b.rst
+++ b/docs/source/whatsnew/1.0.0b.rst
@@ -29,6 +29,7 @@ Bug fixes
 * Address numpy, pandas deprecations. (:pull:`156`)
 * Remove TODO, EXAMPLE text from reports template in favor of GitHub
   Issues. (:issue:`167`)
+* Account for timezone in metrics/report generation. (:issue:`164`)
 
 Testing
 ~~~~~~~

--- a/solarforecastarbiter/cli.py
+++ b/solarforecastarbiter/cli.py
@@ -326,3 +326,7 @@ def report(verbose, user, password, base_url, report_file, output_file):
     full_report = template.full_html(body)
     with open(output_file, 'w') as f:
         f.write(full_report)
+
+
+if __name__ == "__main__":
+    cli()

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -826,7 +826,8 @@ def raw_report(report_objects):
         end=report.end,
         now=report.end,
         versions=(),
-        validation_issues=()
+        validation_issues=(),
+        timezone=obs.site.timezone
     )
 
     def gen(with_series):

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -571,6 +571,7 @@ class ReportMetadata(BaseModel):
     start: pd.Timestamp
     end: pd.Timestamp
     now: pd.Timestamp
+    timezone: str
     versions: dict
     validation_issues: dict
 

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -85,7 +85,7 @@ def timeseries(fx_obs_cds, start, end, timezone='UTC'):
         cds is a Bokeh ColumnDataSource with columns
         timestamp, observation, forecast.
     start : pandas.Timestamp
-        Report start time.
+        Report start time
     end : pandas.Timestamp
         Report end time
     timezone : str

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -41,8 +41,12 @@ def construct_fx_obs_cds(fx_values, obs_values):
     -------
     cds : bokeh.models.ColumnDataSource
         Keys are 'observation', 'forecast', and 'timestamp'.
+        tz-aware input times are converted to tz-naive times in the
+        input time zone.
     """
     data = pd.DataFrame({'observation': obs_values, 'forecast': fx_values})
+    # drop tz info from localized times. GH164
+    data = data.tz_localize(None)
     data = data.rename_axis('timestamp')
     cds = ColumnDataSource(data)
     return cds
@@ -70,7 +74,7 @@ def _obs_color(interval_length):
     return obs_color
 
 
-def timeseries(fx_obs_cds, start, end):
+def timeseries(fx_obs_cds, start, end, timezone='UTC'):
     """
     Timeseries plot of one or more forecasts and observations.
 
@@ -81,9 +85,11 @@ def timeseries(fx_obs_cds, start, end):
         cds is a Bokeh ColumnDataSource with columns
         timestamp, observation, forecast.
     start : pandas.Timestamp
-        Report start time
+        Report start time.
     end : pandas.Timestamp
         Report end time
+    timezone : str
+        Timezone consistent with the data in the obs_fx_cds.
 
     Returns
     -------
@@ -124,7 +130,7 @@ def timeseries(fx_obs_cds, start, end):
 
     fig.legend.location = "top_left"
     fig.legend.click_policy = "hide"
-    fig.xaxis.axis_label = 'Time (UTC)'
+    fig.xaxis.axis_label = f'Time ({timezone})'
     fig.yaxis.axis_label = format_variable_name(fx_obs.forecast.variable)
     return fig
 

--- a/solarforecastarbiter/reports/metrics.py
+++ b/solarforecastarbiter/reports/metrics.py
@@ -13,9 +13,9 @@ from solarforecastarbiter.validation.quality_mapping import \
     convert_mask_into_dataframe
 
 
-def validate_resample_align(report, data):
+def validate_resample_align(report, metadata, data):
     data_validated = apply_validation(report, data)
-    processed_fxobs = resample_realign(report, data_validated)
+    processed_fxobs = resample_realign(report, metadata, data_validated)
     return processed_fxobs
 
 
@@ -40,7 +40,7 @@ def apply_validation(report, data):
     return data_validated
 
 
-def resample_realign(report, data):
+def resample_realign(report, metadata, data):
     """Probably apply validation and other filters before this"""
     processed = []
     data_resampled = {}
@@ -56,8 +56,8 @@ def resample_realign(report, data):
                 interval_length, label=label).mean()
             data_resampled[fxobs.observation] = resampled
         # no resampling allowed for forecasts for now
-        # convert tzs to site tz (GH 164)
-        tz = fxobs.forecast.site.timezone
+        # convert tzs (GH 164)
+        tz = metadata.timezone
         forecast_values = data[fxobs.forecast].tz_convert(tz)
         observation_values = data_resampled[fxobs.observation].tz_convert(tz)
         processed_fxobs = datamodel.ProcessedForecastObservation(

--- a/solarforecastarbiter/reports/metrics.py
+++ b/solarforecastarbiter/reports/metrics.py
@@ -56,11 +56,15 @@ def resample_realign(report, data):
                 interval_length, label=label).mean()
             data_resampled[fxobs.observation] = resampled
         # no resampling allowed for forecasts for now
+        # convert tzs to site tz (GH 164)
+        tz = fxobs.forecast.site.timezone
+        forecast_values = data[fxobs.forecast].tz_convert(tz)
+        observation_values = data_resampled[fxobs.observation].tz_convert(tz)
         processed_fxobs = datamodel.ProcessedForecastObservation(
             original=fxobs, interval_value_type=interval_value_type,
             interval_length=interval_length, interval_label=interval_label,
-            forecast_values=data[fxobs.forecast],
-            observation_values=data_resampled[fxobs.observation])
+            forecast_values=forecast_values,
+            observation_values=observation_values)
         processed.append(processed_fxobs)
     return processed
 

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -133,7 +133,8 @@ def add_figures_to_report_template(fx_obs_cds, metadata, report_template,
     """
     body_template = Template(report_template)
 
-    ts_fig = figures.timeseries(fx_obs_cds, metadata.start, metadata.end)
+    ts_fig = figures.timeseries(fx_obs_cds, metadata.start, metadata.end,
+                                timezone=metadata.timezone)
     scat_fig = figures.scatter(fx_obs_cds)
     try:
         script, div = components(gridplot((ts_fig, scat_fig), ncols=1))

--- a/solarforecastarbiter/reports/templates/head.html
+++ b/solarforecastarbiter/reports/templates/head.html
@@ -1,12 +1,12 @@
 <link
-    href="https://cdn.pydata.org/bokeh/release/bokeh-1.2.0.min.css"
+    href="https://cdn.pydata.org/bokeh/release/bokeh-1.3.4.min.css"
     rel="stylesheet" type="text/css">
 <link
-    href="https://cdn.pydata.org/bokeh/release/bokeh-widgets-1.2.0.min.css"
+    href="https://cdn.pydata.org/bokeh/release/bokeh-widgets-1.3.4.min.css"
     rel="stylesheet" type="text/css">
 <link
-    href="https://cdn.pydata.org/bokeh/release/bokeh-tables-1.2.0.min.css"
+    href="https://cdn.pydata.org/bokeh/release/bokeh-tables-1.3.4.min.css"
     rel="stylesheet" type="text/css">
-<script src="https://cdn.pydata.org/bokeh/release/bokeh-1.2.0.min.js"></script>
-<script src="https://cdn.pydata.org/bokeh/release/bokeh-widgets-1.2.0.min.js"></script>
-<script src="https://cdn.pydata.org/bokeh/release/bokeh-tables-1.2.0.min.js"></script>
+<script src="https://cdn.pydata.org/bokeh/release/bokeh-1.3.4.min.js"></script>
+<script src="https://cdn.pydata.org/bokeh/release/bokeh-widgets-1.3.4.min.js"></script>
+<script src="https://cdn.pydata.org/bokeh/release/bokeh-tables-1.3.4.min.js"></script>


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #164  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added. No... let @dplarson and @awig handle this in metrics
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes. Maybe add reports.main.infer_timezone? 
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Now plots look like this:

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

<img width="907" alt="Screen Shot 2019-08-30 at 3 01 23 PM" src="https://user-images.githubusercontent.com/4383303/64053398-11930b80-cb37-11e9-8b13-45662e60e556.png">

![bokeh_plot(7)](https://user-images.githubusercontent.com/4383303/64053420-22dc1800-cb37-11e9-80a2-f4fac1682edd.png)

