### PR TITLE
add probabilistic forecast classes to datamodel

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -39,6 +39,14 @@ The Observation and Forecast:
    datamodel.Observation
    datamodel.Forecast
 
+Probabilistic forecasts:
+
+.. autosummary::
+   :toctree: generated/
+
+   datamodel.ProbabilisticForecast
+   datamodel.ProbabilisticForecastConstantValue
+
 All :py:mod:`~solarforecastarbiter.datamodel` objects have ``from_dict`` and
 ``to_dict`` methods:
 

--- a/docs/source/whatsnew/1.0.0b.rst
+++ b/docs/source/whatsnew/1.0.0b.rst
@@ -14,6 +14,8 @@ API Changes
 Enhancements
 ~~~~~~~~~~~~
 * Add command line interface option for reports. (:issue:`168`)
+* Add classes to :py:mod:`~solarforecastarbiter.datamodel` to support
+  probabilistic forecasts. (:issue:`47`)
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0b.rst
+++ b/docs/source/whatsnew/1.0.0b.rst
@@ -20,6 +20,9 @@ Enhancements
   :py:class:`~solarforecastarbiter.datamodel.ProbabilisticForecast`
   to :py:mod:`~solarforecastarbiter.datamodel` to support
   probabilistic forecasts. (:issue:`47`)
+* Datamodel classes `.from_dict` constructors will now accept nested dicts.
+  For example, a dict describing an Observation may now specify its site as a
+  dict that describes a Site, rather than a Site object. (:issue:`125`)
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0b.rst
+++ b/docs/source/whatsnew/1.0.0b.rst
@@ -14,7 +14,11 @@ API Changes
 Enhancements
 ~~~~~~~~~~~~
 * Add command line interface option for reports. (:issue:`168`)
-* Add classes to :py:mod:`~solarforecastarbiter.datamodel` to support
+* Add classes
+  :py:class:`~solarforecastarbiter.datamodel.ProbabilisticForecastConstantValue`
+  and
+  :py:class:`~solarforecastarbiter.datamodel.ProbabilisticForecast`
+  to :py:mod:`~solarforecastarbiter.datamodel` to support
   probabilistic forecasts. (:issue:`47`)
 
 Bug fixes

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -618,7 +618,7 @@ def many_observations(many_observations_text, _observation_from_dict):
 
 @pytest.fixture()
 def single_observation_text_with_site_text(site_text):
-    return b"""
+    return (b"""
 {
   "_links": {
     "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440002"
@@ -635,9 +635,10 @@ def single_observation_text_with_site_text(site_text):
   "site_id": "123e4567-e89b-12d3-a456-426655440002",
   "uncertainty": 0.1,
   "variable": "dni",
-  "site": """ + site_text + b"""
+  "site": """  # NOQA
+  + site_text + b"""
 }
-"""  # NOQA
+""")
 
 
 @pytest.fixture()

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -617,6 +617,30 @@ def many_observations(many_observations_text, _observation_from_dict):
 
 
 @pytest.fixture()
+def single_observation_text_with_site_text(site_text):
+    return b"""
+{
+  "_links": {
+    "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440002"
+  },
+  "created_at": "2019-03-01T12:01:48+00:00",
+  "extra_parameters": "{\\"instrument\\": \\"Ascension Technology Rotating Shadowband Pyranometer\\", \\"network\\": \\"UO SRML\\"}",
+  "interval_label": "beginning",
+  "interval_length": 5,
+  "interval_value_type": "interval_mean",
+  "modified_at": "2019-03-01T12:01:48+00:00",
+  "name": "DNI Instrument 2",
+  "observation_id": "9ce9715c-bd91-47b7-989f-50bb558f1eb9",
+  "provider": "Organization 1",
+  "site_id": "123e4567-e89b-12d3-a456-426655440002",
+  "uncertainty": 0.1,
+  "variable": "dni",
+  "site": """ + site_text + b"""
+}
+"""  # NOQA
+
+
+@pytest.fixture()
 def single_forecast_text():
     return b"""
 {

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -736,7 +736,9 @@ def prob_forecast_constant_value_text():
   "provider": "Organization 1",
   "run_length": 1440,
   "site_id": "123e4567-e89b-12d3-a456-426655440002",
-  "variable": "ghi"
+  "variable": "ghi",
+  "axis": "x",
+  "constant_value": 0
 }
 """
 
@@ -762,7 +764,9 @@ def prob_forecast_text():
     "provider": "Organization 1",
     "run_length": 1440,
     "site_id": "123e4567-e89b-12d3-a456-426655440001",
-    "variable": "ghi"
+    "variable": "ghi",
+    "axis": "x",
+    "constant_value": 0
   },
   {
     "_links": {
@@ -781,7 +785,9 @@ def prob_forecast_text():
     "provider": "Organization 1",
     "run_length": 60,
     "site_id": "123e4567-e89b-12d3-a456-426655440002",
-    "variable": "ac_power"
+    "variable": "ac_power",
+    "axis": "x",
+    "constant_value": 1
   }
 ]
 """  # NOQA
@@ -801,7 +807,9 @@ def _prob_forecast_constant_value_from_dict(single_site, get_site):
             lead_time_to_start=pd.Timedelta(f"{fx_dict['lead_time_to_start']}min"),  # NOQA
             run_length=pd.Timedelta(f"{fx_dict['run_length']}min"),
             forecast_id=fx_dict.get('forecast_id', ''),
-            extra_parameters=fx_dict.get('extra_parameters', ''))
+            extra_parameters=fx_dict.get('extra_parameters', ''),
+            axis=fx_dict['axis'],
+            constant_value=fx_dict['constant_value'])
     return f
 
 

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -762,7 +762,7 @@ def prob_forecast_text():
     "name": "DA GHI",
     "provider": "Organization 1",
     "run_length": 1440,
-    "site_id": "123e4567-e89b-12d3-a456-426655440001",
+    "site_id": "123e4567-e89b-12d3-a456-426655440002",
     "variable": "ghi",
     "axis": "x",
     "constant_values": [
@@ -777,7 +777,7 @@ def prob_forecast_text():
 
 
 @pytest.fixture()
-def _prob_forecast_constant_value_from_dict(single_site, get_site):
+def _prob_forecast_constant_value_from_dict(get_site):
     def f(fx_dict):
         return datamodel.ProbabilisticForecastConstantValue(
             name=fx_dict['name'], variable=fx_dict['variable'],
@@ -797,8 +797,7 @@ def _prob_forecast_constant_value_from_dict(single_site, get_site):
 
 
 @pytest.fixture()
-def _prob_forecast_from_dict(single_site, get_site,
-                             prob_forecast_constant_value):
+def _prob_forecast_from_dict(get_site, prob_forecast_constant_value):
     def f(fx_dict):
         return datamodel.ProbabilisticForecast(
             name=fx_dict['name'], variable=fx_dict['variable'],

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -716,6 +716,126 @@ def many_forecasts(many_forecasts_text, _forecast_from_dict):
             in json.loads(many_forecasts_text)]
 
 
+@pytest.fixture()
+def prob_forecast_constant_value_text():
+    return b"""
+{
+  "_links": {
+    "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440002"
+  },
+  "created_at": "2019-03-01T11:55:37+00:00",
+  "extra_parameters": "",
+  "forecast_id": "11c20780-76ae-4b11-bef1-7a75bdc784e3",
+  "interval_label": "beginning",
+  "interval_length": 5,
+  "interval_value_type": "interval_mean",
+  "issue_time_of_day": "06:00",
+  "lead_time_to_start": 60,
+  "modified_at": "2019-03-01T11:55:37+00:00",
+  "name": "DA GHI",
+  "provider": "Organization 1",
+  "run_length": 1440,
+  "site_id": "123e4567-e89b-12d3-a456-426655440002",
+  "variable": "ghi"
+}
+"""
+
+
+@pytest.fixture()
+def prob_forecast_text():
+    return b"""
+[
+  {
+    "_links": {
+      "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440001"
+    },
+    "created_at": "2019-03-01T11:55:37+00:00",
+    "extra_parameters": "",
+    "forecast_id": "11c20780-76ae-4b11-bef1-7a75bdc784e3",
+    "interval_label": "beginning",
+    "interval_length": 5,
+    "interval_value_type": "interval_mean",
+    "issue_time_of_day": "06:00",
+    "lead_time_to_start": 60,
+    "modified_at": "2019-03-01T11:55:37+00:00",
+    "name": "DA GHI",
+    "provider": "Organization 1",
+    "run_length": 1440,
+    "site_id": "123e4567-e89b-12d3-a456-426655440001",
+    "variable": "ghi"
+  },
+  {
+    "_links": {
+      "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440002"
+    },
+    "created_at": "2019-03-01T11:55:38+00:00",
+    "extra_parameters": "",
+    "forecast_id": "f8dd49fa-23e2-48a0-862b-ba0af6dec276",
+    "interval_label": "beginning",
+    "interval_length": 1,
+    "interval_value_type": "interval_mean",
+    "issue_time_of_day": "12:00",
+    "lead_time_to_start": 60,
+    "modified_at": "2019-03-01T11:55:38+00:00",
+    "name": "HA Power",
+    "provider": "Organization 1",
+    "run_length": 60,
+    "site_id": "123e4567-e89b-12d3-a456-426655440002",
+    "variable": "ac_power"
+  }
+]
+"""  # NOQA
+
+
+@pytest.fixture()
+def _prob_forecast_constant_value_from_dict(single_site, get_site):
+    def f(fx_dict):
+        return datamodel.ProbabilisticForecastConstantValue(
+            name=fx_dict['name'], variable=fx_dict['variable'],
+            interval_value_type=fx_dict['interval_value_type'],
+            interval_length=pd.Timedelta(f"{fx_dict['interval_length']}min"),
+            interval_label=fx_dict['interval_label'],
+            site=get_site(fx_dict['site_id']),
+            issue_time_of_day=dt.time(int(fx_dict['issue_time_of_day'][:2]),
+                                      int(fx_dict['issue_time_of_day'][3:])),
+            lead_time_to_start=pd.Timedelta(f"{fx_dict['lead_time_to_start']}min"),  # NOQA
+            run_length=pd.Timedelta(f"{fx_dict['run_length']}min"),
+            forecast_id=fx_dict.get('forecast_id', ''),
+            extra_parameters=fx_dict.get('extra_parameters', ''))
+    return f
+
+
+@pytest.fixture()
+def _prob_forecast_from_dict(single_site, get_site):
+    def f(fx_dict):
+        return datamodel.ProbabilisticForecast(
+            name=fx_dict['name'], variable=fx_dict['variable'],
+            interval_value_type=fx_dict['interval_value_type'],
+            interval_length=pd.Timedelta(f"{fx_dict['interval_length']}min"),
+            interval_label=fx_dict['interval_label'],
+            site=get_site(fx_dict['site_id']),
+            issue_time_of_day=dt.time(int(fx_dict['issue_time_of_day'][:2]),
+                                      int(fx_dict['issue_time_of_day'][3:])),
+            lead_time_to_start=pd.Timedelta(f"{fx_dict['lead_time_to_start']}min"),  # NOQA
+            run_length=pd.Timedelta(f"{fx_dict['run_length']}min"),
+            forecast_id=fx_dict.get('forecast_id', ''),
+            extra_parameters=fx_dict.get('extra_parameters', ''))
+    return f
+
+
+@pytest.fixture()
+def prob_forecast_constant_value(prob_forecast_constant_value_text,
+                                 _prob_forecast_constant_value_from_dict):
+    return _prob_forecast_constant_value_from_dict(
+        json.loads(prob_forecast_constant_value_text))
+
+
+@pytest.fixture()
+def prob_forecasts(many_forecasts_text, _prob_forecast_from_dict):
+    return [_prob_forecast_from_dict(fx) for fx
+            in json.loads(prob_forecast_text)]
+
+
 @pytest.fixture(scope='module')
 def report_objects():
     tz = 'America/Phoenix'

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -746,8 +746,7 @@ def prob_forecast_constant_value_text():
 @pytest.fixture()
 def prob_forecast_text():
     return b"""
-[
-  {
+{
     "_links": {
       "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440001"
     },
@@ -766,30 +765,14 @@ def prob_forecast_text():
     "site_id": "123e4567-e89b-12d3-a456-426655440001",
     "variable": "ghi",
     "axis": "x",
-    "constant_value": 0
-  },
-  {
-    "_links": {
-      "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440002"
-    },
-    "created_at": "2019-03-01T11:55:38+00:00",
-    "extra_parameters": "",
-    "forecast_id": "f8dd49fa-23e2-48a0-862b-ba0af6dec276",
-    "interval_label": "beginning",
-    "interval_length": 1,
-    "interval_value_type": "interval_mean",
-    "issue_time_of_day": "12:00",
-    "lead_time_to_start": 60,
-    "modified_at": "2019-03-01T11:55:38+00:00",
-    "name": "HA Power",
-    "provider": "Organization 1",
-    "run_length": 60,
-    "site_id": "123e4567-e89b-12d3-a456-426655440002",
-    "variable": "ac_power",
-    "axis": "x",
-    "constant_value": 1
-  }
-]
+    "constant_values": [
+        {
+            "_links": {},
+            "constant_value": 0,
+            "forecast_id": "11c20780-76ae-4b11-bef1-7a75bdc784e3"
+        }
+    ]
+}
 """  # NOQA
 
 
@@ -814,7 +797,8 @@ def _prob_forecast_constant_value_from_dict(single_site, get_site):
 
 
 @pytest.fixture()
-def _prob_forecast_from_dict(single_site, get_site):
+def _prob_forecast_from_dict(single_site, get_site,
+                             prob_forecast_constant_value):
     def f(fx_dict):
         return datamodel.ProbabilisticForecast(
             name=fx_dict['name'], variable=fx_dict['variable'],
@@ -827,7 +811,9 @@ def _prob_forecast_from_dict(single_site, get_site):
             lead_time_to_start=pd.Timedelta(f"{fx_dict['lead_time_to_start']}min"),  # NOQA
             run_length=pd.Timedelta(f"{fx_dict['run_length']}min"),
             forecast_id=fx_dict.get('forecast_id', ''),
-            extra_parameters=fx_dict.get('extra_parameters', ''))
+            extra_parameters=fx_dict.get('extra_parameters', ''),
+            axis=fx_dict['axis'],
+            constant_values=(prob_forecast_constant_value, ))
     return f
 
 
@@ -839,9 +825,8 @@ def prob_forecast_constant_value(prob_forecast_constant_value_text,
 
 
 @pytest.fixture()
-def prob_forecasts(many_forecasts_text, _prob_forecast_from_dict):
-    return [_prob_forecast_from_dict(fx) for fx
-            in json.loads(prob_forecast_text)]
+def prob_forecasts(prob_forecast_text, _prob_forecast_from_dict):
+    return _prob_forecast_from_dict(json.loads(prob_forecast_text))
 
 
 @pytest.fixture(scope='module')

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -504,6 +504,53 @@ class ProbabilisticForecastConstantValue(
     """
     Extends Forecast dataclass to include probabilistic forecast
     attributes.
+
+    Parameters
+    ----------
+    name : str
+        Name of the Forecast
+    issue_time_of_day : datetime.time
+        The time of day that a forecast run is issued, e.g. 00:30. For
+        forecast runs issued multiple times within one day (e.g. hourly),
+        this specifies the first issue time of day. Additional issue times
+        are uniquely determined by the first issue time and the run length &
+        issue frequency attribute.
+    lead_time_to_start : pandas.Timedelta
+        The difference between the issue time and the start of the first
+        forecast interval, e.g. 1 hour.
+    interval_length : pandas.Timedelta
+        The length of time between consecutive data points, e.g. 5 minutes,
+        1 hour.
+    run_length : pandas.Timedelta
+        The total length of a single issued forecast run, e.g. 1 hour.
+        To enforce a continuous, non-overlapping sequence, this is equal
+        to the forecast run issue frequency.
+    interval_label : str
+        Indicates if a time labels the beginning or the ending of an interval
+        average, or indicates an instantaneous value, e.g. beginning, ending,
+        instant.
+    interval_value_type : str
+        The type of the data in the forecast, e.g. mean, max, 95th percentile.
+    variable : str
+        The variable in the forecast, e.g. power, GHI, DNI. Each variable is
+        associated with a standard unit.
+    site : Site
+        The predefined site that the forecast is for, e.g. Power Plant X
+        or Aggregate Y.
+    axis : str
+        The axis on which the constant values of the CDF is specified.
+        The axis can be either *x* (constant variable values) or *y*
+        (constant percentiles).
+    constant_value : float
+        The variable value or percentile.
+    forecast_id : str, optional
+        UUID of the forecast in the API
+    extra_parameters : str, optional
+        Extra configuration parameters of forecast.
+
+    See also
+    --------
+    ProbabilisticForecast
     """
     def __post_init__(self):
         super().__post_init__()
@@ -523,6 +570,53 @@ class ProbabilisticForecast(
     Tracks a group of ProbabilisticForecastConstantValue objects that
     together describe 1 or more points of the same probability
     distribution.
+
+    Parameters
+    ----------
+    name : str
+        Name of the Forecast
+    issue_time_of_day : datetime.time
+        The time of day that a forecast run is issued, e.g. 00:30. For
+        forecast runs issued multiple times within one day (e.g. hourly),
+        this specifies the first issue time of day. Additional issue times
+        are uniquely determined by the first issue time and the run length &
+        issue frequency attribute.
+    lead_time_to_start : pandas.Timedelta
+        The difference between the issue time and the start of the first
+        forecast interval, e.g. 1 hour.
+    interval_length : pandas.Timedelta
+        The length of time between consecutive data points, e.g. 5 minutes,
+        1 hour.
+    run_length : pandas.Timedelta
+        The total length of a single issued forecast run, e.g. 1 hour.
+        To enforce a continuous, non-overlapping sequence, this is equal
+        to the forecast run issue frequency.
+    interval_label : str
+        Indicates if a time labels the beginning or the ending of an interval
+        average, or indicates an instantaneous value, e.g. beginning, ending,
+        instant.
+    interval_value_type : str
+        The type of the data in the forecast, e.g. mean, max, 95th percentile.
+    variable : str
+        The variable in the forecast, e.g. power, GHI, DNI. Each variable is
+        associated with a standard unit.
+    site : Site
+        The predefined site that the forecast is for, e.g. Power Plant X
+        or Aggregate Y.
+    axis : str
+        The axis on which the constant values of the CDF is specified.
+        The axis can be either *x* (constant variable values) or *y*
+        (constant percentiles).
+    constant_values : tuple of ProbabilisticForecastConstantValue
+        The variable values or percentiles.
+    forecast_id : str, optional
+        UUID of the forecast in the API
+    extra_parameters : str, optional
+        Extra configuration parameters of forecast.
+
+    See also
+    --------
+    ProbabilisticForecastConstantValue
     """
     def __post_init__(self):
         super().__post_init__()

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -494,7 +494,7 @@ class ProbabilisticForecastConstantValue(
 @dataclass(frozen=True)
 class _ProbabilisticForecastBase:
     axis: str
-    constant_values: Tuple[ProbabilisticForecastConstantValue]
+    constant_values: Tuple[ProbabilisticForecastConstantValue, ...]
 
 
 @dataclass(frozen=True)
@@ -572,7 +572,7 @@ class QualityFlagFilter(BaseFilter):
         Strings corresponding to ``BITMASK_DESCRIPTION_DICT`` keys.
         These periods will be excluded from the analysis.
     """
-    quality_flags: Tuple[str] = (
+    quality_flags: Tuple[str, ...] = (
         'UNEVEN FREQUENCY', 'LIMITS EXCEEDED', 'CLEARSKY EXCEEDED',
         'STALE VALUES', 'INCONSISTENT IRRADIANCE COMPONENTS'
     )
@@ -665,7 +665,6 @@ class RawReport(BaseModel):
     metadata: ReportMetadata
     template: str
     metrics: dict  # later MetricsResult
-    processed_forecasts_observations: Tuple[ProcessedForecastObservation]
 
     def _special_field_processing(self, model_field, val):
         if model_field.name == 'processed_forecasts_observations':
@@ -678,6 +677,7 @@ class RawReport(BaseModel):
             return tuple(out)
         else:
             return val
+    processed_forecasts_observations: Tuple[ProcessedForecastObservation, ...]
 
 
 @dataclass(frozen=True)
@@ -717,9 +717,9 @@ class Report(BaseModel):
     name: str
     start: pd.Timestamp
     end: pd.Timestamp
-    forecast_observations: Tuple[ForecastObservation]
-    metrics: Tuple[str] = ('mae', 'mbe', 'rmse')
-    filters: Tuple[BaseFilter] = field(default_factory=QualityFlagFilter)
+    forecast_observations: Tuple[ForecastObservation, ...]
+    metrics: Tuple[str, ...] = ('mae', 'mbe', 'rmse')
+    filters: Tuple[BaseFilter, ...] = field(default_factory=QualityFlagFilter)
     status: str = 'pending'
     report_id: str = ''
     raw_report: Union[None, RawReport] = None

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -147,8 +147,10 @@ class BaseModel:
                             )
                         else:
                             raise TypeError(
-                                f'Invalid type of argument for {model_field.name},'
-                                f' must be dict or {model_field.type.__args__[0]}'
+                                f'Invalid type of argument for '
+                                f'{model_field.name}, '
+                                f'must be dict or '
+                                f'{model_field.type.__args__[0]}'
                             )
                     kwargs[model_field.name] = tuple(out)
                 else:

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -458,6 +458,24 @@ class Forecast(BaseModel):
     __post_init__ = __set_units__
 
 
+def ProbabilisticForecast(Forecast):
+    """
+    Extends Forecast dataclass to include probabilistic forecast
+    attributes.
+    """
+    axis: str
+    constant_value: float
+
+
+def ProbabilisticForecastGroup(Forecast):
+    """
+    Tracks a group of ProbabilisticForecast objects that together
+    describe several points of the same probability distribution.
+    """
+    axis: str
+    constant_values: Tuple[ProbabilisticForecast]
+
+
 def __check_units__(*args):
     ref_unit = args[0].units
     if not all(arg.units == ref_unit for arg in args):

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -466,6 +466,9 @@ def ProbabilisticForecastConstantValue(Forecast):
     axis: str
     constant_value: float
 
+    def __post_init__(self):
+        __check_axis__(self.axis)
+
 
 def ProbabilisticForecast(Forecast):
     """
@@ -475,6 +478,20 @@ def ProbabilisticForecast(Forecast):
     """
     axis: str
     constant_values: Tuple[ProbabilisticForecastConstantValue]
+
+    def __post_init__(self):
+        __check_axis__(self.axis)
+        __check_axis_consistency__(self.axis, self.constant_values)
+
+
+def __check_axis__(axis):
+    if axis not in ('x', 'y'):
+        raise ValueError('Axis must be x or y')
+
+
+def __check_axis_consistency__(axis, constant_values):
+    if not all(arg.axis == axis for arg in constant_values):
+        raise ValueError('All axis attributes must be identical')
 
 
 def __check_units__(*args):

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -458,7 +458,7 @@ class Forecast(BaseModel):
     __post_init__ = __set_units__
 
 
-def ProbabilisticForecast(Forecast):
+def ProbabilisticForecastConstantValue(Forecast):
     """
     Extends Forecast dataclass to include probabilistic forecast
     attributes.
@@ -467,13 +467,14 @@ def ProbabilisticForecast(Forecast):
     constant_value: float
 
 
-def ProbabilisticForecastGroup(Forecast):
+def ProbabilisticForecast(Forecast):
     """
-    Tracks a group of ProbabilisticForecast objects that together
-    describe several points of the same probability distribution.
+    Tracks a group of ProbabilisticForecastConstantValue objects that
+    together describe 1 or more points of the same probability
+    distribution.
     """
     axis: str
-    constant_values: Tuple[ProbabilisticForecast]
+    constant_values: Tuple[ProbabilisticForecastConstantValue]
 
 
 def __check_units__(*args):

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -458,7 +458,8 @@ class Forecast(BaseModel):
     __post_init__ = __set_units__
 
 
-def ProbabilisticForecastConstantValue(Forecast):
+@dataclass(frozen=True)
+class ProbabilisticForecastConstantValue(Forecast):
     """
     Extends Forecast dataclass to include probabilistic forecast
     attributes.
@@ -470,7 +471,8 @@ def ProbabilisticForecastConstantValue(Forecast):
         __check_axis__(self.axis)
 
 
-def ProbabilisticForecast(Forecast):
+@dataclass(frozen=True)
+class ProbabilisticForecast(Forecast):
     """
     Tracks a group of ProbabilisticForecastConstantValue objects that
     together describe 1 or more points of the same probability

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -349,7 +349,7 @@ def test_apisession_get_report(requests_mock, report_text, report_objects,
                                content=report_text)
     out = session.get_report('')
     # TODO: fix filters
-    expected = report_objects[0].replace(filters=[])
+    expected = report_objects[0].replace(filters=())
     assert out == expected
 
 
@@ -370,7 +370,7 @@ def test_apisession_get_report_with_raw(
     out = session.get_report('')
     # TODO: fix filters
     expected = report_objects[0].replace(
-        filters=[],
+        filters=(),
         raw_report=raw.replace(processed_forecasts_observations=()))
     assert out == expected
 
@@ -382,7 +382,7 @@ def test_apisession_list_reports(requests_mock, report_text, report_objects,
                                content=b'['+report_text+b']')
     out = session.list_reports()
     # TODO: fix filters
-    expected = [report_objects[0].replace(filters=[])]
+    expected = [report_objects[0].replace(filters=())]
     assert out == expected
 
 

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -135,6 +135,40 @@ def test_from_dict_invalid_time_format(many_forecasts_text):
         datamodel.Forecast.from_dict(obj_dict)
 
 
+def test_from_dict_invalid_constant_values(prob_forecast_text, single_site):
+    fx_dict = json.loads(prob_forecast_text)
+    fx_dict['site'] = single_site
+    fx_dict['constant_values'] = ('not a tuple of cv', 1)
+    with pytest.raises(TypeError):
+        datamodel.ProbabilisticForecast.from_dict(fx_dict)
+
+
+def test_from_dict_invalid_axis(prob_forecast_text, single_site,
+                                prob_forecast_constant_value):
+    fx_dict = json.loads(prob_forecast_text)
+    fx_dict['site'] = single_site
+    fx_dict['constant_values'] = (prob_forecast_constant_value,)
+    fx_dict['axis'] = 'z'
+    with pytest.raises(ValueError):
+        datamodel.ProbabilisticForecast.from_dict(fx_dict)
+
+
+def test_from_dict_inconsistent_axis(prob_forecast_text, single_site,
+                                     prob_forecast_constant_value_text,
+                                     prob_forecast_constant_value):
+    cv_dict = json.loads(prob_forecast_constant_value_text)
+    cv_dict['site'] = single_site
+    fx_dict = json.loads(prob_forecast_text)
+    fx_dict['site'] = single_site
+    fx_dict['constant_values'] = (prob_forecast_constant_value, cv_dict)
+    fx_dict['axis'] = 'x'
+    # check multiple constant values
+    datamodel.ProbabilisticForecast.from_dict(fx_dict)
+    cv_dict['axis'] = 'y'
+    with pytest.raises(ValueError):
+        datamodel.ProbabilisticForecast.from_dict(fx_dict)
+
+
 def test_dict_roundtrip(pdid_params):
     expected, _, model = pdid_params
     dict_ = expected.to_dict()

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -10,10 +10,15 @@ from solarforecastarbiter import datamodel
 
 
 @pytest.fixture(params=['site', 'fixed', 'single', 'observation',
-                        'forecast', 'forecastobservation'])
+                        'forecast', 'forecastobservation',
+                        'probabilisticforecastconstantvalue',
+                        'probabilisticforecast'])
 def pdid_params(request, many_sites, many_sites_text, single_observation,
                 single_observation_text, single_site,
-                single_forecast_text, single_forecast):
+                single_forecast_text, single_forecast,
+                prob_forecast_constant_value,
+                prob_forecast_constant_value_text,
+                prob_forecasts, prob_forecast_text):
     if request.param == 'site':
         return (many_sites[0], json.loads(many_sites_text)[0],
                 datamodel.Site)
@@ -34,6 +39,16 @@ def pdid_params(request, many_sites, many_sites_text, single_observation,
         fx_dict = json.loads(single_forecast_text)
         fx_dict['site'] = single_site
         return (single_forecast, fx_dict, datamodel.Forecast)
+    elif request.param == 'probabilisticforecastconstantvalue':
+        fx_dict = json.loads(prob_forecast_constant_value_text)
+        fx_dict['site'] = single_site
+        return (prob_forecast_constant_value, fx_dict,
+                datamodel.ProbabilisticForecastConstantValue)
+    elif request.param == 'probabilisticforecast':
+        fx_dict = json.loads(prob_forecast_text)
+        fx_dict['site'] = single_site
+        fx_dict['constant_values'] = (prob_forecast_constant_value, )
+        return (prob_forecasts, fx_dict, datamodel.ProbabilisticForecast)
     elif request.param == 'forecastobservation':
         fx_dict = json.loads(single_forecast_text)
         fx_dict['site'] = single_site

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -222,3 +222,12 @@ def test_process_site_dict(_sites):
     site_dict, expected, model = _sites
     out = model.from_dict(site_dict)
     assert out == expected
+
+
+def test_process_nested_objects(single_observation_text_with_site_text,
+                                single_site, single_observation):
+    obs_dict = json.loads(single_observation_text_with_site_text)
+    obs = datamodel.Observation.from_dict(obs_dict)
+    assert obs == single_observation
+    assert obs.site == single_site
+    assert obs.site == single_observation.site


### PR DESCRIPTION
  - [x] Closes #47 . closes #125
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

@alorenzo175 is this how we want to implement probabilistic forecasts in `datamodel.py`? I've forgotten what we discussed months ago.

I'll add tests once we agree on the design.