### PR TITLE
Add aggregates to datamodel

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -47,6 +47,14 @@ Probabilistic forecasts:
    datamodel.ProbabilisticForecast
    datamodel.ProbabilisticForecastConstantValue
 
+Aggregates:
+
+.. autosummary::
+   :toctree: generated/
+
+   datamodel.AggregateObservation
+   datamodel.Aggregate
+
 All :py:mod:`~solarforecastarbiter.datamodel` objects have ``from_dict`` and
 ``to_dict`` methods:
 
@@ -286,7 +294,6 @@ Forecasts
    io.api.APISession.post_forecast_values
 
 Probabilistic Forecasts
------------------------
 
 .. autosummary::
    :toctree: generated/
@@ -297,6 +304,16 @@ Probabilistic Forecasts
    io.api.APISession.get_probabilistic_forecast_constant_value
    io.api.APISession.get_probabilistic_forecast_constant_value_values
    io.api.APISession.post_probabilistic_forecast_constant_value_values
+
+Aggregates
+
+.. autosummary::
+   :toctree: generated/
+
+   io.api.APISession.get_aggregate
+   io.api.APISession.list_aggregates
+   io.api.APISession.create_aggregate
+   io.api.APISession.get_aggregate_values
 
 Utils
 -----

--- a/docs/source/whatsnew/1.0.0b2.rst
+++ b/docs/source/whatsnew/1.0.0b2.rst
@@ -17,7 +17,6 @@ API Changes
   either a Site or an Aggregate, and add corresponding Aggregate
   methods to the APISession (:pull:`235`)
 
-======= end
 
 Enhancements
 ~~~~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0b2.rst
+++ b/docs/source/whatsnew/1.0.0b2.rst
@@ -13,6 +13,11 @@ API Changes
   :py:mod:`solarforecastarbiter.metrics.preprocessing.resample_and_align`, and
   :py:mod:`solarforecastarbiter.metrics.preprocessing.exclude`. (:pull:`221`)
 * Moved temporary functions from report to metrics calculator. (:pull:`221`)
+* Add Aggregate to the datamodel, allow forecasts to reference
+  either a Site or an Aggregate, and add corresponding Aggregate
+  methods to the APISession (:pull:`235`)
+
+======= end
 
 Enhancements
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1144,11 +1144,18 @@ def aggregate_text():
 def aggregate_observations(aggregate_text, many_observations):
     obsd = {o.observation_id: o for o in many_observations}
     aggd = json.loads(aggregate_text)
+
+    def _tstamp(val):
+        if val is None:
+            return val
+        else:
+            return pd.Timestamp(val)
+
     aggobs = tuple([datamodel.AggregateObservation(
         observation=obsd[o['observation_id']],
-        effective_from=o['effective_from'],
-        effective_until=o['effective_until'],
-        observation_deleted_at=o['observation_deleted_at'])
+        effective_from=_tstamp(o['effective_from']),
+        effective_until=_tstamp(o['effective_until']),
+        observation_deleted_at=_tstamp(o['observation_deleted_at']))
                     for o in aggd['observations']])
     return aggobs
 

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -664,7 +664,8 @@ def single_forecast_text():
     return b"""
 {
   "_links": {
-    "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440002"
+    "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440002",
+    "aggregate": null
   },
   "created_at": "2019-03-01T11:55:37+00:00",
   "extra_parameters": "",
@@ -679,6 +680,7 @@ def single_forecast_text():
   "provider": "Organization 1",
   "run_length": 1440,
   "site_id": "123e4567-e89b-12d3-a456-426655440002",
+  "aggregate_id": null,
   "variable": "ghi"
 }
 """
@@ -690,7 +692,8 @@ def many_forecasts_text():
 [
   {
     "_links": {
-      "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440001"
+      "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440001",
+      "aggregate": null
     },
     "created_at": "2019-03-01T11:55:37+00:00",
     "extra_parameters": "",
@@ -705,11 +708,13 @@ def many_forecasts_text():
     "provider": "Organization 1",
     "run_length": 1440,
     "site_id": "123e4567-e89b-12d3-a456-426655440001",
+    "aggregate_id": null,
     "variable": "ghi"
   },
   {
     "_links": {
-      "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440002"
+      "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440002",
+      "aggregate": null
     },
     "created_at": "2019-03-01T11:55:38+00:00",
     "extra_parameters": "",
@@ -724,6 +729,7 @@ def many_forecasts_text():
     "provider": "Organization 1",
     "run_length": 60,
     "site_id": "123e4567-e89b-12d3-a456-426655440002",
+    "aggregate_id": null,
     "variable": "ac_power"
   }
 ]
@@ -764,7 +770,8 @@ def prob_forecast_constant_value_text():
     return b"""
 {
   "_links": {
-    "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440002"
+    "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440002",
+    "aggregate": null
   },
   "created_at": "2019-03-01T11:55:37+00:00",
   "extra_parameters": "",
@@ -779,6 +786,7 @@ def prob_forecast_constant_value_text():
   "provider": "Organization 1",
   "run_length": 1440,
   "site_id": "123e4567-e89b-12d3-a456-426655440002",
+  "aggregate_id": null,
   "variable": "ghi",
   "axis": "x",
   "constant_value": 0
@@ -791,7 +799,8 @@ def prob_forecast_text():
     return b"""
 {
     "_links": {
-      "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440001"
+      "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440001",
+      "aggregate": null
     },
     "created_at": "2019-03-01T11:55:37+00:00",
     "extra_parameters": "",
@@ -806,6 +815,7 @@ def prob_forecast_text():
     "provider": "Organization 1",
     "run_length": 1440,
     "site_id": "123e4567-e89b-12d3-a456-426655440002",
+    "aggregate_id": null,
     "variable": "ghi",
     "axis": "x",
     "constant_values": [
@@ -825,7 +835,8 @@ def many_prob_forecasts_text():
 [
     {
         "_links": {
-        "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440001"
+          "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440001",
+          "aggregate": null
         },
         "created_at": "2019-03-01T11:55:37+00:00",
         "extra_parameters": "",
@@ -840,6 +851,7 @@ def many_prob_forecasts_text():
         "provider": "Organization 1",
         "run_length": 1440,
         "site_id": "123e4567-e89b-12d3-a456-426655440002",
+        "aggregate_id": null,
         "variable": "ghi",
         "axis": "x",
         "constant_values": [
@@ -852,7 +864,8 @@ def many_prob_forecasts_text():
     },
     {
         "_links": {
-        "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440001"
+          "site": "http://127.0.0.1:5000/sites/123e4567-e89b-12d3-a456-426655440001",
+          "aggregate": null
         },
         "created_at": "2019-03-01T11:55:37+00:00",
         "extra_parameters": "",
@@ -867,6 +880,7 @@ def many_prob_forecasts_text():
         "provider": "Organization 1",
         "run_length": 1440,
         "site_id": "123e4567-e89b-12d3-a456-426655440002",
+        "aggregate_id": null,
         "variable": "ghi",
         "axis": "x",
         "constant_values": [
@@ -1171,3 +1185,112 @@ def aggregate(aggregate_text, aggregate_observations):
         timezone=aggd['timezone'], aggregate_id=aggd['aggregate_id'],
         provider=aggd['provider'], extra_parameters=aggd['extra_parameters'],
         observations=aggregate_observations)
+
+
+@pytest.fixture()
+def aggregate_forecast_text():
+    return b"""
+{
+  "_links": {
+    "site": null,
+    "aggregate": "http://localhost:5000/aggregates/458ffc27-df0b-11e9-b622-62adb5fd6af0"
+  },
+  "aggregate_id": "458ffc27-df0b-11e9-b622-62adb5fd6af0",
+  "created_at": "2019-03-01T11:55:37+00:00",
+  "extra_parameters": "",
+  "forecast_id": "39220780-76ae-4b11-bef1-7a75bdc784e3",
+  "interval_label": "beginning",
+  "interval_length": 5,
+  "interval_value_type": "interval_mean",
+  "issue_time_of_day": "06:00",
+  "lead_time_to_start": 60,
+  "modified_at": "2019-03-01T11:55:37+00:00",
+  "name": "GHI Aggregate FX",
+  "provider": "Organization 1",
+  "run_length": 1440,
+  "site_id": null,
+  "variable": "ghi"
+}
+"""  # NOQA
+
+
+@pytest.fixture()
+def aggregateforecast(aggregate_forecast_text, aggregate):
+    fx_dict = json.loads(aggregate_forecast_text)
+    return datamodel.Forecast(
+        name=fx_dict['name'], variable=fx_dict['variable'],
+        interval_value_type=fx_dict['interval_value_type'],
+        interval_length=pd.Timedelta(f"{fx_dict['interval_length']}min"),
+        interval_label=fx_dict['interval_label'],
+        aggregate=aggregate,
+        issue_time_of_day=dt.time(int(fx_dict['issue_time_of_day'][:2]),
+                                  int(fx_dict['issue_time_of_day'][3:])),
+        lead_time_to_start=pd.Timedelta(f"{fx_dict['lead_time_to_start']}min"),  # NOQA
+        run_length=pd.Timedelta(f"{fx_dict['run_length']}min"),
+        forecast_id=fx_dict.get('forecast_id', ''),
+        extra_parameters=fx_dict.get('extra_parameters', ''))
+
+
+@pytest.fixture()
+def aggregate_prob_forecast_text():
+    return b"""
+{
+    "_links": {
+      "site": null,
+      "aggregate": "http://127.0.0.1:5000/aggregates/458ffc27-df0b-11e9-b622-62adb5fd6af0"
+    },
+    "created_at": "2019-03-02T14:55:38+00:00",
+    "extra_parameters": "",
+    "forecast_id": "f6b620ca-f743-11e9-a34f-f4939feddd82",
+    "interval_label": "beginning",
+    "interval_length": 5,
+    "interval_value_type": "interval_mean",
+    "issue_time_of_day": "06:00",
+    "lead_time_to_start": 60,
+    "modified_at": "2019-03-02T14:55:38+00:00",
+    "name": "GHI Aggregate CDF FX",
+    "provider": "Organization 1",
+    "run_length": 1440,
+    "site_id": null,
+    "variable": "ghi",
+    "aggregate_id": "458ffc27-df0b-11e9-b622-62adb5fd6af0",
+    "axis": "y",
+    "constant_values": [
+      {
+        "_links": {
+          "values": "http://localhost:5000/forecasts/cdf/single/733f9396-50bb-11e9-8647-d663bd873d93/values"
+        },
+        "constant_value": 10.0,
+        "forecast_id": "733f9396-50bb-11e9-8647-d663bd873d93"
+      },
+      {
+        "_links": {
+          "values": "http://localhost:5000/forecasts/cdf/single/733f9864-50bb-11e9-8647-d663bd873d93/values"
+        },
+        "constant_value": 20.0,
+        "forecast_id": "733f9864-50bb-11e9-8647-d663bd873d93"
+      },
+      {
+        "_links": {
+          "values": "http://localhost:5000/forecasts/cdf/single/733f9b2a-50bb-11e9-8647-d663bd873d93/values"
+        },
+        "constant_value": 50.0,
+        "forecast_id": "733f9b2a-50bb-11e9-8647-d663bd873d93"
+      },
+      {
+        "_links": {
+          "values": "http://localhost:5000/forecasts/cdf/single/733f9d96-50bb-11e9-8647-d663bd873d93/values"
+        },
+        "constant_value": 80.0,
+        "forecast_id": "733f9d96-50bb-11e9-8647-d663bd873d93"
+      },
+      {
+        "_links": {
+          "values": "http://localhost:5000/forecasts/cdf/single/733fa548-50bb-11e9-8647-d663bd873d93/values"
+        },
+        "constant_value": 100.0,
+        "forecast_id": "733fa548-50bb-11e9-8647-d663bd873d93"
+      }
+    ],
+}
+"""  # NOQA

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1254,43 +1254,34 @@ def aggregate_prob_forecast_text():
     "site_id": null,
     "variable": "ghi",
     "aggregate_id": "458ffc27-df0b-11e9-b622-62adb5fd6af0",
-    "axis": "y",
+    "axis": "x",
     "constant_values": [
-      {
-        "_links": {
-          "values": "http://localhost:5000/forecasts/cdf/single/733f9396-50bb-11e9-8647-d663bd873d93/values"
-        },
-        "constant_value": 10.0,
-        "forecast_id": "733f9396-50bb-11e9-8647-d663bd873d93"
-      },
-      {
-        "_links": {
-          "values": "http://localhost:5000/forecasts/cdf/single/733f9864-50bb-11e9-8647-d663bd873d93/values"
-        },
-        "constant_value": 20.0,
-        "forecast_id": "733f9864-50bb-11e9-8647-d663bd873d93"
-      },
-      {
-        "_links": {
-          "values": "http://localhost:5000/forecasts/cdf/single/733f9b2a-50bb-11e9-8647-d663bd873d93/values"
-        },
-        "constant_value": 50.0,
-        "forecast_id": "733f9b2a-50bb-11e9-8647-d663bd873d93"
-      },
-      {
-        "_links": {
-          "values": "http://localhost:5000/forecasts/cdf/single/733f9d96-50bb-11e9-8647-d663bd873d93/values"
-        },
-        "constant_value": 80.0,
-        "forecast_id": "733f9d96-50bb-11e9-8647-d663bd873d93"
-      },
-      {
-        "_links": {
-          "values": "http://localhost:5000/forecasts/cdf/single/733fa548-50bb-11e9-8647-d663bd873d93/values"
-        },
-        "constant_value": 100.0,
-        "forecast_id": "733fa548-50bb-11e9-8647-d663bd873d93"
-      }
-    ],
+        {
+            "_links": {},
+            "constant_value": 0,
+            "forecast_id": "11c20780-76ae-4b11-bef1-7a75bdc784e3"
+        }
+    ]
 }
 """  # NOQA
+
+
+@pytest.fixture()
+def aggregate_prob_forecast(prob_forecast_constant_value,
+                            aggregate_prob_forecast_text,
+                            aggregate):
+    fx_dict = json.loads(aggregate_prob_forecast_text)
+    return datamodel.ProbabilisticForecast(
+        name=fx_dict['name'], variable=fx_dict['variable'],
+        interval_value_type=fx_dict['interval_value_type'],
+        interval_length=pd.Timedelta(f"{fx_dict['interval_length']}min"),
+        interval_label=fx_dict['interval_label'],
+        aggregate=aggregate,
+        issue_time_of_day=dt.time(int(fx_dict['issue_time_of_day'][:2]),
+                                  int(fx_dict['issue_time_of_day'][3:])),
+        lead_time_to_start=pd.Timedelta(f"{fx_dict['lead_time_to_start']}min"),  # NOQA
+        run_length=pd.Timedelta(f"{fx_dict['run_length']}min"),
+        forecast_id=fx_dict.get('forecast_id', ''),
+        extra_parameters=fx_dict.get('extra_parameters', ''),
+        axis=fx_dict['axis'],
+        constant_values=(prob_forecast_constant_value, ))

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1093,22 +1093,22 @@ def aggregate_text():
 {
   "aggregate_id": "458ffc27-df0b-11e9-b622-62adb5fd6af0",
   "aggregate_type": "mean",
-  "created_at": "2019-09-24T12:00:00",
+  "created_at": "2019-09-24T12:00:00+00:00",
   "description": "ghi agg",
   "extra_parameters": "extra",
   "interval_label": "ending",
   "interval_length": 60,
   "interval_value_type": "interval_mean",
-  "modified_at": "2019-09-24T12:00:00",
+  "modified_at": "2019-09-24T12:00:00+00:00",
   "name": "Test Aggregate ghi",
   "observations": [
     {
       "_links": {
         "observation": "http://localhost:5000/observations/123e4567-e89b-12d3-a456-426655440000/metadata"
       },
-      "created_at": "2019-09-25T00:00:00",
-      "effective_from": "2019-01-01T00:00:00",
-      "effective_until": "2020-01-01T00:00:00",
+      "created_at": "2019-09-25T00:00:00+00:00",
+      "effective_from": "2019-01-01T00:00:00+00:00",
+      "effective_until": "2020-01-01T00:00:00+00:00",
       "observation_deleted_at": null,
       "observation_id": "123e4567-e89b-12d3-a456-426655440000"
     },
@@ -1116,8 +1116,8 @@ def aggregate_text():
       "_links": {
         "observation": "http://localhost:5000/observations/e0da0dea-9482-4073-84de-f1b12c304d23/metadata"
       },
-      "created_at": "2019-09-25T00:00:00",
-      "effective_from": "2019-01-01T00:00:00",
+      "created_at": "2019-09-25T00:00:00+00:00",
+      "effective_from": "2019-01-01T00:00:00+00:00",
       "effective_until": null,
       "observation_deleted_at": null,
       "observation_id": "e0da0dea-9482-4073-84de-f1b12c304d23"
@@ -1126,8 +1126,8 @@ def aggregate_text():
       "_links": {
         "observation": "http://localhost:5000/observations/b1dfe2cb-9c8e-43cd-afcf-c5a6feaf81e2/metadata"
       },
-      "created_at": "2019-09-25T00:00:00",
-      "effective_from": "2019-01-01T00:00:00",
+      "created_at": "2019-09-25T00:00:00+00:00",
+      "effective_from": "2019-01-01T00:00:00+00:00",
       "effective_until": null,
       "observation_deleted_at": null,
       "observation_id": "b1dfe2cb-9c8e-43cd-afcf-c5a6feaf81e2"

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -351,7 +351,17 @@ def get_site(many_sites):
     site_dict = {site.site_id: site for site in many_sites}
 
     def get(site_id):
-        return site_dict[site_id]
+        return site_dict.get(site_id, None)
+    return get
+
+
+@pytest.fixture()
+def get_aggregate(aggregate):
+    def get(agg_id):
+        if agg_id is None:
+            return None
+        else:
+            return aggregate
     return get
 
 
@@ -731,20 +741,42 @@ def many_forecasts_text():
     "site_id": "123e4567-e89b-12d3-a456-426655440002",
     "aggregate_id": null,
     "variable": "ac_power"
+  },
+  {
+    "_links": {
+      "site": null,
+      "aggregate": "http://localhost:5000/aggregates/458ffc27-df0b-11e9-b622-62adb5fd6af0"
+    },
+    "aggregate_id": "458ffc27-df0b-11e9-b622-62adb5fd6af0",
+    "created_at": "2019-03-01T11:55:37+00:00",
+    "extra_parameters": "",
+    "forecast_id": "39220780-76ae-4b11-bef1-7a75bdc784e3",
+    "interval_label": "beginning",
+    "interval_length": 5,
+    "interval_value_type": "interval_mean",
+    "issue_time_of_day": "06:00",
+    "lead_time_to_start": 60,
+    "modified_at": "2019-03-01T11:55:37+00:00",
+    "name": "GHI Aggregate FX",
+    "provider": "Organization 1",
+    "run_length": 1440,
+    "site_id": null,
+    "variable": "ghi"
   }
 ]
 """  # NOQA
 
 
 @pytest.fixture()
-def _forecast_from_dict(single_site, get_site):
+def _forecast_from_dict(single_site, get_site, get_aggregate):
     def f(fx_dict):
         return datamodel.Forecast(
             name=fx_dict['name'], variable=fx_dict['variable'],
             interval_value_type=fx_dict['interval_value_type'],
             interval_length=pd.Timedelta(f"{fx_dict['interval_length']}min"),
             interval_label=fx_dict['interval_label'],
-            site=get_site(fx_dict['site_id']),
+            site=get_site(fx_dict.get('site_id')),
+            aggregate=get_aggregate(fx_dict.get('aggregate_id')),
             issue_time_of_day=dt.time(int(fx_dict['issue_time_of_day'][:2]),
                                       int(fx_dict['issue_time_of_day'][3:])),
             lead_time_to_start=pd.Timedelta(f"{fx_dict['lead_time_to_start']}min"),  # NOQA

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -868,6 +868,15 @@ class AggregateObservation(BaseModel):
     effective_until: Union[pd.Timestamp, None] = None
     observation_deleted_at: Union[pd.Timestamp, None] = None
 
+    def _special_field_processing(self, model_field, val):
+        if model_field.name in ('effective_until', 'observation_deleted_at'):
+            if val is None:
+                return val
+            else:
+                return pd.Timestamp(val)
+        else:
+            return val
+
 
 def __check_variable__(variable, *args):
     if not all(arg.variable == variable for arg in args):

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -879,16 +879,16 @@ class AggregateObservation(BaseModel):
 
 
 def __check_variable__(variable, *args):
-    if not all(arg.variable == variable for arg in args):
+    if not all(arg.variable == variable for arg in args if arg is not None):
         raise ValueError('All variables must be identical.')
 
 
 def __check_aggregate_interval_compatibility__(interval, *args):
-    if any(arg.interval_length > interval for arg in args):
+    if any(arg.interval_length > interval for arg in args if arg is not None):
         raise ValueError('observation.interval_length cannot be greater than '
                          'aggregate.interval_length.')
     if any(arg.interval_value_type not in ('interval_mean', 'instantaneous')
-           for arg in args):
+           for arg in args if arg is not None):
         raise ValueError('Only observations with interval_value_type of '
                          'interval_mean or instantaneous are acceptable')
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -874,7 +874,7 @@ class AggregateObservation(BaseModel):
                 return val
             else:
                 return pd.Timestamp(val)
-        else:
+        else:  # pragma: no cover
             return val
 
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -833,3 +833,118 @@ class Report(BaseModel):
             ((k.forecast, k.observation) for k in self.forecast_observations)))
         # ensure the metrics can be applied to the forecasts and observations
         __check_metrics__()
+
+
+@dataclass(frozen=True)
+class AggregateObservation(BaseModel):
+    """
+    Class for keeping track of Observations in Aggregates
+    and when they are added and removed from the Aggregate
+
+    Parameters
+    ----------
+    observation : Observation
+        The Observation object that is part of the Aggregate
+    effective_from : pandas.Timestamp
+        The effective datetime of when the Observation should be
+        included in the Aggregate
+    effective_until : pandas.Timestamp
+        The effective datetime of when the Observation should be
+        excluded from the Aggregate
+    observation_deleted_at : pandas.Timestamp
+        The datetime that the Observation was deleted from the
+        Arbiter. This indicates that the Observation should be
+        removed from the Aggregate, and without the data
+        from this Observation, the Aggregate is invalid before
+        this time.
+
+    See Also
+    --------
+    Observation
+    Aggregate
+    """
+    observation: Observation
+    effective_from: pd.Timestamp
+    effective_until: Union[pd.Timestamp, None] = None
+    observation_deleted_at: Union[pd.Timestamp, None] = None
+
+
+def __check_variable__(variable, *args):
+    if not all(arg.variable == variable for arg in args):
+        raise ValueError('All variables must be identical.')
+
+
+def __check_aggregate_interval_compatibility__(interval, *args):
+    if any(arg.interval_length > interval for arg in args):
+        raise ValueError('observation.interval_length cannot be greater than '
+                         'aggregate.interval_length.')
+    if any(arg.interval_value_type not in ('interval_mean', 'instantaneous')
+           for arg in args):
+        raise ValueError('Only observations with interval_value_type of '
+                         'interval_mean or instantaneous are acceptable')
+
+
+@dataclass(frozen=True)
+class Aggregate(BaseModel):
+    """
+    Class for keeping track of Aggregate metadata.
+
+    Parameters
+    ----------
+    name : str
+        Name of the Aggregate, e.g. Utility X Solar PV
+    description : str
+        A description of what the aggregate is.
+    variable : str
+        Variable name, e.g. power, GHI. Each allowed variable has an
+        associated pre-defined unit. All observations that make up the
+        Aggregate must also have this variable.
+    aggregate_type : str
+        The aggregation function that will be applied to observations.
+        Generally, this will be 'sum' although one might be interested,
+        for example, in the 'mean' irradiance of some observations.
+    interval_length : pandas.Timedelta
+        The length of time between consecutive data points, e.g. 5 minutes,
+        1 hour. This must be >= any observations that will make up the
+        Aggregate.
+    interval_label : str
+        Indicates if a time labels the beginning or the ending of an interval
+        average.
+    timezone : str
+        IANA timezone of the Aggregate, e.g. Etc/GMT+8
+    aggregate_id : str, optional
+        UUID of the Aggregate in the API
+    provider : str, optional
+        Provider of the Aggregate information.
+    extra_parameters : str, optional
+        Any extra parameters for the Aggregate.
+    observations : tuple of AggregateObservation
+        The Observations that contribute to the Aggregate
+
+    See Also
+    --------
+    Observation
+    """
+    name: str
+    description: str
+    variable: str
+    aggregate_type: str
+    interval_length: pd.Timedelta
+    interval_label: str
+    timezone: str
+    observations: Tuple[AggregateObservation, ...]
+    aggregate_id: str = ''
+    provider: str = ''
+    extra_parameters: str = ''
+    units: str = field(init=False)
+    interval_value_type: str = field(default='interval_mean')
+
+    def __post_init__(self):
+        __set_units__(self)
+        __check_variable__(
+            self.variable,
+            *(ao.observation for ao in self.observations))
+        __check_aggregate_interval_compatibility__(
+            self.interval_length,
+            *(ao.observation for ao in self.observations))
+        object.__setattr__(self, 'interval_value_type', 'interval_mean')

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -819,7 +819,7 @@ class APISession(requests.Session):
         out = []
         for agg_dict in agg_dicts:
             for o in agg_dict['observations']:
-                o['observation'] = observations[o['observation_id']]
+                o['observation'] = observations.get(o['observation_id'])
             out.append(datamodel.Aggregate.from_dict(agg_dict))
         return out
 

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -867,7 +867,7 @@ class APISession(requests.Session):
         Returns
         -------
         datamodel.Aggregate
-            With the appropriate parameters such as aggregate_id set by the API
+            With the parameters aggregate_id and provider set by the API.
         """
         agg_dict = aggregate.to_dict()
         agg_dict.pop('aggregate_id')
@@ -909,7 +909,7 @@ class APISession(requests.Session):
         end : timelike object
             End time of the interval
         interval_label : str or None
-            If beginning, ending, adjust the data to return only data that is
+            If beginning or ending, return only data that is
             valid between start and end. If None, return any data
             between start and end inclusive of the endpoints.
 

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -285,14 +285,13 @@ class APISession(requests.Session):
         -------
         datamodel.Forecast
             With the appropriate parameters such as forecast_id set by the API
+
         """
         fx_dict = forecast.to_dict()
         fx_dict.pop('forecast_id')
         site = fx_dict.pop('site')
         agg = fx_dict.pop('aggregate')
-        if site is None and agg is None:
-            raise ValueError('Both site and aggregate are None')
-        elif site is None and agg is not None:
+        if site is None and agg is not None:
             fx_dict['aggregate_id'] = agg['aggregate_id']
         else:
             fx_dict['site_id'] = site['site_id']
@@ -430,9 +429,7 @@ class APISession(requests.Session):
         fx_dict.pop('forecast_id')
         site = fx_dict.pop('site')
         agg = fx_dict.pop('aggregate')
-        if site is None and agg is None:
-            raise ValueError('Both site and aggregate are None')
-        elif site is None and agg is not None:
+        if site is None and agg is not None:
             fx_dict['aggregate_id'] = agg['aggregate_id']
         else:
             fx_dict['site_id'] = site['site_id']

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -773,8 +773,7 @@ def test_apisession_create_aggregate(requests_mock, aggregate, aggregate_text,
                 'effective_from' in rj['observations'][0]
                 or 'effective_until' in rj['observations'][0])
 
-    requests_mock.register_uri('POST', matcher,
-                               text=callback)
+    requests_mock.register_uri('POST', matcher, text=callback)
     requests_mock.register_uri('GET', matcher, content=aggregate_text)
     aggregate_dict = aggregate.to_dict()
     del aggregate_dict['aggregate_id']

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -934,13 +934,11 @@ def test_real_apisession_post_prob_forecast_constant_val_values(real_session):
     pdt.assert_series_equal(fx, test_ser)
 
 
-@pytest.mark.xfail(raises=requests.exceptions.HTTPError, strict=True)
 def test_real_apisession_get_aggregate(real_session):
     agg = real_session.get_aggregate('458ffc27-df0b-11e9-b622-62adb5fd6af0')
     assert isinstance(agg, datamodel.Aggregate)
 
 
-@pytest.mark.xfail(raises=requests.exceptions.HTTPError, strict=True)
 def test_real_apisession_list_aggregates(real_session):
     aggs = real_session.list_aggregates()
     assert {a.aggregate_id for a in aggs} == {
@@ -948,16 +946,21 @@ def test_real_apisession_list_aggregates(real_session):
         'd3d1e8e5-df1b-11e9-b622-62adb5fd6af0'}
 
 
-@pytest.mark.xfail(raises=requests.exceptions.HTTPError, strict=True)
 def test_real_apisession_create_aggregate(real_session, aggregate):
     new_agg = real_session.create_aggregate(aggregate)
-    for attr in ('name', 'descxription', 'variable', 'aggregate_type',
-                 'interval_length', 'interval_label', 'timezone',
-                 'obaservations'):
+    for attr in ('name', 'description', 'variable', 'aggregate_type',
+                 'interval_length', 'interval_label', 'timezone'):
         assert getattr(new_agg, attr) == getattr(aggregate, attr)
+    for i, obs in enumerate(new_agg.observations):
+        assert (
+            aggregate.observations[i].observation.observation_id ==
+            obs.observation.observation_id)
+        for attr in ('effective_from', 'effective_until',
+                     'observation_deleted_at'):
+            assert getattr(aggregate.observations[i], attr) == (
+                getattr(obs, attr))
 
 
-@pytest.mark.xfail(raises=requests.exceptions.HTTPError, strict=True)
 def test_real_apisession_get_aggregate_values(real_session):
     start = pd.Timestamp('2019-04-15T00:00:00Z')
     end = pd.Timestamp('2019-04-15T12:00:00Z')

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -947,9 +947,10 @@ def test_real_apisession_get_aggregate(real_session):
 
 def test_real_apisession_list_aggregates(real_session):
     aggs = real_session.list_aggregates()
-    assert {a.aggregate_id for a in aggs} == {
-        '458ffc27-df0b-11e9-b622-62adb5fd6af0',
-        'd3d1e8e5-df1b-11e9-b622-62adb5fd6af0'}
+    assert isinstance(aggs, list)
+    assert isinstance(aggs[0], datamodel.Aggregate)
+    assert s'458ffc27-df0b-11e9-b622-62adb5fd6af0' in {
+        a.aggregate_id for a in aggs}
 
 
 def test_real_apisession_create_aggregate(real_session, aggregate):

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -79,7 +79,25 @@ def mock_get_site(requests_mock, site_text, many_sites_text):
 
 
 @pytest.fixture()
-def mock_get_agg(requests_mock, aggregate_text):
+def mock_get_observation(requests_mock, many_observations_text):
+    def get_observation_from_text(request, context):
+        obs_id = request.url.split('/')[-2]
+        if obs_id == '':
+            return many_observations_text
+        else:
+            obs = json.loads(many_observations_text)
+            for ob in obs:
+                if ob['observation_id'] == obs_id:
+                    return json.dumps(ob).encode('utf-8')
+
+    matcher = re.compile(
+        'https://api.solarforecastarbiter.org/observations/.*/metadata')
+    requests_mock.register_uri(
+        'GET', matcher, content=get_observation_from_text)
+
+
+@pytest.fixture()
+def mock_get_agg(requests_mock, aggregate_text, mock_get_observation):
     matcher = re.compile(f'https://api.solarforecastarbiter.org/aggregates/.*')
     requests_mock.register_uri('GET', matcher, content=aggregate_text)
 

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -79,6 +79,12 @@ def mock_get_site(requests_mock, site_text, many_sites_text):
 
 
 @pytest.fixture()
+def mock_get_agg(requests_mock, aggregate_text):
+    matcher = re.compile(f'https://api.solarforecastarbiter.org/aggregates/.*')
+    requests_mock.register_uri('GET', matcher, content=aggregate_text)
+
+
+@pytest.fixture()
 def mock_list_sites(mocker, many_sites):
     mocker.patch('solarforecastarbiter.io.api.APISession.list_sites',
                  return_value=many_sites)
@@ -180,7 +186,8 @@ def test_apisession_get_forecast(requests_mock, single_forecast,
 
 
 def test_apisession_list_forecasts(requests_mock, many_forecasts,
-                                   many_forecasts_text, mock_list_sites):
+                                   many_forecasts_text, mock_get_site,
+                                   mock_get_agg):
     session = api.APISession('')
     matcher = re.compile(f'{session.base_url}/forecasts/.*')
     requests_mock.register_uri('GET', matcher, content=many_forecasts_text)
@@ -189,7 +196,8 @@ def test_apisession_list_forecasts(requests_mock, many_forecasts,
 
 
 def test_apisession_create_forecast(requests_mock, single_forecast,
-                                    single_forecast_text, mock_get_site):
+                                    single_forecast_text, mock_get_site,
+                                    mock_get_agg):
     session = api.APISession('')
     matcher = re.compile(f'{session.base_url}/forecasts/single/.*')
     requests_mock.register_uri('POST', matcher,
@@ -949,7 +957,7 @@ def test_real_apisession_list_aggregates(real_session):
     aggs = real_session.list_aggregates()
     assert isinstance(aggs, list)
     assert isinstance(aggs[0], datamodel.Aggregate)
-    assert s'458ffc27-df0b-11e9-b622-62adb5fd6af0' in {
+    assert '458ffc27-df0b-11e9-b622-62adb5fd6af0' in {
         a.aggregate_id for a in aggs}
 
 

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -83,7 +83,7 @@ def mock_get_observation(requests_mock, many_observations_text,
                          mock_get_site):
     def get_observation_from_text(request, context):
         obs_id = request.url.split('/')[-2]
-        if obs_id == '':
+        if obs_id == '':  # pragma: no cover
             return many_observations_text
         else:
             obs = json.loads(many_observations_text)

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -254,7 +254,7 @@ def test_report_defaults(report_objects):
 @pytest.mark.parametrize('key,val', [
     ('interval_length', pd.Timedelta('2h')),
     ('interval_value_type', 'interval_max'),
-    ('variable', 'dni')
+    ('variable', 'ghi')
 ])
 def test_aggregate_invalid(single_observation, key, val):
     obsd = single_observation.to_dict()
@@ -264,7 +264,7 @@ def test_aggregate_invalid(single_observation, key, val):
         obs, pd.Timestamp.utcnow())
     with pytest.raises(ValueError):
         datamodel.Aggregate(
-            'test', 'testd', 'ghi', 'mean', pd.Timedelta('1h'),
+            'test', 'testd', 'dni', 'mean', pd.Timedelta('1h'),
             'ending', 'America/Denver',
             observations=(aggobs,)
         )

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -1,6 +1,5 @@
 from dataclasses import fields, MISSING, dataclass
 import json
-from typing import Union
 
 
 import pandas as pd

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -23,7 +23,8 @@ def pdid_params(request, many_sites, many_sites_text, single_observation,
                 aggregate, aggregate_observations,
                 aggregate_text, aggregate_forecast_text,
                 aggregateforecast, aggregate_prob_forecast,
-                aggregate_prob_forecast_text):
+                aggregate_prob_forecast_text,
+                agg_prob_forecast_constant_value):
     if request.param == 'site':
         return (many_sites[0], json.loads(many_sites_text)[0],
                 datamodel.Site)
@@ -74,7 +75,7 @@ def pdid_params(request, many_sites, many_sites_text, single_observation,
     elif request.param == 'aggregateprobforecast':
         fx_dict = json.loads(aggregate_prob_forecast_text)
         fx_dict['aggregate'] = aggregate.to_dict()
-        fx_dict['constant_values'] = (prob_forecast_constant_value, )
+        fx_dict['constant_values'] = (agg_prob_forecast_constant_value, )
         return (aggregate_prob_forecast, fx_dict,
                 datamodel.ProbabilisticForecast)
 

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -14,7 +14,7 @@ from solarforecastarbiter import datamodel
                         'forecast', 'forecastobservation',
                         'probabilisticforecastconstantvalue',
                         'probabilisticforecast', 'aggregate',
-                        'aggregateforecast'])
+                        'aggregateforecast', 'aggregateprobforecast'])
 def pdid_params(request, many_sites, many_sites_text, single_observation,
                 single_observation_text, single_site,
                 single_forecast_text, single_forecast,
@@ -23,7 +23,8 @@ def pdid_params(request, many_sites, many_sites_text, single_observation,
                 prob_forecasts, prob_forecast_text,
                 aggregate, aggregate_observations,
                 aggregate_text, aggregate_forecast_text,
-                aggregateforecast):
+                aggregateforecast, aggregate_prob_forecast,
+                aggregate_prob_forecast_text):
     if request.param == 'site':
         return (many_sites[0], json.loads(many_sites_text)[0],
                 datamodel.Site)
@@ -71,6 +72,12 @@ def pdid_params(request, many_sites, many_sites_text, single_observation,
         aggfx_dict = json.loads(aggregate_forecast_text)
         aggfx_dict['aggregate'] = aggregate.to_dict()
         return (aggregateforecast, aggfx_dict, datamodel.Forecast)
+    elif request.param == 'aggregateprobforecast':
+        fx_dict = json.loads(aggregate_prob_forecast_text)
+        fx_dict['aggregate'] = aggregate.to_dict()
+        fx_dict['constant_values'] = (prob_forecast_constant_value, )
+        return (aggregate_prob_forecast, fx_dict,
+                datamodel.ProbabilisticForecast)
 
 
 @pytest.mark.parametrize('extra', [


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #61  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Adds the aggregate object to the datamodel. We'll also need to allow forecasts to reference an aggregate instead of a site. The question is how should we do that? One option is to add aggregate as a parameter and then either site or aggregate will be None (or some missing value), or make a new AggregateForecast object where aggregate replaces site. I'm leaning towards a separate object (and separate probabilistic object) since processing an aggregate forecast will be quite different in e.g. making a report. Thoughts @wholmgren 
