### PR TITLE
handle when fx or obs are empty in current calculate metrics

### DIFF
--- a/docs/source/whatsnew/1.0.0b.rst
+++ b/docs/source/whatsnew/1.0.0b.rst
@@ -36,7 +36,7 @@ Bug fixes
 * Bigger metrics graphics to avoid (but not yet totally prevent) label overlap.
   (:issue:`163`)
 * Handle empty observation or forecast in current report metrics calc
-  (:issue:`148`)
+  (:pull:`178`)
 
 Testing
 ~~~~~~~

--- a/docs/source/whatsnew/1.0.0b.rst
+++ b/docs/source/whatsnew/1.0.0b.rst
@@ -35,6 +35,8 @@ Bug fixes
   with pandas >= 0.25.1. (:issue:`173`)
 * Bigger metrics graphics to avoid (but not yet totally prevent) label overlap.
   (:issue:`163`)
+* Handle empty observation or forecast in current report metrics calc
+  (:issue:`148`)
 
 Testing
 ~~~~~~~

--- a/solarforecastarbiter/reports/metrics.py
+++ b/solarforecastarbiter/reports/metrics.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 
 
 import numpy as np
+import pandas as pd
 
 
 from solarforecastarbiter import datamodel
@@ -81,7 +82,12 @@ def loop_forecasts_calculate_metrics(report, processed_fxobs):
 def calculate_metrics(forecast_observation, fx_values, obs_values):
     metrics = defaultdict(dict)
     metrics['name'] = forecast_observation.forecast.name
-    diff = fx_values - obs_values
+    if fx_values.empty:
+        diff = pd.Series(index=obs_values.index)
+    elif obs_values.empty:
+        diff = pd.Series(index=fx_values.index)
+    else:
+        diff = fx_values - obs_values
     metrics['total']['mae'] = diff.abs().mean()
     _rmse = diff.aggregate(rmse)
     metrics['total']['rmse'] = _rmse

--- a/solarforecastarbiter/reports/tests/test_metrics.py
+++ b/solarforecastarbiter/reports/tests/test_metrics.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import pytest
+
+
+from solarforecastarbiter.reports import metrics
+
+
+@pytest.mark.parametrize('fx,obs', [
+    (pd.Series(index=pd.DatetimeIndex([])),
+     pd.Series(index=pd.DatetimeIndex([]))),
+    (pd.Series(index=pd.DatetimeIndex([])),
+     pd.Series([1.0, 1.0], index=pd.date_range(
+         start='20190801', periods=2, freq='1h', tz='MST', name='timestamp'))),
+    (pd.Series([1.0, 1.0], index=pd.date_range(
+        start='20190801', periods=2, freq='1h', tz='UTC', name='timestamp')),
+     pd.Series(index=pd.DatetimeIndex([]))),
+    (pd.Series([1.0, 1.0], index=pd.date_range(
+        start='20190801', periods=2, freq='1h', tz='MST')),
+     pd.Series([1.0, 1.0], index=pd.date_range(
+         start='20190801', periods=2, freq='1h', tz='UTC')))
+])
+def test_calculate_metrics_runs(report_objects, fx, obs):
+    fxobs = report_objects[0].forecast_observations[0]
+    metrics.calculate_metrics(fxobs, fx, obs)


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #177 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

also closes https://github.com/SolarArbiter/solarforecastarbiter-api/issues/148/