### PR TITLE
Metrics: add KSI, OVER, CPI

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -351,6 +351,9 @@ Functions to compute forecast deterministic performance metrics:
    metrics.deterministic.forecast_skill
    metrics.deterministic.pearson_correlation_coeff
    metrics.deterministic.coeff_determination
+   metrics.deterministic.kolmogorov_smirnov_integral
+   metrics.deterministic.over
+   metrics.deterministic.combined_performance_index
 
 
 Reports

--- a/docs/source/whatsnew/1.0.0b2.rst
+++ b/docs/source/whatsnew/1.0.0b2.rst
@@ -12,6 +12,10 @@ API Changes
   :py:mod:`solarforecastarbiter.metrics.preprocessing.apply_validation`,
   :py:mod:`solarforecastarbiter.metrics.preprocessing.resample_and_align`, and
   :py:mod:`solarforecastarbiter.metrics.preprocessing.exclude`. (:pull:`221`)
+* Add additional metrics for deterministic forecasts
+  :py:mod:`solarforecastarbiter.metrics.kolmogorov_smirnov_integral`,
+  :py:mod:`solarforecastarbiter.metrics.over`, and
+  :py:mod:`solarforecastarbiter.metrics.combined_performance_index`. (:pull:`230`)
 * Moved temporary functions from report to metrics calculator. (:pull:`221`)
 
 Enhancements

--- a/docs/source/whatsnew/1.0.0b2.rst
+++ b/docs/source/whatsnew/1.0.0b2.rst
@@ -13,9 +13,9 @@ API Changes
   :py:mod:`solarforecastarbiter.metrics.preprocessing.resample_and_align`, and
   :py:mod:`solarforecastarbiter.metrics.preprocessing.exclude`. (:pull:`221`)
 * Add additional metrics for deterministic forecasts
-  :py:mod:`solarforecastarbiter.metrics.kolmogorov_smirnov_integral`,
-  :py:mod:`solarforecastarbiter.metrics.over`, and
-  :py:mod:`solarforecastarbiter.metrics.combined_performance_index`. (:pull:`230`)
+  :py:mod:`solarforecastarbiter.metrics.deterministic.kolmogorov_smirnov_integral`,
+  :py:mod:`solarforecastarbiter.metrics.deterministic.over`, and
+  :py:mod:`solarforecastarbiter.metrics.deterministic.combined_performance_index`. (:pull:`230`)
 * Moved temporary functions from report to metrics calculator. (:pull:`221`)
 
 Enhancements

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ python-dateutil==2.8.0
 requests==2.22.0
 scipy==1.3.1
 sentry-sdk==0.12.3
+statsmodels==0.10.1
 tables==3.5.2
 xarray==0.13.0

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -245,7 +245,7 @@ def kolmogorov_smirnov_integral(y_true, y_pred, normed=False):
     ecdf_fx = ECDF(y_pred)
 
     # evaluate CDFs
-    x = np.sort(np.concatenate((y_true, y_pred)))
+    x = np.unique(np.concatenate((y_true, y_pred)))
     y_o = ecdf_obs(x)
     y_f = ecdf_fx(x)
 
@@ -289,7 +289,7 @@ def over(y_true, y_pred):
     ecdf_fx = ECDF(y_pred)
 
     # evaluate CDFs
-    x = np.sort(np.concatenate((y_true, y_pred)))
+    x = np.unique(np.concatenate((y_true, y_pred)))
     y_o = ecdf_obs(x)
     y_f = ecdf_fx(x)
 

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -298,7 +298,7 @@ def over(y_true, y_pred):
     Vc = 1.63 / np.sqrt(len(y_true))
     Dstar = D - Vc
     Dstar[D <= Vc] = 0.0
-    over = np.trapz(Dstar, x=x)
+    over = np.sum(Dstar[:-1] * np.diff(x))
     return over
 
 

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -12,6 +12,9 @@ __all__ = [
     "pearson_correlation_coeff",
     "coeff_determination",
     "centered_root_mean_square",
+    "kolmogorov_smirnov_integral",
+    "over",
+    "combined_performance_index",
 ]
 
 
@@ -209,3 +212,59 @@ def centered_root_mean_square(y_true, y_pred):
     return np.sqrt(np.mean(
         ((y_pred - np.mean(y_pred)) - (y_true - np.mean(y_true))) ** 2
     ))
+
+
+def kolmogorov_smirnov_integral():
+    """Kolmogorov-Smirnov Test Integral (KSI).
+
+    Parameters
+    ----------
+    y_true : array-like
+        True values.
+    y_pred : array-like
+        Predicted values.
+
+    Returns
+    -------
+    ksi : float
+        The KSI between the true and predicted values.
+
+    """
+    return None
+
+def over():
+    """OVER metric.
+
+    Parameters
+    ----------
+    y_true : array-like
+        True values.
+    y_pred : array-like
+        Predicted values.
+
+    Returns
+    -------
+    over : float
+        The OVER metric between the true and predicted values.
+
+    """
+    return None
+
+
+def combined_performance_index():
+    """Combined Performance Index (CPI) metric.
+
+    Parameters
+    ----------
+    y_true : array-like
+        True values.
+    y_pred : array-like
+        Predicted values.
+
+    Returns
+    -------
+    cpi : float
+        The CPI between the true and predicted values.
+
+    """
+    return None

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -251,7 +251,7 @@ def kolmogorov_smirnov_integral(y_true, y_pred, normed=False):
 
     # compute metric
     D = np.abs(y_o - y_f)
-    ksi = np.trapz(D, x=x)
+    ksi = np.sum(D[:-1] * np.diff(x))
 
     if normed:
         Vc = 1.63 / np.sqrt(len(y_true))

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -214,7 +214,14 @@ def centered_root_mean_square(y_true, y_pred):
     ))
 
 
-def kolmogorov_smirnov_integral():
+def _estimate_cdf(z, bins=100):
+    hist, bin_edges = np.histogram(z, bins=bins, density=True)
+    x = bin_edges[1:]
+    y = np.cumsum(hist * np.diff(bin_edges))
+    return x, y
+
+
+def kolmogorov_smirnov_integral(y_true, y_pred):
     """Kolmogorov-Smirnov Test Integral (KSI).
 
     Parameters
@@ -230,9 +237,36 @@ def kolmogorov_smirnov_integral():
         The KSI between the true and predicted values.
 
     """
-    return None
 
-def over():
+    # empirical CDF
+    x_o, y_o = _estimate_cdf(y_true)
+    x_f, y_f = _estimate_cdf(y_pred)
+
+    print("Before:")
+    print(x_o[:5])
+    print(x_f[:5])
+    print(y_o[:5])
+    print(y_f[:5])
+
+    # interpolate CDFs to same grid
+    xmin = min(x_o.min(), x_f.min())
+    xmax = max(x_o.max(), x_f.max())
+    x = np.linspace(xmin, xmax, 100)
+    y_o = np.interp(x, x_o, y_o)
+    y_f = np.interp(x, x_f, y_f)
+
+    print("After:")
+    print(x[:5])
+    print(y_o[:5])
+    print(y_f[:5])
+
+    # KSI
+    D = np.abs(y_o - y_f)
+    ksi = np.trapz(D, x=x)
+    return ksi
+
+
+def over(y_true, y_pred):
     """OVER metric.
 
     Parameters
@@ -248,10 +282,16 @@ def over():
         The OVER metric between the true and predicted values.
 
     """
+
+    # critical limit (V_c) = 1.63 / sqrt(N) if N >= 35
+    # where N = number of samples
+
+    Vc = 1.63 / np.sqrt(len(y_true))
+
     return None
 
 
-def combined_performance_index():
+def combined_performance_index(y_true, y_pred):
     """Combined Performance Index (CPI) metric.
 
     Parameters
@@ -267,4 +307,6 @@ def combined_performance_index():
         The CPI between the true and predicted values.
 
     """
+    ksi = kolmogorov_smirnov_integral(y_true, y_pred)
+
     return None

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -234,9 +234,9 @@ def kolmogorov_smirnov_integral(y_true, y_pred, normed=False):
 
     Notes
     -----
-        The calculation of the empirical CDF uses a right endpoint rule (the
-        default of the statsmodels ECDF function). For example, if the data is
-        [1.0, 2.0], then ECDF output is 0.5 for any input less than 1.0.
+    The calculation of the empirical CDF uses a right endpoint rule (the
+    default of the statsmodels ECDF function). For example, if the data is
+    [1.0, 2.0], then ECDF output is 0.5 for any input less than 1.0.
 
     """
 
@@ -278,9 +278,9 @@ def over(y_true, y_pred):
 
     Notes
     -----
-        The calculation of the empirical CDF uses a right endpoint rule (the
-        default of the statsmodels ECDF function). For example, if the data is
-        [1.0, 2.0], then ECDF output is 0.5 for any input less than 1.0.
+    The calculation of the empirical CDF uses a right endpoint rule (the
+    default of the statsmodels ECDF function). For example, if the data is
+    [1.0, 2.0], then ECDF output is 0.5 for any input less than 1.0.
 
     """
 

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -238,7 +238,7 @@ def _estimate_cdf(z, bins=100):
     return x, y
 
 
-def kolmogorov_smirnov_integral(y_true, y_pred):
+def kolmogorov_smirnov_integral(y_true, y_pred, normed=False):
     """Kolmogorov-Smirnov Test Integral (KSI).
 
     Parameters
@@ -247,6 +247,8 @@ def kolmogorov_smirnov_integral(y_true, y_pred):
         True values.
     y_pred : array-like
         Predicted values.
+    normed : bool, optional
+        If True, return the normalized KSI [%].
 
     Returns
     -------
@@ -269,7 +271,13 @@ def kolmogorov_smirnov_integral(y_true, y_pred):
     # compute metric
     D = np.abs(y_o - y_f)
     ksi = np.trapz(D, x=x)
-    return ksi
+
+    if normed:
+        Vc = 1.63 / np.sqrt(len(y_true))
+        a_critical = Vc * (x.max() - x.min())
+        return ksi / a_critical * 100.0
+    else:
+        return ksi
 
 
 def over(y_true, y_pred):

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -238,8 +238,8 @@ def kolmogorov_smirnov_integral(y_true, y_pred, normed=False):
     ecdf_obs = ECDF(y_true)
     ecdf_fx = ECDF(y_pred)
 
-    # evaluate CDFs on forecast range
-    x = np.linspace(np.min(y_pred), np.max(y_pred), 100)
+    # evaluate CDFs
+    x = np.sort(np.concatenate((y_true, y_pred)))
     y_o = ecdf_obs(x)
     y_f = ecdf_fx(x)
 
@@ -276,8 +276,8 @@ def over(y_true, y_pred):
     ecdf_obs = ECDF(y_true)
     ecdf_fx = ECDF(y_pred)
 
-    # evaluate CDFs on forecast range
-    x = np.linspace(np.min(y_pred), np.max(y_pred), 100)
+    # evaluate CDFs
+    x = np.sort(np.concatenate((y_true, y_pred)))
     y_o = ecdf_obs(x)
     y_f = ecdf_fx(x)
 

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -232,6 +232,12 @@ def kolmogorov_smirnov_integral(y_true, y_pred, normed=False):
     ksi : float
         The KSI between the true and predicted values.
 
+    Notes
+    -----
+        The calculation of the empirical CDF uses a right endpoint rule (the
+        default of the statsmodels ECDF function). For example, if the data is
+        [1.0, 2.0], then ECDF output is 0.5 for any input less than 1.0.
+
     """
 
     # empirical CDF
@@ -269,6 +275,12 @@ def over(y_true, y_pred):
     -------
     over : float
         The OVER metric between the true and predicted values.
+
+    Notes
+    -----
+        The calculation of the empirical CDF uses a right endpoint rule (the
+        default of the statsmodels ECDF function). For example, if the data is
+        [1.0, 2.0], then ECDF output is 0.5 for any input less than 1.0.
 
     """
 

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -109,6 +109,7 @@ def test_ksi_norm(y_true, y_pred, value):
 @pytest.mark.parametrize("y_true,y_pred,value", [
     ([0, 1], [0, 1], 0.0),
     ([1, 2], [1, 2], 0.0),
+    ([0, 1, 2, 3, 4], [0, 0, 0, 0, 0], 0.8 - 1.63 / np.sqrt(5)),
 ])
 def test_over(y_true, y_pred, value):
     ov = deterministic.over(y_true, y_pred)

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -87,10 +87,12 @@ def test_crmse(y_true, y_pred, value):
 @pytest.mark.parametrize("y_true,y_pred,value", [
     ([0, 1], [0, 1], 0.0),
     ([1, 2], [1, 2], 0.0),
+    ([0, 1], [0, 2], 0.5),
+    ([0, 1, 2], [0, 0, 2], 1.0 / 6.0),
 ])
 def test_ksi(y_true, y_pred, value):
     ksi = deterministic.kolmogorov_smirnov_integral(y_true, y_pred)
-    assert ksi == value
+    assert pytest.approx(ksi) == value
 
 
 @pytest.mark.parametrize("y_true,y_pred,value", [

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -97,6 +97,15 @@ def test_ksi(y_true, y_pred, value):
     ([0, 1], [0, 1], 0.0),
     ([1, 2], [1, 2], 0.0),
 ])
+def test_ksi_norm(y_true, y_pred, value):
+    ksi = deterministic.kolmogorov_smirnov_integral(y_true, y_pred, normed=True)
+    assert ksi == value
+
+
+@pytest.mark.parametrize("y_true,y_pred,value", [
+    ([0, 1], [0, 1], 0.0),
+    ([1, 2], [1, 2], 0.0),
+])
 def test_over(y_true, y_pred, value):
     ov = deterministic.over(y_true, y_pred)
     assert ov == value

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -120,3 +120,11 @@ def test_over(y_true, y_pred, value):
 def test_cpi(y_true, y_pred, value):
     cpi = deterministic.combined_performance_index(y_true, y_pred)
     assert cpi == value
+
+@pytest.mark.parametrize("x,bins,ecdf", [
+    ([0, 1, 2, 3], [0, 1, 2, 3], [0.25, 0.50, 0.75, 1.00]),
+])
+def test_ecdf(x, bins, ecdf):
+    t, F = deterministic.estimate_cdf(x)
+    assert (t == bins).all()
+    assert (F == ecdf).all()

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -118,7 +118,12 @@ def test_over(y_true, y_pred, value):
 @pytest.mark.parametrize("y_true,y_pred,value", [
     (np.array([0, 1]), np.array([0, 1]), 0.0),
     (np.array([1, 2]), np.array([1, 2]), 0.0),
+    (
+        np.array([0, 1, 2]),
+        np.array([0, 0, 2]),
+        1/4 * (1/3 + 0 + 2 * np.sqrt(1/3))
+    ),
 ])
 def test_cpi(y_true, y_pred, value):
     cpi = deterministic.combined_performance_index(y_true, y_pred)
-    assert cpi == value
+    assert pytest.approx(cpi) == value

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -98,7 +98,9 @@ def test_ksi(y_true, y_pred, value):
     ([1, 2], [1, 2], 0.0),
 ])
 def test_ksi_norm(y_true, y_pred, value):
-    ksi = deterministic.kolmogorov_smirnov_integral(y_true, y_pred, normed=True)
+    ksi = deterministic.kolmogorov_smirnov_integral(
+        y_true, y_pred, normed=True
+    )
     assert ksi == value
 
 

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -88,7 +88,7 @@ def test_crmse(y_true, y_pred, value):
     ([0, 1], [0, 1], 0.0),
     ([1, 2], [1, 2], 0.0),
     ([0, 1], [0, 2], 0.5),
-    ([0, 1, 2], [0, 0, 2], 1.0 / 6.0),
+    ([0, 1, 2], [0, 0, 2], 1.0 / 3.0),
 ])
 def test_ksi(y_true, y_pred, value):
     ksi = deterministic.kolmogorov_smirnov_integral(y_true, y_pred)

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -82,3 +82,30 @@ def test_r2(y_true, y_pred, value):
 def test_crmse(y_true, y_pred, value):
     crmse = deterministic.centered_root_mean_square(y_true, y_pred)
     assert crmse == value
+
+
+@pytest.mark.parametrize("y_true,y_pred,value", [
+    ([0, 1], [0, 1], 0.0),
+    ([1, 2], [1, 2], 0.0),
+])
+def test_ksi(y_true, y_pred, value):
+    ksi = deterministic.kolmogorov_smirnov_integral(y_true, y_pred)
+    assert ksi == value
+
+
+@pytest.mark.parametrize("y_true,y_pred,value", [
+    ([0, 1], [0, 1], 0.0),
+    ([1, 2], [1, 2], 0.0),
+])
+def test_over(y_true, y_pred, value):
+    ov = deterministic.over(y_true, y_pred)
+    assert ov == value
+
+
+@pytest.mark.parametrize("y_true,y_pred,value", [
+    (np.array([0, 1]), np.array([0, 1]), 0.0),
+    (np.array([1, 2]), np.array([1, 2]), 0.0),
+])
+def test_cpi(y_true, y_pred, value):
+    cpi = deterministic.combined_performance_index(y_true, y_pred)
+    assert cpi == value

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -120,11 +120,3 @@ def test_over(y_true, y_pred, value):
 def test_cpi(y_true, y_pred, value):
     cpi = deterministic.combined_performance_index(y_true, y_pred)
     assert cpi == value
-
-@pytest.mark.parametrize("x,bins,ecdf", [
-    ([0, 1, 2, 3], [0, 1, 2, 3], [0.25, 0.50, 0.75, 1.00]),
-])
-def test_ecdf(x, bins, ecdf):
-    t, F = deterministic.estimate_cdf(x)
-    assert (t == bins).all()
-    assert (F == ecdf).all()


### PR DESCRIPTION
  - [x] Closes #229 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Initial attempt at adding the KSI, OVER and CPI metrics for deterministic forecasts. These metrics are based on the (empirical) CDFs of the forecasts and observations, which make it a big more complicated to test (compared to MAE, MBE, etc.).

A couple discussion points:
- Thoughts on the function names? I went with more verbose naming to avoid name conflicts between functions and values (e.g. avoid `ksi = metrics.ksi(y_true, y_pred)`), but the current functions may be too verbose.
- Can someone check that I'm not making a dumb mistake with how I'm computing the empirical CDFs? See the `_estimate_cdf()` function in the `deterministic.py` file for details, but the current code 1) computes the CDFs for the observations and forecasts and then 2) linearly interpolates the two CDFs to the same grid (to enable `CDF_obs - CDF_fx` in the code).
