### PR TITLE
Reindex reference observations to interval_length before posting

### DIFF
--- a/docs/source/whatsnew/1.0.0b.rst
+++ b/docs/source/whatsnew/1.0.0b.rst
@@ -91,6 +91,8 @@ Bug fixes
   attribute a tuple
   ``(:py:class:`~solarforecastarbiter.datamodel.QualityFlagFilter`, )``
   instead of a single ``QualityFlagFilter``. (:issue:`166`)
+* Reindex reference observation data to include NaNs when posting
+  when appropriate (:issue:`216`)
 
 Testing
 ~~~~~~~

--- a/solarforecastarbiter/io/reference_observations/common.py
+++ b/solarforecastarbiter/io/reference_observations/common.py
@@ -235,7 +235,7 @@ def update_site_observations(api, fetch_func, site, observations,
 
 
 def _prepare_data_to_post(data, variable, observation, start, end):
-    """Maniuplate the data including reindexing to observation.interval_label
+    """Manipulate the data including reindexing to observation.interval_label
     to prepare for posting"""
     data = data[[variable]]
     data = data.rename(columns={variable: 'value'})

--- a/solarforecastarbiter/io/reference_observations/common.py
+++ b/solarforecastarbiter/io/reference_observations/common.py
@@ -291,7 +291,7 @@ def post_observation_data(api, observation, data, start, end):
                                     observation.variable)
     try:
         var_df = _prepare_data_to_post(data, variable, observation,
-                                      start, end)
+                                       start, end)
     except KeyError:
         logger.error(f'{variable} could not be found in the data file '
                      f'from {data.index[0]} to {data.index[-1]}'

--- a/solarforecastarbiter/io/reference_observations/common.py
+++ b/solarforecastarbiter/io/reference_observations/common.py
@@ -235,6 +235,8 @@ def update_site_observations(api, fetch_func, site, observations,
 
 
 def _prepare_data_to_post(data, variable, observation, start, end):
+    """Maniuplate the data including reindexing to observation.interval_label
+    to prepare for posting"""
     data = data[[variable]]
     data = data.rename(columns={variable: 'value'})
     # remove all future values, some files have forward filled nightly data

--- a/solarforecastarbiter/io/reference_observations/crn.py
+++ b/solarforecastarbiter/io/reference_observations/crn.py
@@ -104,7 +104,7 @@ def initialize_site_forecasts(api, site):
 
 def update_observation_data(api, sites, observations, start, end):
     """ Post new observation data to all reference observations at each
-    USCRN site betweem start amd emd.
+    USCRN site between start and end.
 
     api : solarforecastarbiter.io.api.APISession
         An active Reference user session.

--- a/solarforecastarbiter/io/reference_observations/tests/test_common.py
+++ b/solarforecastarbiter/io/reference_observations/tests/test_common.py
@@ -243,6 +243,15 @@ def test_create_observation_with_kwargs(
                    'quality_flag': [0, 0, 0, 1, 0, 0]},
                   index=pd.date_range('2019-10-04T1200Z', freq='1min',
                                       periods=6))),
+    # new freq
+    (pd.DataFrame({'ghi': [0, 1]}, dtype='float',
+                  index=pd.DatetimeIndex(
+                      ['2019-10-04T1200Z', '2019-10-04T1205Z'])),
+     pd.DataFrame({'value': [0, None, None, None, None, 1.0],
+                   'quality_flag': [0, 1, 1, 1, 1, 0]},
+                  index=pd.date_range('2019-10-04T1200Z', freq='1min',
+                                      periods=6))),
+
     # nans not extended to start end
     (pd.DataFrame({'ghi': [0, 1]}, dtype='float',
                   index=pd.DatetimeIndex(

--- a/solarforecastarbiter/io/reference_observations/tests/test_common.py
+++ b/solarforecastarbiter/io/reference_observations/tests/test_common.py
@@ -224,6 +224,81 @@ def test_create_observation_with_kwargs(
     mock_api.create_observation.assert_called_with(expected)
 
 
+@pytest.mark.parametrize('inp,expected', [
+    # nan kept
+    (pd.DataFrame({'ghi': [0, 1, 4.0, None, 5, 6]}, dtype='float',
+                  index=pd.date_range('2019-10-04T1200Z', freq='1min',
+                                      periods=6)),
+     pd.DataFrame({'value': [0, 1, 4.0, None, 5, 6],
+                   'quality_flag': [0, 0, 0, 1, 0, 0]},
+                  index=pd.date_range('2019-10-04T1200Z', freq='1min',
+                                      periods=6))),
+    # nan filled in center
+    (pd.DataFrame({'ghi': [0, 1, 4.0, 5, 6]}, dtype='float',
+                  index=pd.DatetimeIndex(
+                      ['2019-10-04T1200Z', '2019-10-04T1201Z',
+                       '2019-10-04T1202Z', '2019-10-04T1204Z',
+                       '2019-10-04T1205Z'])),
+     pd.DataFrame({'value': [0, 1, 4.0, None, 5, 6],
+                   'quality_flag': [0, 0, 0, 1, 0, 0]},
+                  index=pd.date_range('2019-10-04T1200Z', freq='1min',
+                                      periods=6))),
+    # nans not extended to start end
+    (pd.DataFrame({'ghi': [0, 1]}, dtype='float',
+                  index=pd.DatetimeIndex(
+                      ['2019-10-04T1201Z', '2019-10-04T1202Z'])),
+     pd.DataFrame({'value': [0.0, 1.0],
+                   'quality_flag': [0, 0]},
+                  index=pd.DatetimeIndex(
+                      ['2019-10-04T1201Z', '2019-10-04T1202Z']))),
+])
+def test_prepare_data_to_post(inp, expected):
+    start = pd.Timestamp('2019-10-04T1200Z')
+    end = pd.Timestamp('2019-10-04T1205Z')
+    variable = 'ghi'
+    out = common._prepare_data_to_post(inp, variable, test_kwarg_observation,
+                                       start, end)
+    pd.testing.assert_frame_equal(out, expected)
+
+
+def test_prepare_data_to_post_offset():
+    # offset data is kept as is. If this is a problem we'll need to
+    # probably resample the reference data to the appropriate index
+    start = pd.Timestamp('2019-10-04T1200Z')
+    end = pd.Timestamp('2019-10-04T1215Z')
+    variable = 'ghi'
+    inp = pd.DataFrame({'ghi': [0, 1, 4.0]},
+                       index=pd.date_range('2019-10-04T1201Z', freq='5min',
+                                           periods=3))
+    expected = pd.DataFrame(
+        {'value': [0, 1, 4.0], 'quality_flag': [0, 0, 0]},
+        index=pd.date_range('2019-10-04T1201Z', freq='5min',
+                            periods=3))
+    out = common._prepare_data_to_post(
+        inp, variable, observation_with_extra_params, start, end)
+    pd.testing.assert_frame_equal(out, expected)
+
+
+def test_prepare_data_to_post_empty():
+    inp = pd.DataFrame(
+        {'ghi': [0.0]}, index=pd.DatetimeIndex(['2019-01-01 00:00Z']))
+    start = pd.Timestamp('2019-10-04T1200Z')
+    end = pd.Timestamp('2019-10-04T1205Z')
+    variable = 'ghi'
+    out = common._prepare_data_to_post(inp, variable, test_kwarg_observation,
+                                       start, end)
+    assert out.empty
+
+
+def test_prepare_data_to_post_no_var():
+    start = pd.Timestamp('2109-10-04T1200Z')
+    end = pd.Timestamp('2109-10-04T1300Z')
+    data = pd.DataFrame({'notavar': [0, 1]})
+    with pytest.raises(KeyError):
+        common._prepare_data_to_post(data, 'GHI 7', test_kwarg_observation,
+                                     start, end)
+
+
 def test_post_observation_data_no_data(mock_api, log, start, end,):
     common.post_observation_data(
         mock_api, test_kwarg_observation,
@@ -263,7 +338,8 @@ def test_post_observation_data_all_nans(
     nan_data['ghi'] = np.NaN
     ret = common.post_observation_data(mock_api, site_test_observation,
                                        nan_data, start, end)
-    log.warning.assert_called()
+    # post the nans
+    log.warning.assert_not_called()
     assert ret is None
 
 
@@ -277,7 +353,9 @@ def test_update_site_observations(
     args, _ = mock_api.post_observation_values.call_args
     assert args[0] == ''
     pd.testing.assert_frame_equal(
-        args[1], fake_ghi_data.rename(columns={'ghi': 'value'})[start:end])
+        args[1], fake_ghi_data.rename(
+            columns={'ghi': 'value'})[start:end].resample(
+                args[1].index.freq).first())
 
 
 def test_update_site_observations_no_data(


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #209  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
