### PR TITLE
fix non-tuple default report filter

### DIFF
--- a/docs/source/whatsnew/1.0.0b.rst
+++ b/docs/source/whatsnew/1.0.0b.rst
@@ -64,6 +64,10 @@ Bug fixes
   `~solarforecastarbiter.validation.validator.check_irradiance_limits_QCRad`.
   (:issue:`182`)
 * Fix resampled/aligned observation/forecast labels in report. (:issue:`184`)
+* Make :py:class:`~solarforecastarbiter.datamodel.Report` default ``filter``
+  attribute a tuple
+  ``(:py:class:`~solarforecastarbiter.datamodel.QualityFlagFilter`, )``
+  instead of a single ``QualityFlagFilter``. (:issue:`166`)
 
 Testing
 ~~~~~~~

--- a/solarforecastarbiter/cli.py
+++ b/solarforecastarbiter/cli.py
@@ -317,7 +317,7 @@ def report(verbose, user, password, base_url, report_file, output_file):
         end=pd.Timestamp(params['end']),
         forecast_observations=fx_obs,
         metrics=params['metrics'],
-        filters=[datamodel.QualityFlagFilter]
+        # filters=[datamodel.QualityFlagFilter]
     )
     data = reports.get_data_for_report(session, report)
     raw_report = reports.create_raw_report_from_data(report, data)

--- a/solarforecastarbiter/cli.py
+++ b/solarforecastarbiter/cli.py
@@ -316,8 +316,7 @@ def report(verbose, user, password, base_url, report_file, output_file):
         start=pd.Timestamp(params['start']),
         end=pd.Timestamp(params['end']),
         forecast_observations=fx_obs,
-        metrics=params['metrics'],
-        # filters=[datamodel.QualityFlagFilter]
+        metrics=params['metrics']
     )
     data = reports.get_data_for_report(session, report)
     raw_report = reports.create_raw_report_from_data(report, data)

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -820,7 +820,8 @@ class Report(BaseModel):
     end: pd.Timestamp
     forecast_observations: Tuple[ForecastObservation, ...]
     metrics: Tuple[str, ...] = ('mae', 'mbe', 'rmse')
-    filters: Tuple[BaseFilter, ...] = field(default_factory=QualityFlagFilter)
+    filters: Tuple[BaseFilter, ...] = field(
+        default_factory=lambda: (QualityFlagFilter(), ))
     status: str = 'pending'
     report_id: str = ''
     raw_report: Union[None, RawReport] = None

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -234,7 +234,7 @@ def test_process_nested_objects(single_observation_text_with_site_text,
 
 
 def test_report_defaults(report_objects):
-    report, _ = report_objects
+    report, *_ = report_objects
     report_defaults = datamodel.Report(
         name=report.name,
         start=report.start,

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -231,3 +231,15 @@ def test_process_nested_objects(single_observation_text_with_site_text,
     assert obs == single_observation
     assert obs.site == single_site
     assert obs.site == single_observation.site
+
+
+def test_report_defaults(report_objects):
+    report, _ = report_objects
+    report_defaults = datamodel.Report(
+        name=report.name,
+        start=report.start,
+        end=report.end,
+        forecast_observations=report.forecast_observations,
+        report_id=report.report_id
+    )
+    assert isinstance(report_defaults.filters, tuple)


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #166 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
