### PR TITLE
handle long names in report figures and tables

### DIFF
--- a/docs/source/whatsnew/1.0.0b2.rst
+++ b/docs/source/whatsnew/1.0.0b2.rst
@@ -31,6 +31,10 @@ Bug fixes
 ~~~~~~~~~
 * Fix handling of observation and forecast metadata in report timeseries
   and scatter plots. (:issue:`238`)
+* Fix overlapping labels on report's total metrics plots and too short
+  metrics table when more than 3 forecasts are selected. (:issue:`163`)
+* Fix report limitation of 6 forecasts due to how the color palette was
+  specified. (:issue:`242`)
 
 
 Contributors

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -240,6 +240,23 @@ def construct_metrics_cds(metrics, kind, index='forecast', rename=False):
     return cds
 
 
+def abbreviate(x, limit=3):
+    # might need to add logic to ensure uniqueness
+    # and/or enforce max length using textwrap.shorten
+    components = x.split(' ')
+    out_components = []
+    for c in components:
+        if len(c) <= limit:
+            out = c
+        elif c.upper() == c:
+            # probably an acronym
+            out = c
+        else:
+            out = f'{c[0:limit]}.'
+        out_components.append(out)
+    return ' '.join(out_components)
+
+
 def construct_metrics_series(metrics, kind):
     """
     Contructs a series of metrics values with a MultiIndex.

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -316,6 +316,17 @@ def bar(cds, metric):
         (metric.upper(), f'@{metric}'),
     ]
     hover = HoverTool(tooltips=tooltips, mode='vline')
+    # more accurate would be if any single name is longer than each
+    # name's allotted space. For example, never need to rotate labels
+    # if forecasts are named A, B, C, D... but quickly need to rotate
+    # if they have long names.
+    if len(x_range) > 6:
+        # pi/4 looks a lot better, but first tick label flows off chart
+        # and I can't figure out how to add padding in bokeh
+        fig.xaxis.major_label_orientation = np.pi/2
+        fig.width = 800
+        # add more height to figure so that the names can go somewhere.
+        fig.height = 400
     fig.add_tools(hover)
     return fig
 
@@ -430,9 +441,11 @@ def metrics_table(cds):
         col = TableColumn(field=field, title=title.upper(),
                           formatter=formatter, width=metric_width)
         columns.append(col)
-    width = name_width + metric_width * len(field)
+    width = name_width + metric_width * (len(field) - 1)
+    height = 25 * (1 + len(cds.data['forecast']))
     data_table = DataTable(source=cds, columns=columns, width=width,
-                           height=150, index_position=None, fit_columns=False)
+                           height=height, index_position=None,
+                           fit_columns=False)
     return data_table
 
 

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -202,7 +202,7 @@ def scatter(fx_obs_cds):
     return fig
 
 
-def construct_metrics_cds(metrics, kind, index='forecast', rename=False):
+def construct_metrics_cds(metrics, kind, index='forecast', rename=None):
     """
     Possibly bad assumptions:
     * metrics contains keys: name, total, month, day, hour
@@ -217,6 +217,8 @@ def construct_metrics_cds(metrics, kind, index='forecast', rename=False):
     index : str
         Determines if the index is the array of metrics ('metric') or
         forecast ('forecast') names
+    rename : function or None
+        Function of one argument that is applied to each forecast name.
 
     Returns
     -------

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -200,7 +200,7 @@ def scatter(fx_obs_cds):
     return fig
 
 
-def construct_metrics_cds(metrics, kind, index='forecast'):
+def construct_metrics_cds(metrics, kind, index='forecast', rename=False):
     """
     Possibly bad assumptions:
     * metrics contains keys: name, total, month, day, hour
@@ -221,7 +221,12 @@ def construct_metrics_cds(metrics, kind, index='forecast'):
     cds : bokeh.models.ColumnDataSource
     """
     if kind == 'total':
-        df = pd.DataFrame({m['name']: m[kind] for m in metrics})
+        if rename:
+            f = rename
+        else:
+            def f(x): return x
+        d = {f(m['name']): m[kind] for m in metrics}
+        df = pd.DataFrame(d)
     df = df.rename_axis(index='metric', columns='forecast')
     if index == 'metric':
         pass

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -1,6 +1,7 @@
 """
 Functions to make all of the figures for Solar Forecast Arbiter reports.
 """
+from itertools import cycle
 import textwrap
 
 from bokeh.models import ColumnDataSource, HoverTool
@@ -17,7 +18,8 @@ from solarforecastarbiter.plotting.utils import (line_or_step,
                                                  format_variable_name)
 
 
-PALETTE = palettes.d3['Category10'][6]
+PALETTE = (
+    palettes.d3['Category20'][20][::2] + palettes.d3['Category20'][20][1::2])
 _num_obs_colors = 3
 OBS_PALETTE = palettes.grey(_num_obs_colors+1)[0:_num_obs_colors]  # drop white
 OBS_PALETTE.reverse()
@@ -96,7 +98,7 @@ def timeseries(fx_obs_cds, start, end, timezone='UTC'):
     fig : bokeh.plotting.figure
     """
 
-    palette = iter(PALETTE)
+    palette = cycle(PALETTE)
 
     fig = figure(
         sizing_mode='scale_width', plot_width=900, plot_height=300,
@@ -184,7 +186,7 @@ def scatter(fx_obs_cds):
 
     kwargs = dict(size=6, line_color=None)
 
-    palette = iter(PALETTE)
+    palette = cycle(PALETTE)
 
     for proc_fx_obs, cds in fx_obs_cds:
         fig.scatter(
@@ -296,11 +298,13 @@ def bar(cds, metric):
     data_table : bokeh.widgets.DataTable
     """
     x_range = cds.data['forecast']
+    palette = cycle(PALETTE)
+    palette = [next(palette) for _ in x_range]
     # TODO: add units to title
     fig = figure(x_range=x_range, width=800, height=200, title=metric.upper())
     fig.vbar(x='forecast', top=metric, width=0.8, source=cds,
              line_color='white',
-             fill_color=factor_cmap('forecast', PALETTE, factors=x_range))
+             fill_color=factor_cmap('forecast', palette, factors=x_range))
     fig.xgrid.grid_line_color = None
     if metric in START_AT_ZER0:
         fig.y_range.start = 0
@@ -338,7 +342,7 @@ def bar_subdivisions(cds, kind, metric):
     -------
     figs : tuple of figures
     """
-    palette = iter(PALETTE)
+    palette = cycle(PALETTE)
     tools = 'pan,xwheel_zoom,box_zoom,box_select,reset,save'
     fig_kwargs = dict(tools=tools)
     figs = []

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -65,7 +65,21 @@ def template_report(report, metadata, metrics,
 
 
 def _metrics_script_divs(report, metrics):
-    cds = figures.construct_metrics_cds(metrics, 'total', index='forecast')
+    def rename(x, limit=3):
+        components = x.split(' ')
+        out_components = []
+        for c in components:
+            if len(c) <= limit:
+                out = c
+            elif c.upper() == c:
+                # probably an acronym
+                out = c
+            else:
+                out = f'{c[0:limit]}.'
+            out_components.append(out)
+        return ' '.join(out_components)
+    cds = figures.construct_metrics_cds(metrics, 'total', index='forecast',
+                                        rename=rename)
     data_table = figures.metrics_table(cds)
 
     figures_bar = []

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -66,6 +66,8 @@ def template_report(report, metadata, metrics,
 
 def _metrics_script_divs(report, metrics):
     def rename(x, limit=3):
+        # might need to add logic to ensure uniqueness
+        # and/or enforce max length using textwrap.shorten
         components = x.split(' ')
         out_components = []
         for c in components:

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -4,7 +4,6 @@ Inserts metadata and figures into the report template.
 import logging
 import subprocess
 
-
 from bokeh.embed import components
 from bokeh.layouts import gridplot
 from jinja2 import (Environment, DebugUndefined, PackageLoader,
@@ -65,23 +64,8 @@ def template_report(report, metadata, metrics,
 
 
 def _metrics_script_divs(report, metrics):
-    def rename(x, limit=3):
-        # might need to add logic to ensure uniqueness
-        # and/or enforce max length using textwrap.shorten
-        components = x.split(' ')
-        out_components = []
-        for c in components:
-            if len(c) <= limit:
-                out = c
-            elif c.upper() == c:
-                # probably an acronym
-                out = c
-            else:
-                out = f'{c[0:limit]}.'
-            out_components.append(out)
-        return ' '.join(out_components)
     cds = figures.construct_metrics_cds(metrics, 'total', index='forecast',
-                                        rename=rename)
+                                        rename=figures.abbreviate)
     data_table = figures.metrics_table(cds)
 
     figures_bar = []

--- a/solarforecastarbiter/reports/tests/test_figures.py
+++ b/solarforecastarbiter/reports/tests/test_figures.py
@@ -8,14 +8,14 @@ import pytest
 def test_construct_metrics_cds():
     metrics = [
         {
-            'name': 'University of Arizona OASIS Day Ahead GFS ghi',
+            'name': 'Forecast 1 AAAA',
             'total': {'mae': 74.},
             'month': {'mae': pd.Series(74., index=[8])},
             'day': {'mae': pd.Series(74., index=[21])},
             'hour': {'mae': pd.Series([74., 75.], index=[12, 13])}
         },
         {
-            'name': 'University of Arizona OASIS Intraday NAM',
+            'name': 'Forecast 1 BBBB',
             'total': {'mae': 74.},
             'month': {'mae': pd.Series(74., index=[8])},
             'day': {'mae': pd.Series(74., index=[21])},
@@ -23,14 +23,16 @@ def test_construct_metrics_cds():
         }
     ]
     cds = figures.construct_metrics_cds(metrics, 'total')
-    assert cds.data['forecast'][0] == \
-        'University of Arizona OASIS Day Ahead GFS ghi'
+    assert cds.data['forecast'][0] == 'Forecast 1 AAAA'
     cds = figures.construct_metrics_cds(metrics, 'total',
                                         rename=figures.abbreviate)
-    assert cds.data['forecast'][0] == 'Uni. of Ari. OASIS Day Ahe. GFS ghi'
+    assert cds.data['forecast'][0] == 'For. 1 AAAA'
 
 
 @pytest.mark.parametrize('arg,expected', [
+    ('a', 'a'),
+    ('abcd', 'abc.'),
+    ('ABCDEFGHIJKLMNOP', 'ABCDEFGHIJKLMNOP'),
     ('University of Arizona OASIS Day Ahead GFS ghi',
      'Uni. of Ari. OASIS Day Ahe. GFS ghi')
 ])

--- a/solarforecastarbiter/reports/tests/test_figures.py
+++ b/solarforecastarbiter/reports/tests/test_figures.py
@@ -1,0 +1,39 @@
+from solarforecastarbiter.reports import figures
+
+import pandas as pd
+
+import pytest
+
+
+def test_construct_metrics_cds():
+    metrics = [
+        {
+            'name': 'University of Arizona OASIS Day Ahead GFS ghi',
+            'total': {'mae': 74.},
+            'month': {'mae': pd.Series(74., index=[8])},
+            'day': {'mae': pd.Series(74., index=[21])},
+            'hour': {'mae': pd.Series([74., 75.], index=[12, 13])}
+        },
+        {
+            'name': 'University of Arizona OASIS Intraday NAM',
+            'total': {'mae': 74.},
+            'month': {'mae': pd.Series(74., index=[8])},
+            'day': {'mae': pd.Series(74., index=[21])},
+            'hour': {'mae': pd.Series([74., 75.], index=[12, 13])}
+        }
+    ]
+    cds = figures.construct_metrics_cds(metrics, 'total')
+    assert cds.data['forecast'][0] == \
+        'University of Arizona OASIS Day Ahead GFS ghi'
+    cds = figures.construct_metrics_cds(metrics, 'total',
+                                        rename=figures.abbreviate)
+    assert cds.data['forecast'][0] == 'Uni. of Ari. OASIS Day Ahe. GFS ghi'
+
+
+@pytest.mark.parametrize('arg,expected', [
+    ('University of Arizona OASIS Day Ahead GFS ghi',
+     'Uni. of Ari. OASIS Day Ahe. GFS ghi')
+])
+def test_abbreviate(arg, expected):
+    out = figures.abbreviate(arg)
+    assert out == expected


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #163 .
  - [x] Closes #242. 10 unique colors, then same colors but different shade for another 10. then the whole cycle repeats. good enough.
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added. yes for CDS, renaming; no for plot orientation switch - that's harder.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes. `figures` isn't documented because it's a dumpster fire.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

To do:
- [x] rotate x labels, make plot taller if any reduced name length is too long or there are too many forecasts
