### PR TITLE
slice with consistent tz

### DIFF
--- a/docs/source/whatsnew/1.0.0b.rst
+++ b/docs/source/whatsnew/1.0.0b.rst
@@ -30,6 +30,9 @@ Bug fixes
 * Remove TODO, EXAMPLE text from reports template in favor of GitHub
   Issues. (:issue:`167`)
 * Account for timezone in metrics/report generation. (:issue:`164`)
+* Account for different timezones in
+  :py:func:`solarforecastarbiter.io.utils.adjust_timeseries_for_interval_label`
+  with pandas >= 0.25.1. (:issue:`173`)
 
 Testing
 ~~~~~~~

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -589,6 +589,7 @@ def test_real_apisession_get_observation_values(real_session):
 
 
 def test_real_apisession_get_observation_values_tz(real_session):
+    # use different tzs to confirm that it works
     start = pd.Timestamp('2019-04-14T22:00:00-0200')
     end = pd.Timestamp('2019-04-15T05:00:00-0700')
     obs = real_session.get_observation_values(
@@ -597,6 +598,7 @@ def test_real_apisession_get_observation_values_tz(real_session):
     assert isinstance(obs, pd.DataFrame)
     assert set(obs.columns) == set(['value', 'quality_flag'])
     assert len(obs.index) > 0
+    end = end.tz_convert(start.tzinfo)
     pdt.assert_frame_equal(obs.loc[start:end], obs)
 
 
@@ -612,6 +614,7 @@ def test_real_apisession_get_forecast_values(real_session):
 
 
 def test_real_apisession_get_forecast_values_tz(real_session):
+    # use different tzs to confirm that it works
     start = pd.Timestamp('2019-04-14T20:00:00-0400')
     end = pd.Timestamp('2019-04-15T13:00:00+0100')
     fx = real_session.get_forecast_values(
@@ -619,6 +622,7 @@ def test_real_apisession_get_forecast_values_tz(real_session):
         start, end)
     assert isinstance(fx, pd.Series)
     assert len(fx) > 0
+    end = end.tz_convert(start.tzinfo)
     pdt.assert_series_equal(fx.loc[start:end], fx)
 
 

--- a/solarforecastarbiter/io/tests/test_io_utils.py
+++ b/solarforecastarbiter/io/tests/test_io_utils.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext as does_not_raise
 import json
 import pandas as pd
 import pandas.testing as pdt
@@ -109,12 +110,28 @@ def test_adjust_timeseries_for_interval_label(label, exp, start, end):
     pdt.assert_frame_equal(exp, out)
 
 
+@pytest.mark.parametrize('exp,start,end,raise_exp', [
+    (TEST_DATA.iloc[1:-1].tz_localize(None), pd.Timestamp('20190124T0001Z'),
+     pd.Timestamp('20190124T0003Z'), does_not_raise()),
+    (TEST_DATA.iloc[1:].tz_localize(None), pd.Timestamp('20190124T0001Z'),
+     pd.Timestamp('20190124T0004-0001'), does_not_raise())
+])
+def test_adjust_timeseries_for_interval_label_no_tz(exp, start, end,
+                                                    raise_exp):
+    test_data = TEST_DATA.tz_localize(None)
+    label = None
+    with raise_exp:
+        out = utils.adjust_timeseries_for_interval_label(
+            test_data, label, start, end)
+    pdt.assert_frame_equal(exp, out)
+
+
 @pytest.mark.parametrize('label,exp', [
     ('instant', TEST_DATA['value']),
     ('ending', TEST_DATA['value'].iloc[1:]),
     ('beginning', TEST_DATA['value'].iloc[:-1])
 ])
-def test_adjust_timeserise_for_interval_label_series(label, exp):
+def test_adjust_timeseries_for_interval_label_series(label, exp):
     start = pd.Timestamp('2019-01-24T00:00Z')
     end = pd.Timestamp('2019-01-24T00:04Z')
     out = utils.adjust_timeseries_for_interval_label(

--- a/solarforecastarbiter/io/tests/test_io_utils.py
+++ b/solarforecastarbiter/io/tests/test_io_utils.py
@@ -1,4 +1,3 @@
-from contextlib import nullcontext as does_not_raise
 import json
 import pandas as pd
 import pandas.testing as pdt

--- a/solarforecastarbiter/io/tests/test_io_utils.py
+++ b/solarforecastarbiter/io/tests/test_io_utils.py
@@ -110,20 +110,24 @@ def test_adjust_timeseries_for_interval_label(label, exp, start, end):
     pdt.assert_frame_equal(exp, out)
 
 
-@pytest.mark.parametrize('exp,start,end,raise_exp', [
-    (TEST_DATA.iloc[1:-1].tz_localize(None), pd.Timestamp('20190124T0001Z'),
-     pd.Timestamp('20190124T0003Z'), does_not_raise()),
-    (TEST_DATA.iloc[1:].tz_localize(None), pd.Timestamp('20190124T0001Z'),
-     pd.Timestamp('20190124T0004-0001'), does_not_raise())
-])
-def test_adjust_timeseries_for_interval_label_no_tz(exp, start, end,
-                                                    raise_exp):
+def test_adjust_timeseries_for_interval_label_no_tz():
     test_data = TEST_DATA.tz_localize(None)
     label = None
-    with raise_exp:
-        out = utils.adjust_timeseries_for_interval_label(
+    start = pd.Timestamp('2019-01-24T00:00Z')
+    end = pd.Timestamp('2019-01-24T00:04Z')
+    with pytest.raises(ValueError):
+        utils.adjust_timeseries_for_interval_label(
             test_data, label, start, end)
-    pdt.assert_frame_equal(exp, out)
+
+
+def test_adjust_timeseries_for_interval_label_no_tz_empty():
+    test_data = pd.DataFrame()
+    label = None
+    start = pd.Timestamp('2019-01-24T00:00Z')
+    end = pd.Timestamp('2019-01-24T00:04Z')
+    out = utils.adjust_timeseries_for_interval_label(
+            test_data, label, start, end)
+    pdt.assert_frame_equal(test_data, out)
 
 
 @pytest.mark.parametrize('label,exp', [

--- a/solarforecastarbiter/io/utils.py
+++ b/solarforecastarbiter/io/utils.py
@@ -196,7 +196,7 @@ def adjust_timeseries_for_interval_label(data, interval_label, start, end):
     Parameters
     ----------
     data : pandas.Series or pandas.DataFrame
-       The data with a DatetimeIndex
+       The data with a localized DatetimeIndex
     interval_label : str or None
        The interval label for the the object the data represents
     start : pandas.Timestamp
@@ -213,11 +213,17 @@ def adjust_timeseries_for_interval_label(data, interval_label, start, end):
     Raises
     ------
     ValueError
-       If an invalid interval_label is given
+       If an invalid interval_label is given or data is not localized.
     """
     start, end = adjust_start_end_for_interval_label(interval_label, start,
                                                      end)
     data = data.sort_index(axis=0)
+    # pandas >= 0.25.1 requires start, end to have same tzinfo.
+    # unexpected behavior when data is not localized, so prevent that
+    if data.empty:
+        return data
+    if data.index.tzinfo is None:
+        raise ValueError('data must be localized')
     start = start.tz_convert(data.index.tzinfo)
     end = end.tz_convert(data.index.tzinfo)
     return data.loc[start:end]

--- a/solarforecastarbiter/io/utils.py
+++ b/solarforecastarbiter/io/utils.py
@@ -217,7 +217,9 @@ def adjust_timeseries_for_interval_label(data, interval_label, start, end):
     """
     start, end = adjust_start_end_for_interval_label(interval_label, start,
                                                      end)
-    data.sort_index(axis=0, inplace=True)
+    data = data.sort_index(axis=0)
+    start = start.tz_convert(data.index.tzinfo)
+    end = end.tz_convert(data.index.tzinfo)
     return data.loc[start:end]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #173 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

There are a couple of additional places in the code that use `.loc[start:end]` but they are not likely to be passed inconsistent timezones, so I don't think this is worth handling more generally.