### PR TITLE
improve legend layout

### DIFF
--- a/docs/source/whatsnew/1.0.0b2.rst
+++ b/docs/source/whatsnew/1.0.0b2.rst
@@ -44,6 +44,9 @@ Bug fixes
   metrics table when more than 3 forecasts are selected. (:issue:`163`)
 * Fix report limitation of 6 forecasts due to how the color palette was
   specified. (:issue:`242`)
+* Timeseries plot legends can accomodate more items (20) by shrinking
+  the font size and scatter plot legends were moved to the side to
+  prevent them from blocking the data. (:issue:`218`)
 
 
 Contributors

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -4,7 +4,6 @@ Functions to make all of the figures for Solar Forecast Arbiter reports.
 from itertools import cycle
 import textwrap
 
-from bokeh.layouts import Row
 from bokeh.models import ColumnDataSource, HoverTool, Legend
 from bokeh.models.ranges import Range1d
 from bokeh.models.widgets import DataTable, TableColumn, NumberFormatter

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -186,7 +186,7 @@ def scatter(fx_obs_cds):
 
     # match_aspect=True does not work well, so these need to be close
     plot_height = 400
-    # will be updated later based on label length
+    # width will be updated later based on label length
     plot_width = plot_height + 50
     fig = figure(
         plot_width=plot_width, plot_height=plot_height, match_aspect=True,
@@ -207,22 +207,19 @@ def scatter(fx_obs_cds):
             fill_color=next(palette), **kwargs)
         scatters_labels.append((label, [r]))
 
-    # second figure for legend so it doesn't distort the first
-    # when text length/size changes. otherwise plot_width would be
-    # coupled to length of the labels. unfortunately, this doesn't
-    # work due to bokeh's inability to communicate legend information
-    # across figures.
-    # legend_fig = figure(
-    #     plot_width=400, plot_height=plot_height, x_axis_location=None,
-    #     y_axis_location=None, title=None, tools='', toolbar_location=None)
-
     # manual legend so it can be placed outside the plot area
     legend = Legend(items=scatters_labels, location='top_center',
                     click_policy='hide')
     fig.add_layout(legend, 'right')
 
+    # compute new plot width accounting for legend label text width.
+    # also considered using second figure for legend so it doesn't
+    # distort the first when text length/size changes. unfortunately,
+    # that doesn't work due to bokeh's inability to communicate legend
+    # information across figures.
+    # widest part of the legend
     max_legend_length = max((len(label) for label, _ in scatters_labels))
-    px_per_length = 7.75
+    px_per_length = 7.75  # found through trial and error
     fig.plot_width = int(fig.plot_width + max_legend_length * px_per_length)
 
     label = format_variable_name(proc_fx_obs.original.forecast.variable)

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -141,6 +141,12 @@ def timeseries(fx_obs_cds, start, end, timezone='UTC'):
 
     fig.legend.location = "top_left"
     fig.legend.click_policy = "hide"
+    if len(plotted_objects) > 10:
+        fig.legend.label_height = 10
+        fig.legend.label_text_font_size = '8px'
+        fig.legend.glyph_height = 10
+        fig.legend.spacing = 1
+        fig.legend.margin = 0
     fig.xaxis.axis_label = f'Time ({timezone})'
     fig.yaxis.axis_label = format_variable_name(
         proc_fx_obs.original.forecast.variable)

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -179,10 +179,12 @@ def scatter(fx_obs_cds):
     """
     xy_min, xy_max = _get_scatter_limits(fx_obs_cds)
 
-    # match_aspect=True does not work because of the legend
+    # match_aspect=True does not work well, so these need to be close
     plot_height = 400
+    # will be updated later based on label length
+    plot_width = plot_height + 50
     fig = figure(
-        plot_width=450, plot_height=plot_height, match_aspect=True,
+        plot_width=plot_width, plot_height=plot_height, match_aspect=True,
         x_range=Range1d(xy_min, xy_max), y_range=Range1d(xy_min, xy_max),
         tools='pan,wheel_zoom,box_zoom,box_select,lasso_select,reset,save',
         name='scatter')
@@ -202,19 +204,26 @@ def scatter(fx_obs_cds):
 
     # second figure for legend so it doesn't distort the first
     # when text length/size changes. otherwise plot_width would be
-    # coupled to length of the labels.
-    legend_fig = figure(
-        plot_width=400, plot_height=plot_height, x_axis_location=None,
-        y_axis_location=None, title=None, tools='', toolbar_location=None)
+    # coupled to length of the labels. unfortunately, this doesn't
+    # work due to bokeh's inability to communicate legend information
+    # across figures.
+    # legend_fig = figure(
+    #     plot_width=400, plot_height=plot_height, x_axis_location=None,
+    #     y_axis_location=None, title=None, tools='', toolbar_location=None)
+
     # manual legend so it can be placed outside the plot area
     legend = Legend(items=scatters_labels, location='top_center',
                     click_policy='hide')
-    legend_fig.add_layout(legend, 'left')
+    fig.add_layout(legend, 'right')
+
+    max_legend_length = max((len(label) for label, _ in scatters_labels))
+    px_per_length = 7.75
+    fig.plot_width = int(fig.plot_width + max_legend_length * px_per_length)
 
     label = format_variable_name(proc_fx_obs.original.forecast.variable)
     fig.xaxis.axis_label = 'Observed ' + label
     fig.yaxis.axis_label = 'Forecast ' + label
-    return Row(fig, legend_fig)
+    return fig
 
 
 def construct_metrics_cds(metrics, kind, index='forecast', rename=None):


### PR DESCRIPTION

  - [x] Closes #218  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.


Moves the scatter plot's legend to its own figure layout and dynamically determines the `plot_width` so the aspect ratio remains (nearly) 1:1 (see figures below). 

Not sure what to do about the time series plot. Could use the same approach. Some might argue the widest possible plot is better even if it means some of the plot is obscured and pan/zoom let's you position the data window to see things. Bigger problem is what to do about too many legend items for the box. I am guessing it won't be possible to address this without distorting the aspect ratio. Maybe reduce font size.

Unfortunately, bokeh does not support linking legends to multiple figures.

I miss matplotlib.

got any better ideas @alorenzo175?

![bokeh_plot(40)](https://user-images.githubusercontent.com/4383303/68717279-9650cb80-0563-11ea-8435-d1fd19f5727a.png)
![bokeh_plot(38)](https://user-images.githubusercontent.com/4383303/68717282-99e45280-0563-11ea-8620-78f3d26e043b.png)
