### PR TITLE
bigger metrics table, summary graphics

### DIFF
--- a/docs/source/whatsnew/1.0.0b.rst
+++ b/docs/source/whatsnew/1.0.0b.rst
@@ -33,6 +33,8 @@ Bug fixes
 * Account for different timezones in
   :py:func:`solarforecastarbiter.io.utils.adjust_timeseries_for_interval_label`
   with pandas >= 0.25.1. (:issue:`173`)
+* Bigger metrics graphics to avoid (but not yet totally prevent) label overlap.
+  (:issue:`163`)
 
 Testing
 ~~~~~~~

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -405,7 +405,7 @@ def metrics_table(cds):
         col = TableColumn(field=field, title=title.upper(),
                           formatter=formatter, width=metric_width)
         columns.append(col)
-    width = name_width + metric_width * (len(field) - 1)
+    width = name_width + metric_width * len(field)
     data_table = DataTable(source=cds, columns=columns, width=width,
                            height=150, index_position=None, fit_columns=False)
     return data_table

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -276,7 +276,7 @@ def bar(cds, metric):
     """
     x_range = cds.data['forecast']
     # TODO: add units to title
-    fig = figure(x_range=x_range, width=400, height=200, title=metric.upper())
+    fig = figure(x_range=x_range, width=800, height=200, title=metric.upper())
     fig.vbar(x='forecast', top=metric, width=0.8, source=cds,
              line_color='white',
              fill_color=factor_cmap('forecast', PALETTE, factors=x_range))
@@ -396,7 +396,7 @@ def metrics_table(cds):
     """
     formatter = NumberFormatter(format="0.000")
     # construct list of columns. make sure that forecast name is first
-    name_width = 200
+    name_width = 300
     metric_width = 60
     columns = [TableColumn(field='forecast', title='Forecast',
                            width=name_width)]
@@ -407,7 +407,7 @@ def metrics_table(cds):
         columns.append(col)
     width = name_width + metric_width * (len(field) - 1)
     data_table = DataTable(source=cds, columns=columns, width=width,
-                           height=100, index_position=None, fit_columns=False)
+                           height=150, index_position=None, fit_columns=False)
     return data_table
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Short term hack on #163. The long term fix is fixing bokeh, using bokeh text fields, or dynamically sizing the graphics. But this gives us breathing room.
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Works with 3 long names. 4 is too much. Note that the table now shows all of the forecasts and metrics (at least for 4 forecasts).

<img width="819" alt="Screen Shot 2019-09-03 at 2 54 36 PM" src="https://user-images.githubusercontent.com/4383303/64211371-d48e8800-ce5a-11e9-839e-d762910aa868.png">

