### PR TITLE
add probabilistic forecasts to APISession

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -255,7 +255,7 @@ Class for communicating with the Solar Forecast Arbiter API.
    io.api.APISession.list_forecasts
    io.api.APISession.create_forecast
    io.api.APISession.list_probabilistic_forecasts
-   io.api.APISession.get_probabilistic_forecast_constant_values
+   io.api.APISession.get_probabilistic_forecast_constant_value
    io.api.APISession.get_observation_values
    io.api.APISession.get_forecast_values
    io.api.APISession.post_observation_values

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -254,6 +254,8 @@ Class for communicating with the Solar Forecast Arbiter API.
    io.api.APISession.get_forecast
    io.api.APISession.list_forecasts
    io.api.APISession.create_forecast
+   io.api.APISession.list_probabilistic_forecasts
+   io.api.APISession.get_probabilistic_forecast_constant_values
    io.api.APISession.get_observation_values
    io.api.APISession.get_forecast_values
    io.api.APISession.post_observation_values

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -245,21 +245,49 @@ Class for communicating with the Solar Forecast Arbiter API.
 
    io.api.APISession
    io.api.APISession.request
+
+Sites
+
+.. autosummary::
+   :toctree: generated/
+
    io.api.APISession.get_site
    io.api.APISession.list_sites
    io.api.APISession.create_site
+
+Observations
+
+.. autosummary::
+   :toctree: generated/
+
    io.api.APISession.get_observation
    io.api.APISession.list_observations
    io.api.APISession.create_observation
+   io.api.APISession.get_observation_values
+   io.api.APISession.post_observation_values
+
+Forecasts
+
+.. autosummary::
+   :toctree: generated/
+
    io.api.APISession.get_forecast
    io.api.APISession.list_forecasts
    io.api.APISession.create_forecast
-   io.api.APISession.list_probabilistic_forecasts
-   io.api.APISession.get_probabilistic_forecast_constant_value
-   io.api.APISession.get_observation_values
    io.api.APISession.get_forecast_values
-   io.api.APISession.post_observation_values
    io.api.APISession.post_forecast_values
+
+Probabilistic Forecasts
+
+.. autosummary::
+   :toctree: generated/
+
+   io.api.APISession.get_probabilistic_forecast
+   io.api.APISession.list_probabilistic_forecasts
+   io.api.APISession.create_probabilistic_forecast
+   io.api.APISession.get_probabilistic_forecast_constant_value
+   io.api.APISession.get_probabilistic_forecast_constant_value_values
+   io.api.APISession.post_probabilistic_forecast_constant_value_values
 
 
 Metrics

--- a/docs/source/whatsnew/1.0.0b.rst
+++ b/docs/source/whatsnew/1.0.0b.rst
@@ -27,6 +27,11 @@ Enhancements
   For example, a dict describing an Observation may now specify its site as a
   dict that describes a Site, rather than a Site object. (:issue:`125`)
 * Documentation page for command line interface. (:issue:`169`)
+* Add methods to :py:class:`~solarforecastarbiter.io.api.APISession` to
+  support getting and posting data with
+  :py:class:`~solarforecastarbiter.datamodel.ProbabilisticForecastConstantValue`
+  and
+  :py:class:`~solarforecastarbiter.datamodel.ProbabilisticForecast` classes.
 
 Bug fixes
 ~~~~~~~~~

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -802,6 +802,68 @@ def prob_forecast_text():
 
 
 @pytest.fixture()
+def many_prob_forecasts_text():
+    return b"""
+[
+    {
+        "_links": {
+        "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440001"
+        },
+        "created_at": "2019-03-01T11:55:37+00:00",
+        "extra_parameters": "",
+        "forecast_id": "11c20780-76ae-4b11-bef1-7a75bdc784e3",
+        "interval_label": "beginning",
+        "interval_length": 5,
+        "interval_value_type": "interval_mean",
+        "issue_time_of_day": "06:00",
+        "lead_time_to_start": 60,
+        "modified_at": "2019-03-01T11:55:37+00:00",
+        "name": "DA GHI",
+        "provider": "Organization 1",
+        "run_length": 1440,
+        "site_id": "123e4567-e89b-12d3-a456-426655440002",
+        "variable": "ghi",
+        "axis": "x",
+        "constant_values": [
+            {
+                "_links": {},
+                "constant_value": 0,
+                "forecast_id": "11c20780-76ae-4b11-bef1-7a75bdc784e3"
+            }
+        ]
+    },
+    {
+        "_links": {
+        "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440001"
+        },
+        "created_at": "2019-03-01T11:55:37+00:00",
+        "extra_parameters": "",
+        "forecast_id": "11c20780-76ae-4b11-bef1-7a75bdc784e3",
+        "interval_label": "beginning",
+        "interval_length": 5,
+        "interval_value_type": "interval_mean",
+        "issue_time_of_day": "06:00",
+        "lead_time_to_start": 60,
+        "modified_at": "2019-03-01T11:55:37+00:00",
+        "name": "DA GHI",
+        "provider": "Organization 1",
+        "run_length": 1440,
+        "site_id": "123e4567-e89b-12d3-a456-426655440002",
+        "variable": "ghi",
+        "axis": "x",
+        "constant_values": [
+            {
+                "_links": {},
+                "constant_value": 0,
+                "forecast_id": "11c20780-76ae-4b11-bef1-7a75bdc784e3"
+            }
+        ]
+    }
+]
+"""  # NOQA
+
+
+@pytest.fixture()
 def _prob_forecast_constant_value_from_dict(get_site):
     def f(fx_dict):
         return datamodel.ProbabilisticForecastConstantValue(
@@ -851,6 +913,12 @@ def prob_forecast_constant_value(prob_forecast_constant_value_text,
 @pytest.fixture()
 def prob_forecasts(prob_forecast_text, _prob_forecast_from_dict):
     return _prob_forecast_from_dict(json.loads(prob_forecast_text))
+
+
+@pytest.fixture()
+def many_prob_forecasts(many_prob_forecasts_text, _prob_forecast_from_dict):
+    return [_prob_forecast_from_dict(fx) for fx
+            in json.loads(many_prob_forecasts_text)]
 
 
 @pytest.fixture(scope='module')

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -381,13 +381,19 @@ class APISession(requests.Session):
         datamodel.ProbabilisticForecast
             With the appropriate parameters such as forecast_id set by the API
         """
-        raise NotImplementedError
         fx_dict = forecast.to_dict()
         fx_dict.pop('forecast_id')
         site = fx_dict.pop('site')
         fx_dict['site_id'] = site['site_id']
+        # fx_dict['constant_values'] is tuple of dict representations of
+        # all ProbabilisticForecastConstantValue objects in the
+        # ProbabilisticForecast. We need to extract just the numeric
+        # values from these dicts and put them into a list for the API.
+        constant_values_fxs = fx_dict.pop('constant_values')
+        constant_values = [fx['constant_value'] for fx in constant_values_fxs]
+        fx_dict['constant_values'] = constant_values
         fx_json = json.dumps(fx_dict)
-        req = self.post('/forecasts/single/', data=fx_json,
+        req = self.post('/forecasts/cdf/', data=fx_json,
                         headers={'Content-Type': 'application/json'})
         new_id = req.text
         return self.get_probabilistic_forecast(new_id)

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -329,7 +329,7 @@ class APISession(requests.Session):
 
         Returns
         -------
-        datamodel.Forecast
+        datamodel.ProbabilisticForecastConstantValue
         """
         # add /metadata after
         # https://github.com/SolarArbiter/solarforecastarbiter-api/issues/158

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -312,7 +312,7 @@ class APISession(requests.Session):
             cvs = []
             for constant_value_dict in fx_dict['constant_values']:
                 cvs.append(self.get_probabilistic_forecast_constant_value(
-                    constant_value_dict['forecast_id']))
+                    constant_value_dict['forecast_id'], site=site))
             fx_dict['constant_values'] = cvs
             out.append(datamodel.ProbabilisticForecast.from_dict(fx_dict))
         return out
@@ -362,6 +362,12 @@ class APISession(requests.Session):
         Returns
         -------
         datamodel.ProbabilisticForecastConstantValue
+
+        Raises
+        ------
+        ValueError
+            If provided site.site_id does not match database record of
+            forecast object's linked site_id.
         """
         # add /metadata after
         # https://github.com/SolarArbiter/solarforecastarbiter-api/issues/158

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -211,6 +211,37 @@ def test_apisession_list_forecasts_empty(requests_mock):
     assert fx_list == []
 
 
+def test_apisession_get_prob_forecast(requests_mock, prob_forecasts,
+                                      prob_forecast_text, mock_get_site):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/forecasts/cdf/.*')
+    requests_mock.register_uri('GET', matcher, content=prob_forecast_text)
+    fx = session.get_probabilistic_forecast('')
+    assert fx == prob_forecasts
+
+
+def test_apisession_list_prob_forecasts(requests_mock, many_prob_forecasts,
+                                        many_prob_forecasts_text,
+                                        mock_list_sites):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/forecasts/cdf/.*')
+    requests_mock.register_uri(
+        'GET', matcher, content=many_prob_forecasts_text)
+    fx_list = session.list_probabilistic_forecasts()
+    assert fx_list == many_prob_forecasts
+
+
+def test_apisession_get_prob_forecast_constant_value(
+        requests_mock, prob_forecast_constant_value,
+        prob_forecast_constant_value_text, mock_get_site):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/forecasts/cdf/single/.*')
+    requests_mock.register_uri(
+        'GET', matcher, content=prob_forecast_constant_value_text)
+    fx = session.get_probabilistic_forecast_constant_value('')
+    assert fx == prob_forecast_constant_value
+
+
 @pytest.fixture(params=[0, 1])
 def obs_start_end(request):
     if request.param == 0:

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -848,9 +848,9 @@ def test_real_apisession_post_prob_forecast_constant_val_values(real_session):
         index=pd.DatetimeIndex([pd.Timestamp('2019-04-14T00:00:00Z')],
                                name='timestamp'))
     real_session.post_probabilistic_forecast_constant_value_values(
-        'f8dd49fa-23e2-48a0-862b-ba0af6dec276', test_ser)
+        '633f9b2a-50bb-11e9-8647-d663bd873d93', test_ser)
     fx = real_session.get_probabilistic_forecast_constant_value_values(
-        'f8dd49fa-23e2-48a0-862b-ba0af6dec276',
+        '633f9b2a-50bb-11e9-8647-d663bd873d93',
         pd.Timestamp('2019-04-14T00:00:00Z'),
         pd.Timestamp('2019-04-14T00:01:00Z'))
     pdt.assert_series_equal(fx, test_ser)

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -258,6 +258,31 @@ def test_apisession_get_prob_forecast_constant_value(
     assert fx == prob_forecast_constant_value
 
 
+def test_apisession_get_prob_forecast_constant_value_site(
+        requests_mock, prob_forecast_constant_value,
+        prob_forecast_constant_value_text, single_site):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/forecasts/cdf/single/.*')
+    requests_mock.register_uri(
+        'GET', matcher, content=prob_forecast_constant_value_text)
+    fx = session.get_probabilistic_forecast_constant_value(
+        '', site=single_site)
+    assert fx == prob_forecast_constant_value
+
+
+def test_apisession_get_prob_forecast_constant_value_site_error(
+        requests_mock, prob_forecast_constant_value_text, single_site):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/forecasts/cdf/single/.*')
+    requests_mock.register_uri(
+        'GET', matcher, content=prob_forecast_constant_value_text)
+    site_dict = single_site.to_dict()
+    site_dict['site_id'] = 'nope'
+    site = datamodel.Site.from_dict(site_dict)
+    with pytest.raises(ValueError):
+        session.get_probabilistic_forecast_constant_value('', site=site)
+
+
 def test_apisession_create_prob_forecast(requests_mock, prob_forecasts,
                                          prob_forecast_text, mock_get_site,
                                          prob_forecast_constant_value_text):

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -323,6 +323,16 @@ def test_apisession_get_forecast_values(requests_mock, forecast_values,
     pdt.assert_series_equal(out, forecast_values)
 
 
+def test_apisession_get_prob_forecast_constant_value_values(
+        requests_mock, forecast_values, forecast_values_text, fx_start_end):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/forecasts/cdf/single/.*/values')
+    requests_mock.register_uri('GET', matcher, content=forecast_values_text)
+    out = session.get_probabilistic_forecast_constant_value_values(
+        'fxid', *fx_start_end)
+    pdt.assert_series_equal(out, forecast_values)
+
+
 @pytest.mark.parametrize('label,theslice', [
     (None, slice(0, 10)),
     ('beginning', slice(0, -1)),
@@ -363,6 +373,16 @@ def test_apisession_post_forecast_values(requests_mock, forecast_values):
     matcher = re.compile(f'{session.base_url}/forecasts/single/.*/values')
     mocked = requests_mock.register_uri('POST', matcher)
     session.post_forecast_values('fxid', forecast_values)
+    assert mocked.request_history[0].text == '{"values":[{"timestamp":"2019-01-01T13:00:00Z","value":0.0},{"timestamp":"2019-01-01T14:00:00Z","value":1.0},{"timestamp":"2019-01-01T15:00:00Z","value":2.0},{"timestamp":"2019-01-01T16:00:00Z","value":3.0},{"timestamp":"2019-01-01T17:00:00Z","value":4.0},{"timestamp":"2019-01-01T18:00:00Z","value":5.0}]}'  # NOQA
+
+
+def test_apisession_post_prob_forecast_constant_value_values(
+        requests_mock, forecast_values):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/forecasts/cdf/single/.*/values')
+    mocked = requests_mock.register_uri('POST', matcher)
+    session.post_probabilistic_forecast_constant_value_values(
+        'fxid', forecast_values)
     assert mocked.request_history[0].text == '{"values":[{"timestamp":"2019-01-01T13:00:00Z","value":0.0},{"timestamp":"2019-01-01T14:00:00Z","value":1.0},{"timestamp":"2019-01-01T15:00:00Z","value":2.0},{"timestamp":"2019-01-01T16:00:00Z","value":3.0},{"timestamp":"2019-01-01T17:00:00Z","value":4.0},{"timestamp":"2019-01-01T18:00:00Z","value":5.0}]}'  # NOQA
 
 

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -212,9 +212,13 @@ def test_apisession_list_forecasts_empty(requests_mock):
 
 
 def test_apisession_get_prob_forecast(requests_mock, prob_forecasts,
-                                      prob_forecast_text, mock_get_site):
+                                      prob_forecast_text, mock_get_site,
+                                      prob_forecast_constant_value_text):
     session = api.APISession('')
-    matcher = re.compile(f'{session.base_url}/forecasts/cdf/.*')
+    matcher = re.compile(f'{session.base_url}/forecasts/cdf/single/.*')
+    requests_mock.register_uri(
+        'GET', matcher, content=prob_forecast_constant_value_text)
+    matcher = re.compile(session.base_url + r'/forecasts/cdf/[\w-]*$')
     requests_mock.register_uri('GET', matcher, content=prob_forecast_text)
     fx = session.get_probabilistic_forecast('')
     assert fx == prob_forecasts
@@ -222,9 +226,13 @@ def test_apisession_get_prob_forecast(requests_mock, prob_forecasts,
 
 def test_apisession_list_prob_forecasts(requests_mock, many_prob_forecasts,
                                         many_prob_forecasts_text,
-                                        mock_list_sites):
+                                        mock_list_sites, mock_get_site,
+                                        prob_forecast_constant_value_text):
     session = api.APISession('')
-    matcher = re.compile(f'{session.base_url}/forecasts/cdf/.*')
+    matcher = re.compile(f'{session.base_url}/forecasts/cdf/single/.*')
+    requests_mock.register_uri(
+        'GET', matcher, content=prob_forecast_constant_value_text)
+    matcher = re.compile(session.base_url + r'/forecasts/cdf/$')
     requests_mock.register_uri(
         'GET', matcher, content=many_prob_forecasts_text)
     fx_list = session.list_probabilistic_forecasts()


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #154  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

@lboeman see the note in `get_probabilistic_forecast_constant_value` regarding https://github.com/SolarArbiter/solarforecastarbiter-api/issues/158 