### PR TITLE
fix processed fx obs handling in timeseries, scatter

### DIFF
--- a/docs/source/whatsnew/1.0.0b2.rst
+++ b/docs/source/whatsnew/1.0.0b2.rst
@@ -21,6 +21,8 @@ Enhancements
 
 Bug fixes
 ~~~~~~~~~
+* Fix handling of observation and forecast metadata in report timeseries
+  and scatter plots. (:issue:`238`)
 
 
 Contributors

--- a/solarforecastarbiter/reports/main.py
+++ b/solarforecastarbiter/reports/main.py
@@ -279,7 +279,7 @@ def render_raw_report(raw_report):
         The full report.
     """
     fx_obs_cds = [
-        (pfxobs.original, figures.construct_fx_obs_cds(
+        (pfxobs, figures.construct_fx_obs_cds(
             pfxobs.forecast_values, pfxobs.observation_values))
         for pfxobs in raw_report.processed_forecasts_observations]
     report_md = template.add_figures_to_report_template(

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -120,8 +120,8 @@ def add_figures_to_report_template(fx_obs_cds, metadata, report_template,
     Parameters
     ----------
     fx_obs_cds : list
-        List of (forecast, observation, ColumnDataSource) tuples to
-        pass to bokeh plotting objects.
+        List of (ProcessedForecastObservation, ColumnDataSource)
+        tuples to pass to bokeh plotting objects.
     report : solarforecastarbiter.datamodel.Report
         Metadata describing report
     report_template : str, markdown


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #238  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

old:

![bokeh_plot(34)](https://user-images.githubusercontent.com/4383303/68235669-e1496c80-ffc0-11e9-8ebf-7c61cb3a8f64.png)

new:

![bokeh_plot(36)](https://user-images.githubusercontent.com/4383303/68235689-e9a1a780-ffc0-11e9-875a-7d6c6b5b0a33.png)

notice that in the new plot the hourly observation data is properly colored black instead of gray.

