### PR TITLE
Add GEFS reference forecasts for select networks

### DIFF
--- a/docs/source/whatsnew/1.0.0b2.rst
+++ b/docs/source/whatsnew/1.0.0b2.rst
@@ -20,11 +20,20 @@ API Changes
 * Add Aggregate to the datamodel, allow forecasts to reference
   either a Site or an Aggregate, and add corresponding Aggregate
   methods to the APISession (:pull:`235`)
+* Add flag to also create probabilistic reference forecasts to
+  :py:mod:`solarforecastarbiter.io.reference_observations.common.create_forecasts`
+  (:pull:`240`)
 
 
 Enhancements
 ~~~~~~~~~~~~
 * Add function to compute an aggregate timeseries (:pull:`223`)
+* Simplify the creation of ProbabilisticForecast objects by passing a list of
+  floats to ``constant_values`` to automatically create
+  :py:mod:`solarforecastarbiter.datamodel.ProbabilisticForecastConstantValues`
+* Make API requests for probabilistic forecasts more efficient (:pull:`240`)
+* Create probabilistic reference forecasts using GEFS and automatically generate
+  those values (:pull:`240`)
 
 
 Bug fixes

--- a/docs/source/whatsnew/1.0.0b2.rst
+++ b/docs/source/whatsnew/1.0.0b2.rst
@@ -20,7 +20,7 @@ API Changes
 * Add Aggregate to the datamodel, allow forecasts to reference
   either a Site or an Aggregate, and add corresponding Aggregate
   methods to the APISession (:pull:`235`)
-* Add flag to also create probabilistic reference forecasts to
+* Require that a list of template Forecasts/ProbabilisticForecasts is passed to
   :py:mod:`solarforecastarbiter.io.reference_observations.common.create_forecasts`
   (:pull:`240`)
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ setup(
         'pvlib',
         'scipy',
         'bokeh',
-        'pyarrow'
+        'pyarrow',
+        'statsmodels'
     ],
     extras_require=EXTRAS_REQUIRE,
     project_urls={

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -948,7 +948,7 @@ def many_prob_forecasts_text():
             {
                 "_links": {},
                 "constant_value": 0,
-                "forecast_id": "11c20780-76ae-4b11-bef1-7a75bdc784e3"
+                "forecast_id": "12c20780-76ae-4b11-bef1-7a75bdc784e3"
             }
         ]
     }
@@ -979,8 +979,12 @@ def _prob_forecast_constant_value_from_dict(get_site, get_aggregate):
 
 @pytest.fixture()
 def _prob_forecast_from_dict(get_site, prob_forecast_constant_value,
-                             get_aggregate):
+                             get_aggregate, agg_prob_forecast_constant_value):
     def f(fx_dict):
+        if fx_dict.get('aggregate_id') is not None:
+            cv = agg_prob_forecast_constant_value
+        else:
+            cv = prob_forecast_constant_value
         return datamodel.ProbabilisticForecast(
             name=fx_dict['name'], variable=fx_dict['variable'],
             interval_value_type=fx_dict['interval_value_type'],
@@ -995,7 +999,7 @@ def _prob_forecast_from_dict(get_site, prob_forecast_constant_value,
             forecast_id=fx_dict.get('forecast_id', ''),
             extra_parameters=fx_dict.get('extra_parameters', ''),
             axis=fx_dict['axis'],
-            constant_values=(prob_forecast_constant_value, ))
+            constant_values=(cv,))
     return f
 
 
@@ -1346,8 +1350,7 @@ def agg_prob_forecast_constant_value_text():
   "interval_value_type": "interval_mean",
   "issue_time_of_day": "06:00",
   "lead_time_to_start": 60,
-  "modified_at": "2019-03-01T11:55:37+00:00",
-  "name": "DA GHI",
+  "name": "GHI Aggregate CDF FX",
   "provider": "Organization 1",
   "run_length": 1440,
   "aggregate_id": "458ffc27-df0b-11e9-b622-62adb5fd6af0",

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -765,8 +765,11 @@ class ProbabilisticForecast(
         The axis on which the constant values of the CDF is specified.
         The axis can be either *x* (constant variable values) or *y*
         (constant percentiles).
-    constant_values : tuple of ProbabilisticForecastConstantValue
-        The variable values or percentiles.
+    constant_values : tuple of ProbabilisticForecastConstantValue or
+            tuple of float
+        The variable values or percentiles. A tuple of floats will
+        automatically be converted to ProbabilisticForecastConstantValue
+        objects.
     forecast_id : str, optional
         UUID of the forecast in the API
     extra_parameters : str, optional
@@ -780,6 +783,7 @@ class ProbabilisticForecast(
     def __post_init__(self):
         super().__post_init__()
         __check_axis__(self.axis)
+        __set_constant_values__(self)
         __check_axis_consistency__(self.axis, self.constant_values)
 
     @classmethod
@@ -791,20 +795,28 @@ class ProbabilisticForecast(
             if isinstance(cv, dict):
                 new_cvs.append(
                     ProbabilisticForecastConstantValue.from_dict(cv))
-            elif isinstance(cv, ProbabilisticForecastConstantValue):
-                new_cvs.append(cv)
-            elif isinstance(cv, (float, int)):
-                cv_dict = dict_.copy()
-                cv_dict.pop('forecast_id', None)
-                cv_dict['constant_value'] = cv
-                new_cvs.append(
-                    ProbabilisticForecastConstantValue.from_dict(cv_dict))
             else:
-                raise TypeError(
-                    f'Invalid type for a constant value {cv}. '
-                    'Must be a dict, float, or ProbablisticConstantValue')
+                new_cvs.append(cv)
         dict_['constant_values'] = tuple(new_cvs)
         return super().from_dict(dict_, raise_on_extra)
+
+
+def __set_constant_values__(self):
+    out = []
+    for cv in self.constant_values:
+        if isinstance(cv, ProbabilisticForecastConstantValue):
+            out.append(cv)
+        elif isinstance(cv, (float, int)):
+            cv_dict = self.to_dict()
+            cv_dict.pop('forecast_id', None)
+            cv_dict['constant_value'] = cv
+            out.append(
+                    ProbabilisticForecastConstantValue.from_dict(cv_dict))
+        else:
+            raise TypeError(
+                f'Invalid type for a constant value {cv}. '
+                'Must be int, float, or ProbablisticConstantValue')
+    object.__setattr__(self, 'constant_values', tuple(out))
 
 
 def __check_axis__(axis):

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -789,12 +789,13 @@ class ProbabilisticForecast(
         new_cvs = []
         for cv in constant_values:
             if isinstance(cv, dict):
-                new_cvs.append(ProbabilisticForecastConstantValue.from_dict(cv))
+                new_cvs.append(
+                    ProbabilisticForecastConstantValue.from_dict(cv))
             elif isinstance(cv, ProbabilisticForecastConstantValue):
                 new_cvs.append(cv)
             elif isinstance(cv, (float, int)):
                 cv_dict = dict_.copy()
-                cv_dict.pop('forecast_id')
+                cv_dict.pop('forecast_id', None)
                 cv_dict['constant_value'] = cv
                 new_cvs.append(
                     ProbabilisticForecastConstantValue.from_dict(cv_dict))

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -765,11 +765,9 @@ class ProbabilisticForecast(
         The axis on which the constant values of the CDF is specified.
         The axis can be either *x* (constant variable values) or *y*
         (constant percentiles).
-    constant_values : tuple of ProbabilisticForecastConstantValue or
-            tuple of float
-        The variable values or percentiles. A tuple of floats will
-        automatically be converted to ProbabilisticForecastConstantValue
-        objects.
+    constant_values : tuple of ProbabilisticForecastConstantValue or float
+        The variable values or percentiles. Floats will automatically
+        be converted to ProbabilisticForecastConstantValue objects.
     forecast_id : str, optional
         UUID of the forecast in the API
     extra_parameters : str, optional

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -312,9 +312,14 @@ class APISession(requests.Session):
             fx_dict['aggregate'] = agg
         cvs = []
         for constant_value_dict in fx_dict['constant_values']:
-            cvs.append(self.get_probabilistic_forecast_constant_value(
-                constant_value_dict['forecast_id'], site=site,
-                aggregate=agg))
+            # the API just gets the groups attributes for the
+            # single constant value forecasts, so avoid
+            # those excess calls
+            cv_dict = fx_dict.copy()
+            cv_dict.update(constant_value_dict)
+            cvs.append(
+                datamodel.ProbabilisticForecastConstantValue.from_dict(
+                    cv_dict))
         fx_dict['constant_values'] = cvs
         return datamodel.ProbabilisticForecast.from_dict(fx_dict)
 

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -230,12 +230,14 @@ class APISession(requests.Session):
         new_id = req.text
         return self.get_observation(new_id)
 
-    def _process_fx(self, fx_dict):
+    def _process_fx(self, fx_dict, sites={}):
         if fx_dict['site_id'] is not None:
-            fx_dict['site'] = self.get_site(fx_dict['site_id'])
+            if fx_dict['site_id'] in sites:
+                fx_dict['site'] = sites[fx_dict['site_id']]
+            else:
+                fx_dict['site'] = self.get_site(fx_dict['site_id'])
         elif fx_dict['aggregate_id'] is not None:
-            fx_dict['aggregate'] = self.get_aggregate(
-                fx_dict['aggregate_id'])
+            fx_dict['aggregate'] = self.get_aggregate(fx_dict['aggregate_id'])
         return datamodel.Forecast.from_dict(fx_dict)
 
     def get_forecast(self, forecast_id):
@@ -267,9 +269,10 @@ class APISession(requests.Session):
         fx_dicts = req.json()
         if len(fx_dicts) == 0:
             return []
+        sites = {site.site_id: site for site in self.list_sites()}
         out = []
         for fx_dict in fx_dicts:
-            out.append(self._process_fx(fx_dict))
+            out.append(self._process_fx(fx_dict, sites=sites))
         return out
 
     def create_forecast(self, forecast):
@@ -301,15 +304,14 @@ class APISession(requests.Session):
         new_id = req.text
         return self.get_forecast(new_id)
 
-    def _process_prob_forecast(self, fx_dict):
-        site = None
-        agg = None
+    def _process_prob_forecast(self, fx_dict, sites={}):
         if fx_dict['site_id'] is not None:
-            site = self.get_site(fx_dict['site_id'])
-            fx_dict['site'] = site
+            if fx_dict['site_id'] in sites:
+                fx_dict['site'] = sites[fx_dict['site_id']]
+            else:
+                fx_dict['site'] = self.get_site(fx_dict['site_id'])
         elif fx_dict['aggregate_id'] is not None:
-            agg = self.get_aggregate(fx_dict['aggregate_id'])
-            fx_dict['aggregate'] = agg
+            fx_dict['aggregate'] = self.get_aggregate(fx_dict['aggregate_id'])
         cvs = []
         for constant_value_dict in fx_dict['constant_values']:
             # the API just gets the groups attributes for the
@@ -335,9 +337,10 @@ class APISession(requests.Session):
         fx_dicts = req.json()
         if len(fx_dicts) == 0:
             return []
+        sites = {site.site_id: site for site in self.list_sites()}
         out = []
         for fx_dict in fx_dicts:
-            out.append(self._process_prob_forecast(fx_dict))
+            out.append(self._process_prob_forecast(fx_dict, sites))
         return out
 
     def get_probabilistic_forecast(self, forecast_id):

--- a/solarforecastarbiter/io/reference_observations/common.py
+++ b/solarforecastarbiter/io/reference_observations/common.py
@@ -338,7 +338,7 @@ def site_name_no_network(site):
 
 def create_one_forecast(api, site, template_forecast, variable,
                         piggyback_on=None):
-    """Creates a new Forecast or Probabilistic Forecast for the variable
+    """Creates a new Forecast or ProbabilisticForecast for the variable
     and site based on the template forecast.
 
     Parameters
@@ -410,7 +410,7 @@ def create_one_forecast(api, site, template_forecast, variable,
         return created
 
 
-def create_forecasts(api, site, variables, include_probabilistic=False):
+def create_forecasts(api, site, variables, templates):
     """Create Forecast objects for each of variables, if NWP forecasts
     can be made for that variable. Each of TEMPLATE_FORECASTS will be
     updated with the appropriate parameters for each variable. Forecasts
@@ -449,9 +449,6 @@ def create_forecasts(api, site, variables, include_probabilistic=False):
         primary = vars_.pop()
 
     created = []
-    templates = TEMPLATE_FORECASTS.copy()
-    if include_probabilistic:
-        templates += TEMPLATE_PROBABILISTIC_FORECASTS
     for template_fx in templates:
         logger.info('Creating forecasts based on %s at site %s',
                     template_fx.name, site.name)

--- a/solarforecastarbiter/io/reference_observations/common.py
+++ b/solarforecastarbiter/io/reference_observations/common.py
@@ -423,11 +423,13 @@ def create_forecasts(api, site, variables, templates):
     site : solarforecastarbiter.datamodel.site
         A site object.
     variables : list-like
-        List of variables to make a new forecast for each of TEMPLATE_FORECASTS
-    include_probabilistic : boolean, default False
-        If true, also create ProbabilisticForecasts from
-        TEMPLATE_PROBABILISTIC_FORECASTS
-    """
+        List of variables to make a new forecast for each of the template
+        forecasts
+    templates : list of datamodel.Forecasts or datamodel.ProbabilisticForecast
+        Forecasts that will be used as templates for many fields. See
+        :py:mod:`solarforecastarbiter.io.reference_data.common.create_one_forecast`
+        for the fields that are required vs overwritten.
+    """  # NOQA
     if not is_in_nwp_domain(site):
         raise ValueError(
             f'Site {site.name} is outside the domain of the current NWP '

--- a/solarforecastarbiter/io/reference_observations/common.py
+++ b/solarforecastarbiter/io/reference_observations/common.py
@@ -8,9 +8,10 @@ import pandas as pd
 from requests.exceptions import HTTPError
 
 
-from solarforecastarbiter.datamodel import Observation
+from solarforecastarbiter.datamodel import Observation, ProbabilisticForecast
 from solarforecastarbiter.io.reference_observations.default_forecasts import (  # NOQA
-    TEMPLATE_FORECASTS, CURRENT_NWP_VARIABLES, is_in_nwp_domain)
+    TEMPLATE_FORECASTS, CURRENT_NWP_VARIABLES, is_in_nwp_domain,
+    TEMPLATE_PROBABILISTIC_FORECASTS)
 
 
 logger = logging.getLogger('reference_data')
@@ -88,7 +89,9 @@ def existing_observations(api):
 
 @lru_cache(maxsize=4)
 def existing_forecasts(api):
-    return {fx.name: fx for fx in api.list_forecasts()}
+    out = {fx.name: fx for fx in api.list_forecasts()}
+    out.update({fx.name: fx for fx in api.list_probabilistic_forecasts()})
+    return out
 
 
 @lru_cache(maxsize=4)
@@ -335,8 +338,8 @@ def site_name_no_network(site):
 
 def create_one_forecast(api, site, template_forecast, variable,
                         piggyback_on=None):
-    """Creates a new Forecast for the variable and site based on the
-    template forecast.
+    """Creates a new Forecast or Probabilistic Forecast for the variable
+    and site based on the template forecast.
 
     Parameters
     ----------
@@ -345,8 +348,9 @@ def create_one_forecast(api, site, template_forecast, variable,
     site : solarforecastarbiter.datamodel.site
         A site object.
     template_forecast : solarforecastarbiter.datamodel.Forecast
-        A Forecast object that will only have name, site, variable, and
-        issue_time_of_day replaced. New keys may be added to extra parameters.
+        A Forecast or ProbabilisticForecast object that will only have name,
+        site, variable, and issue_time_of_day replaced. New keys may be added
+        to extra parameters.
     variable : string
         Variable measured in the forecast.
 
@@ -390,8 +394,13 @@ def create_one_forecast(api, site, template_forecast, variable,
         logger.info('Forecast, %s, already exists', forecast.name)
         return existing[forecast.name]
 
+    if isinstance(forecast, ProbabilisticForecast):
+        create_func = api.create_probabilistic_forecast
+    else:
+        create_func = api.create_forecast
+
     try:
-        created = api.create_forecast(forecast)
+        created = create_func(forecast)
     except HTTPError as e:
         logger.error(f'Failed to create {variable} forecast at Site '
                      f'{site.name}.')
@@ -401,7 +410,7 @@ def create_one_forecast(api, site, template_forecast, variable,
         return created
 
 
-def create_forecasts(api, site, variables):
+def create_forecasts(api, site, variables, include_probabilistic=False):
     """Create Forecast objects for each of variables, if NWP forecasts
     can be made for that variable. Each of TEMPLATE_FORECASTS will be
     updated with the appropriate parameters for each variable. Forecasts
@@ -415,6 +424,9 @@ def create_forecasts(api, site, variables):
         A site object.
     variables : list-like
         List of variables to make a new forecast for each of TEMPLATE_FORECASTS
+    include_probabilistic : boolean, default False
+        If true, also create ProbabilisticForecasts from
+        TEMPLATE_PROBABILISTIC_FORECASTS
     """
     if not is_in_nwp_domain(site):
         raise ValueError(
@@ -437,7 +449,10 @@ def create_forecasts(api, site, variables):
         primary = vars_.pop()
 
     created = []
-    for template_fx in TEMPLATE_FORECASTS:
+    templates = TEMPLATE_FORECASTS.copy()
+    if include_probabilistic:
+        templates += TEMPLATE_PROBABILISTIC_FORECASTS
+    for template_fx in templates:
         logger.info('Creating forecasts based on %s at site %s',
                     template_fx.name, site.name)
         primary_fx = create_one_forecast(api, site, template_fx, primary)

--- a/solarforecastarbiter/io/reference_observations/crn.py
+++ b/solarforecastarbiter/io/reference_observations/crn.py
@@ -5,7 +5,7 @@ from urllib.error import URLError
 import pandas as pd
 from pvlib import iotools
 
-from solarforecastarbiter.io.reference_observations import common
+from solarforecastarbiter.io.reference_observations import common, default_forecasts
 
 
 CRN_URL = 'https://www1.ncdc.noaa.gov/pub/data/uscrn/products/subhourly01/'
@@ -99,7 +99,8 @@ def initialize_site_forecasts(api, site):
     site : datamodel.Site
         The site object for which to create Forecasts.
     """
-    common.create_forecasts(api, site, crn_variables)
+    common.create_forecasts(api, site, crn_variables,
+                            default_forecasts.TEMPLATE_DETERMINISTIC_FORECASTS)
 
 
 def update_observation_data(api, sites, observations, start, end):

--- a/solarforecastarbiter/io/reference_observations/crn.py
+++ b/solarforecastarbiter/io/reference_observations/crn.py
@@ -5,7 +5,8 @@ from urllib.error import URLError
 import pandas as pd
 from pvlib import iotools
 
-from solarforecastarbiter.io.reference_observations import common, default_forecasts
+from solarforecastarbiter.io.reference_observations import (
+    common, default_forecasts)
 
 
 CRN_URL = 'https://www1.ncdc.noaa.gov/pub/data/uscrn/products/subhourly01/'

--- a/solarforecastarbiter/io/reference_observations/default_forecasts.py
+++ b/solarforecastarbiter/io/reference_observations/default_forecasts.py
@@ -28,7 +28,7 @@ CURRENT_NWP_VARIABLES = {'ac_power', 'ghi', 'dni', 'dhi', 'air_temperature',
 
 # issue time of day is in local standard time and will be
 # adjusted to the appropriate UTC hour
-TEMPLATE_FORECASTS = [
+TEMPLATE_DETERMINISTIC_FORECASTS = [
     Forecast(
         name='Day Ahead GFS',
         issue_time_of_day=dt.time(0),
@@ -110,3 +110,7 @@ TEMPLATE_PROBABILISTIC_FORECASTS = [
              })
     )
 ]
+
+
+TEMPLATE_FORECASTS = (
+    TEMPLATE_DETERMINISTIC_FORECASTS + TEMPLATE_PROBABILISTIC_FORECASTS)

--- a/solarforecastarbiter/io/reference_observations/default_forecasts.py
+++ b/solarforecastarbiter/io/reference_observations/default_forecasts.py
@@ -6,7 +6,8 @@ import json
 import pandas as pd
 
 
-from solarforecastarbiter.datamodel import Forecast, Site
+from solarforecastarbiter.datamodel import (
+    Forecast, Site, ProbabilisticForecast)
 from solarforecastarbiter.io.fetch.nwp import DOMAIN
 
 
@@ -88,4 +89,25 @@ TEMPLATE_FORECASTS = [
              'model': 'nam_12km_cloud_cover_to_hourly_mean'
              })
         ),
+]
+
+TEMPLATE_PROBABILISTIC_FORECASTS = [
+    ProbabilisticForecast.from_dict(dict(
+        name='Day Ahead GEFS',
+        issue_time_of_day='00:00',
+        lead_time_to_start=1440,
+        interval_length=60,
+        run_length=1440,
+        interval_label='ending',
+        interval_value_type='interval_mean',
+        variable='ghi',
+        site=_DUMMY_SITE,
+        axis='y',
+        constant_values=range(0, 101, 5),
+        extra_parameters=json.dumps(
+            {'is_reference_forecast': True,
+             'model': 'gefs_half_deg_to_hourly_mean'
+             })
+        )
+    )
 ]

--- a/solarforecastarbiter/io/reference_observations/default_forecasts.py
+++ b/solarforecastarbiter/io/reference_observations/default_forecasts.py
@@ -92,12 +92,12 @@ TEMPLATE_FORECASTS = [
 ]
 
 TEMPLATE_PROBABILISTIC_FORECASTS = [
-    ProbabilisticForecast.from_dict(dict(
+    ProbabilisticForecast(
         name='Day Ahead GEFS',
-        issue_time_of_day='00:00',
-        lead_time_to_start=1440,
-        interval_length=60,
-        run_length=1440,
+        issue_time_of_day=dt.time(0),
+        lead_time_to_start=pd.Timedelta('1d'),
+        interval_length=pd.Timedelta('1h'),
+        run_length=pd.Timedelta('24h'),
         interval_label='ending',
         interval_value_type='interval_mean',
         variable='ghi',
@@ -108,6 +108,5 @@ TEMPLATE_PROBABILISTIC_FORECASTS = [
             {'is_reference_forecast': True,
              'model': 'gefs_half_deg_to_hourly_mean'
              })
-        )
     )
 ]

--- a/solarforecastarbiter/io/reference_observations/midc.py
+++ b/solarforecastarbiter/io/reference_observations/midc.py
@@ -4,7 +4,8 @@ import logging
 from pvlib import iotools
 
 
-from solarforecastarbiter.io.reference_observations import common, midc_config
+from solarforecastarbiter.io.reference_observations import (
+    common, midc_config, default_forecasts)
 
 
 logger = logging.getLogger('reference_data')
@@ -54,7 +55,8 @@ def initialize_site_forecasts(api, site):
         return
     site_api_id = extra_params['network_api_id']
     common.create_forecasts(
-        api, site, midc_config.midc_var_map[site_api_id].keys(), True)
+        api, site, midc_config.midc_var_map[site_api_id].keys(),
+        default_forecasts.TEMPLATE_FORECASTS)
 
 
 def update_observation_data(api, sites, observations, start, end):

--- a/solarforecastarbiter/io/reference_observations/midc.py
+++ b/solarforecastarbiter/io/reference_observations/midc.py
@@ -54,7 +54,7 @@ def initialize_site_forecasts(api, site):
         return
     site_api_id = extra_params['network_api_id']
     common.create_forecasts(
-        api, site, midc_config.midc_var_map[site_api_id].keys())
+        api, site, midc_config.midc_var_map[site_api_id].keys(), True)
 
 
 def update_observation_data(api, sites, observations, start, end):

--- a/solarforecastarbiter/io/reference_observations/rtc.py
+++ b/solarforecastarbiter/io/reference_observations/rtc.py
@@ -6,7 +6,7 @@ from requests.exceptions import HTTPError
 
 
 from solarforecastarbiter.io.fetch import rtc
-from solarforecastarbiter.io.reference_observations import common
+from solarforecastarbiter.io.reference_observations import common, default_forecasts
 
 
 logger = logging.getLogger('reference_data')
@@ -74,7 +74,8 @@ def initialize_site_forecasts(api, site):
     site : datamodel.Site
         The site object for which to create Forecasts.
     """
-    common.create_forecasts(api, site, DOE_RTC_VARIABLE_MAP.values(), True)
+    common.create_forecasts(api, site, DOE_RTC_VARIABLE_MAP.values(),
+                            default_forecasts.TEMPLATE_FORECASTS)
 
 
 def update_observation_data(api, sites, observations, start, end):

--- a/solarforecastarbiter/io/reference_observations/rtc.py
+++ b/solarforecastarbiter/io/reference_observations/rtc.py
@@ -74,7 +74,7 @@ def initialize_site_forecasts(api, site):
     site : datamodel.Site
         The site object for which to create Forecasts.
     """
-    common.create_forecasts(api, site, DOE_RTC_VARIABLE_MAP.values())
+    common.create_forecasts(api, site, DOE_RTC_VARIABLE_MAP.values(), True)
 
 
 def update_observation_data(api, sites, observations, start, end):

--- a/solarforecastarbiter/io/reference_observations/rtc.py
+++ b/solarforecastarbiter/io/reference_observations/rtc.py
@@ -6,7 +6,8 @@ from requests.exceptions import HTTPError
 
 
 from solarforecastarbiter.io.fetch import rtc
-from solarforecastarbiter.io.reference_observations import common, default_forecasts
+from solarforecastarbiter.io.reference_observations import (
+    common, default_forecasts)
 
 
 logger = logging.getLogger('reference_data')

--- a/solarforecastarbiter/io/reference_observations/solrad.py
+++ b/solarforecastarbiter/io/reference_observations/solrad.py
@@ -6,7 +6,7 @@ import pandas as pd
 from pvlib import iotools
 
 
-from solarforecastarbiter.io.reference_observations import common
+from solarforecastarbiter.io.reference_observations import common, default_forecasts
 
 
 solrad_variables = ['ghi', 'dni', 'dhi']
@@ -98,7 +98,8 @@ def initialize_site_forecasts(api, site):
     site : datamodel.Site
         The site object for which to create Forecasts.
     """
-    common.create_forecasts(api, site, solrad_variables, True)
+    common.create_forecasts(api, site, solrad_variables,
+                            default_forecasts.TEMPLATE_FORECASTS)
 
 
 def update_observation_data(api, sites, observations, start, end):

--- a/solarforecastarbiter/io/reference_observations/solrad.py
+++ b/solarforecastarbiter/io/reference_observations/solrad.py
@@ -6,7 +6,8 @@ import pandas as pd
 from pvlib import iotools
 
 
-from solarforecastarbiter.io.reference_observations import common, default_forecasts
+from solarforecastarbiter.io.reference_observations import (
+    common, default_forecasts)
 
 
 solrad_variables = ['ghi', 'dni', 'dhi']

--- a/solarforecastarbiter/io/reference_observations/solrad.py
+++ b/solarforecastarbiter/io/reference_observations/solrad.py
@@ -98,7 +98,7 @@ def initialize_site_forecasts(api, site):
     site : datamodel.Site
         The site object for which to create Forecasts.
     """
-    common.create_forecasts(api, site, solrad_variables)
+    common.create_forecasts(api, site, solrad_variables, True)
 
 
 def update_observation_data(api, sites, observations, start, end):

--- a/solarforecastarbiter/io/reference_observations/srml.py
+++ b/solarforecastarbiter/io/reference_observations/srml.py
@@ -7,7 +7,8 @@ from pvlib import iotools
 from requests.exceptions import HTTPError
 
 
-from solarforecastarbiter.io.reference_observations import common, default_forecasts
+from solarforecastarbiter.io.reference_observations import (
+    common, default_forecasts)
 
 
 # maps the desired variable names to those returned by pvlib.iotools

--- a/solarforecastarbiter/io/reference_observations/srml.py
+++ b/solarforecastarbiter/io/reference_observations/srml.py
@@ -7,7 +7,7 @@ from pvlib import iotools
 from requests.exceptions import HTTPError
 
 
-from solarforecastarbiter.io.reference_observations import common
+from solarforecastarbiter.io.reference_observations import common, default_forecasts
 
 
 # maps the desired variable names to those returned by pvlib.iotools
@@ -201,7 +201,8 @@ def initialize_site_forecasts(api, site):
     site : datamodel.Site
         The site object for which to create Forecasts.
     """
-    common.create_forecasts(api, site, srml_variable_map.values())
+    common.create_forecasts(api, site, srml_variable_map.values(),
+                            default_forecasts.TEMPLATE_DETERMINISTIC_FORECASTS)
 
 
 def update_observation_data(api, sites, observations, start, end):

--- a/solarforecastarbiter/io/reference_observations/surfrad.py
+++ b/solarforecastarbiter/io/reference_observations/surfrad.py
@@ -10,7 +10,8 @@ import pandas as pd
 
 from pvlib import iotools
 from solarforecastarbiter.io.utils import observation_df_to_json_payload as obs_to_payload # NOQA
-from solarforecastarbiter.io.reference_observations import common, default_forecasts
+from solarforecastarbiter.io.reference_observations import (
+    common, default_forecasts)
 
 
 # Format strings for the location of a surfrad data file. Expects the following

--- a/solarforecastarbiter/io/reference_observations/surfrad.py
+++ b/solarforecastarbiter/io/reference_observations/surfrad.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from pvlib import iotools
 from solarforecastarbiter.io.utils import observation_df_to_json_payload as obs_to_payload # NOQA
-from solarforecastarbiter.io.reference_observations import common
+from solarforecastarbiter.io.reference_observations import common, default_forecasts
 
 
 # Format strings for the location of a surfrad data file. Expects the following
@@ -112,7 +112,8 @@ def initialize_site_forecasts(api, site):
     site : datamodel.Site
         The site object for which to create Forecasts.
     """
-    common.create_forecasts(api, site, surfrad_variables, True)
+    common.create_forecasts(api, site, surfrad_variables,
+                            default_forecasts.TEMPLATE_FORECASTS)
 
 
 def update_observation_data(api, sites, observations, start, end):

--- a/solarforecastarbiter/io/reference_observations/surfrad.py
+++ b/solarforecastarbiter/io/reference_observations/surfrad.py
@@ -103,7 +103,7 @@ def initialize_site_observations(api, site):
 
 def initialize_site_forecasts(api, site):
     """
-    Create a forecasts for each variable in surfrad_variables the site
+    Create forecasts for each variable in surfrad_variables at the site
 
     Parameters
     ----------
@@ -112,7 +112,7 @@ def initialize_site_forecasts(api, site):
     site : datamodel.Site
         The site object for which to create Forecasts.
     """
-    common.create_forecasts(api, site, surfrad_variables)
+    common.create_forecasts(api, site, surfrad_variables, True)
 
 
 def update_observation_data(api, sites, observations, start, end):

--- a/solarforecastarbiter/io/reference_observations/tests/test_common.py
+++ b/solarforecastarbiter/io/reference_observations/tests/test_common.py
@@ -480,11 +480,9 @@ def test_create_forecasts(template_fx, mocker, vars_, primary):
     fxdict = template.to_dict()
     fxdict['constant_values'] = [0, 50, 100]
     fxdict['axis'] = 'y'
-    cdf_template = [ProbabilisticForecast.from_dict(fxdict)]
-    mocker.patch.object(common, 'TEMPLATE_FORECASTS', new=templates)
-    mocker.patch.object(common, 'TEMPLATE_PROBABILISTIC_FORECASTS',
-                        new=cdf_template)
-    fxs = common.create_forecasts(api, site, vars_, True)
+    templates += [ProbabilisticForecast.from_dict(fxdict)]
+
+    fxs = common.create_forecasts(api, site, vars_, templates)
     assert len(fxs) == 6
     if primary:
         assert fxs[0].variable == primary
@@ -503,6 +501,5 @@ def test_create_forecasts_outside(template_fx, mocker, log):
     api, template, site = template_fx
     site = site.replace(latitude=19, longitude=-159)
     templates = [template.replace(name='one'), template.replace(name='two')]
-    mocker.patch.object(common, 'TEMPLATE_FORECASTS', new=templates)
     with pytest.raises(ValueError):
-        common.create_forecasts(api, site, vars_)
+        common.create_forecasts(api, site, vars_, templates)

--- a/solarforecastarbiter/io/reference_observations/tests/test_common.py
+++ b/solarforecastarbiter/io/reference_observations/tests/test_common.py
@@ -8,7 +8,8 @@ import pytest
 from requests.exceptions import HTTPError
 
 
-from solarforecastarbiter.datamodel import Site, Observation, Forecast
+from solarforecastarbiter.datamodel import (
+    Site, Observation, Forecast, ProbabilisticForecast)
 from solarforecastarbiter.io.reference_observations import common
 from solarforecastarbiter.io.reference_observations.tests.conftest import (
     expected_site,
@@ -381,6 +382,8 @@ def test_update_site_observations_no_data(
 @pytest.fixture()
 def template_fx(mock_api, mocker):
     mock_api.create_forecast = mocker.MagicMock(side_effect=lambda x: x)
+    mock_api.create_probabilistic_forecast = mocker.MagicMock(
+        side_effect=lambda x: x)
     site = site_objects[1].replace(latitude=32, longitude=-110)
     template = Forecast(
         name='Test Template',
@@ -474,9 +477,15 @@ def test_create_one_forecast_existing(template_fx, mocker):
 def test_create_forecasts(template_fx, mocker, vars_, primary):
     api, template, site = template_fx
     templates = [template.replace(name='one'), template.replace(name='two')]
+    fxdict = template.to_dict()
+    fxdict['constant_values'] = [0, 50, 100]
+    fxdict['axis'] = 'y'
+    cdf_template = [ProbabilisticForecast.from_dict(fxdict)]
     mocker.patch.object(common, 'TEMPLATE_FORECASTS', new=templates)
-    fxs = common.create_forecasts(api, site, vars_)
-    assert len(fxs) == 4
+    mocker.patch.object(common, 'TEMPLATE_PROBABILISTIC_FORECASTS',
+                        new=cdf_template)
+    fxs = common.create_forecasts(api, site, vars_, True)
+    assert len(fxs) == 6
     if primary:
         assert fxs[0].variable == primary
         assert fxs[2].variable == primary
@@ -486,6 +495,7 @@ def test_create_forecasts(template_fx, mocker, vars_, primary):
     assert 'two' in fxs[2].name
     assert 'two' in fxs[3].name
     assert fxs[2].forecast_id in fxs[3].extra_parameters
+    assert isinstance(fxs[-1], ProbabilisticForecast)
 
 
 def test_create_forecasts_outside(template_fx, mocker, log):

--- a/solarforecastarbiter/reference_forecasts/models.py
+++ b/solarforecastarbiter/reference_forecasts/models.py
@@ -540,7 +540,7 @@ def gefs_half_deg_to_hourly_mean(latitude, longitude, elevation,
     -----
     Returned values are hourly averages sorted from smallest to largest
     at each time stamp. Each variable is sorted independently.
-    This describes a ProbabilisticForecast with ``axis='x'`` and
+    This describes a ProbabilisticForecast with ``axis='y'`` and
     ``constant_values=[0, 5, ...95, 100]``.
     """
     start_floored, end_ceil = _adjust_gfs_start_end(start, end)

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -289,3 +289,15 @@ def test_forecast_invalid(single_forecast, single_site, aggregate):
         single_forecast.replace(site=None, aggregate=None)
     with pytest.raises(KeyError):
         single_forecast.replace(site=single_site, aggregate=aggregate)
+
+
+def test_probabilistic_forecast_float_constant_values(
+        prob_forecast_text, single_site, prob_forecast_constant_value,
+        prob_forecasts):
+    fx_dict = json.loads(prob_forecast_text)
+    fx_dict['site'] = single_site
+    fx_dict['constant_values'] = (
+        prob_forecast_constant_value.constant_value, )
+    out = datamodel.ProbabilisticForecast.from_dict(fx_dict)
+    object.__setattr__(prob_forecasts.constant_values[0], 'forecast_id', '')
+    assert out == prob_forecasts

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -291,7 +291,30 @@ def test_forecast_invalid(single_forecast, single_site, aggregate):
         single_forecast.replace(site=single_site, aggregate=aggregate)
 
 
-def test_probabilistic_forecast_float_constant_values(
+def test_probabilistic_forecast_float_constant_values(prob_forecasts):
+    out = datamodel.ProbabilisticForecast(
+        name=prob_forecasts.name,
+        issue_time_of_day=prob_forecasts.issue_time_of_day,
+        lead_time_to_start=prob_forecasts.lead_time_to_start,
+        interval_length=prob_forecasts.interval_length,
+        run_length=prob_forecasts.run_length,
+        interval_label=prob_forecasts.interval_label,
+        interval_value_type=prob_forecasts.interval_value_type,
+        variable=prob_forecasts.variable,
+        site=prob_forecasts.site,
+        forecast_id=prob_forecasts.forecast_id,
+        axis=prob_forecasts.axis,
+        extra_parameters=prob_forecasts.extra_parameters,
+        constant_values=tuple(cv.constant_value
+                              for cv in prob_forecasts.constant_values),
+    )
+    object.__setattr__(prob_forecasts.constant_values[0], 'forecast_id', '')
+    assert isinstance(out.constant_values[0],
+                      datamodel.ProbabilisticForecastConstantValue)
+    assert out == prob_forecasts
+
+
+def test_probabilistic_forecast_float_constant_values_from_dict(
         prob_forecast_text, single_site, prob_forecast_constant_value,
         prob_forecasts):
     fx_dict = json.loads(prob_forecast_text)
@@ -301,3 +324,8 @@ def test_probabilistic_forecast_float_constant_values(
     out = datamodel.ProbabilisticForecast.from_dict(fx_dict)
     object.__setattr__(prob_forecasts.constant_values[0], 'forecast_id', '')
     assert out == prob_forecasts
+
+
+def test_probabilistic_forecast_invalid_constant_value(prob_forecasts):
+    with pytest.raises(TypeError):
+        prob_forecasts.replace(constant_values=(1, 'a'))


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #198  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Enable the creation of reference ProbabilisticForecast objects for MIDC, SOLRAD, SURFRAD, and RTC sites, and scheduled updates using GEFS. API calls to ``list_probabilistic_forecasts`` should also be a bit faster since we don't really need to get each constant value from the API.
Also closes #205. 
