### PR TITLE
add decorator so Api can accept str or time obj start/end

### DIFF
--- a/docs/source/whatsnew/1.0.0b.rst
+++ b/docs/source/whatsnew/1.0.0b.rst
@@ -31,12 +31,16 @@ Bug fixes
   Issues. (:issue:`167`)
 * Account for timezone in metrics/report generation. (:issue:`164`)
 * Account for different timezones in
-  :py:func:`solarforecastarbiter.io.utils.adjust_timeseries_for_interval_label`
+  :py:func:`~solarforecastarbiter.io.utils.adjust_timeseries_for_interval_label`
   with pandas >= 0.25.1. (:issue:`173`)
 * Bigger metrics graphics to avoid (but not yet totally prevent) label overlap.
   (:issue:`163`)
 * Handle empty observation or forecast in current report metrics calc
   (:pull:`178`)
+* Accept string or timelike objects to
+  :py:func:`~solarforecastarbiter.io.api.APISession.get_forecast_values` and
+  :py:func:`~solarforecastarbiter.io.api.APISession.get_observation_values`
+  (:issue:`180`)
 
 Testing
 ~~~~~~~

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -292,7 +292,7 @@ class APISession(requests.Session):
         new_id = req.text
         return self.get_forecast(new_id)
 
-    @ensure_timestamps
+    @ensure_timestamps('start', 'end')
     def get_observation_values(self, observation_id, start, end,
                                interval_label=None):
         """
@@ -328,7 +328,7 @@ class APISession(requests.Session):
         return adjust_timeseries_for_interval_label(
             out, interval_label, start, end)
 
-    @ensure_timestamps
+    @ensure_timestamps('start', 'end')
     def get_forecast_values(self, forecast_id, start, end,
                             interval_label=None):
         """

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -16,7 +16,7 @@ from solarforecastarbiter.io.utils import (
     adjust_timeseries_for_interval_label,
     serialize_data, deserialize_data,
     serialize_raw_report, deserialize_raw_report,
-    HiddenToken)
+    HiddenToken, ensure_timestamps)
 
 
 BASE_URL = 'https://api.solarforecastarbiter.org'
@@ -292,6 +292,7 @@ class APISession(requests.Session):
         new_id = req.text
         return self.get_forecast(new_id)
 
+    @ensure_timestamps
     def get_observation_values(self, observation_id, start, end,
                                interval_label=None):
         """
@@ -315,6 +316,11 @@ class APISession(requests.Session):
         -------
         pandas.DataFrame
             With a datetime index and (value, quality_flag) columns
+
+        Raises
+        ------
+        ValueError
+            If start or end cannot be converted into a Pandas Timestamp
         """
         req = self.get(f'/observations/{observation_id}/values',
                        params={'start': start, 'end': end})
@@ -322,6 +328,7 @@ class APISession(requests.Session):
         return adjust_timeseries_for_interval_label(
             out, interval_label, start, end)
 
+    @ensure_timestamps
     def get_forecast_values(self, forecast_id, start, end,
                             interval_label=None):
         """
@@ -344,6 +351,11 @@ class APISession(requests.Session):
         -------
         pandas.Series
            With the forecast values and a datetime index
+
+        Raises
+        ------
+        ValueError
+            If start or end cannot be converted into a Pandas Timestamp
         """
         req = self.get(f'/forecasts/single/{forecast_id}/values',
                        params={'start': start, 'end': end})

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -211,14 +211,24 @@ def test_apisession_list_forecasts_empty(requests_mock):
     assert fx_list == []
 
 
-def test_apisession_get_observation_values(requests_mock, observation_values,
-                                           observation_values_text):
+@pytest.fixture(params=[0, 1])
+def obs_start_end(request):
+    if request.param == 0:
+        return (pd.Timestamp('2019-01-01T12:00:00-0700'),
+                pd.Timestamp('2019-01-01T12:25:00-0700'))
+    else:
+        return ('2019-01-01T12:00:00-0700',
+                '2019-01-01T12:25:00-0700')
+
+
+def test_apisession_get_observation_values(
+        requests_mock, observation_values, observation_values_text,
+        obs_start_end):
     session = api.APISession('')
     matcher = re.compile(f'{session.base_url}/observations/.*/values')
     requests_mock.register_uri('GET', matcher, content=observation_values_text)
     out = session.get_observation_values(
-        'obsid', pd.Timestamp('2019-01-01T12:00:00-0700'),
-        pd.Timestamp('2019-01-01T12:25:00-0700'))
+        'obsid', *obs_start_end)
     pdt.assert_frame_equal(out, observation_values)
 
 
@@ -229,13 +239,12 @@ def test_apisession_get_observation_values(requests_mock, observation_values,
 ])
 def test_apisession_get_observation_values_interval_label(
         requests_mock, observation_values, observation_values_text,
-        label, theslice):
+        label, theslice, obs_start_end):
     session = api.APISession('')
     matcher = re.compile(f'{session.base_url}/observations/.*/values')
     requests_mock.register_uri('GET', matcher, content=observation_values_text)
     out = session.get_observation_values(
-        'obsid', pd.Timestamp('2019-01-01T12:00:00-0700'),
-        pd.Timestamp('2019-01-01T12:25:00-0700'), label)
+        'obsid', obs_start_end[0], obs_start_end[1], label)
     pdt.assert_frame_equal(out, observation_values.iloc[theslice])
 
 
@@ -255,14 +264,23 @@ def test_apisession_get_observation_values_empty(requests_mock, empty_df):
     pdt.assert_frame_equal(out, empty_df)
 
 
+@pytest.fixture(params=[0, 1])
+def fx_start_end(request):
+    if request.param == 0:
+        return (pd.Timestamp('2019-01-01T06:00:00-0700'),
+                pd.Timestamp('2019-01-01T11:00:00-0700'))
+    else:
+        return ('2019-01-01T06:00:00-0700',
+                '2019-01-01T11:00:00-0700')
+
+
 def test_apisession_get_forecast_values(requests_mock, forecast_values,
-                                        forecast_values_text):
+                                        forecast_values_text, fx_start_end):
     session = api.APISession('')
     matcher = re.compile(f'{session.base_url}/forecasts/single/.*/values')
     requests_mock.register_uri('GET', matcher, content=forecast_values_text)
     out = session.get_forecast_values(
-        'fxid', pd.Timestamp('2019-01-01T06:00:00-0700'),
-        pd.Timestamp('2019-01-01T11:00:00-0700'))
+        'fxid', *fx_start_end)
     pdt.assert_series_equal(out, forecast_values)
 
 
@@ -272,13 +290,13 @@ def test_apisession_get_forecast_values(requests_mock, forecast_values,
     ('ending', slice(1, 10))
 ])
 def test_apisession_get_forecast_values_interval_label(
-        requests_mock, forecast_values, forecast_values_text, label, theslice):
+        requests_mock, forecast_values, forecast_values_text, label, theslice,
+        fx_start_end):
     session = api.APISession('')
     matcher = re.compile(f'{session.base_url}/forecasts/single/.*/values')
     requests_mock.register_uri('GET', matcher, content=forecast_values_text)
     out = session.get_forecast_values(
-        'fxid', pd.Timestamp('2019-01-01T06:00:00-0700'),
-        pd.Timestamp('2019-01-01T11:00:00-0700'), label)
+        'fxid', fx_start_end[0], fx_start_end[1], label)
     pdt.assert_series_equal(out, forecast_values.iloc[theslice])
 
 

--- a/solarforecastarbiter/io/tests/test_io_utils.py
+++ b/solarforecastarbiter/io/tests/test_io_utils.py
@@ -219,7 +219,7 @@ def test_ensure_timestamps_normal(start_end):
 
 def test_ensure_timestamps_err():
     @utils.ensure_timestamps
-    def f(other, start, end, x=None):
+    def f(other, start, end, x=None):  # pragma: no cover
         return start, end
     with pytest.raises(ValueError):
         start, end = f('', '2019-09-01T12:00Z', 'blah')

--- a/solarforecastarbiter/io/tests/test_io_utils.py
+++ b/solarforecastarbiter/io/tests/test_io_utils.py
@@ -199,14 +199,14 @@ def tfunc(request, start_end):
 
 
 def test_ensure_timestamps_partials(tfunc):
-    dec_f = utils.ensure_timestamps(tfunc.func)
+    dec_f = utils.ensure_timestamps('start', 'end')(tfunc.func)
     s, e = dec_f(*tfunc.args, **tfunc.keywords)
     assert s == pd.Timestamp('2019-01-01T12:00:00Z')
     assert e == pd.Timestamp('2019-01-12T17:47:22-0700')
 
 
 def test_ensure_timestamps_normal(start_end):
-    @utils.ensure_timestamps
+    @utils.ensure_timestamps('start', 'end')
     def f(other, start, end, x=None):
         """cool docstring"""
         return start, end
@@ -217,8 +217,20 @@ def test_ensure_timestamps_normal(start_end):
     assert end == pd.Timestamp('2019-01-12T17:47:22-0700')
 
 
+def test_ensure_timestamps_other_args():
+    @utils.ensure_timestamps('x')
+    def f(other, start, end, x=None):
+        """cool docstring"""
+        return start, end, x
+    start, end, x = f('', 'a', 'end', '2019-01-01T12:00:00Z')
+    assert f.__doc__ == 'cool docstring'
+    assert x == pd.Timestamp('2019-01-01T12:00:00Z')
+    assert start == 'a'
+    assert end == 'end'
+
+
 def test_ensure_timestamps_err():
-    @utils.ensure_timestamps
+    @utils.ensure_timestamps('start', 'end', 'x')
     def f(other, start, end, x=None):  # pragma: no cover
         return start, end
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #180  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
