### PR TITLE
retain forecast order in metric cds creation

### DIFF
--- a/docs/source/whatsnew/1.0.0b2.rst
+++ b/docs/source/whatsnew/1.0.0b2.rst
@@ -47,6 +47,8 @@ Bug fixes
 * Timeseries plot legends can accomodate more items (20) by shrinking
   the font size and scatter plot legends were moved to the side to
   prevent them from blocking the data. (:issue:`218`)
+* Fix inconsistent forecast ordering and coloring in report bar charts.
+  (:issue:`204`)
 
 
 Contributors

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -299,7 +299,8 @@ def construct_metrics_series(metrics, kind):
 
 def construct_metrics_cds2(metrics_series, metric):
     df = metrics_series.xs(metric, level='metric').unstack().T
-    cds = ColumnDataSource(df)
+    idx = pd.unique(metrics_series.index.get_level_values('forecast'))
+    cds = ColumnDataSource(df[idx])
     return cds
 
 

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -298,7 +298,26 @@ def construct_metrics_series(metrics, kind):
 
 
 def construct_metrics_cds2(metrics_series, metric):
+    """
+    Create a ColumnDataSource for a single metric (MAE, MBE, etc.) for
+    many forecasts.
+
+    Parameters
+    ----------
+    metrics_series : pd.Series
+        Has a MultiIndex with levels 'forecast', 'metric', group
+    metric : str
+        e.g. MAE
+
+    Returns
+    -------
+    cds : bokeh.models.ColumnDataSource
+    """
     df = metrics_series.xs(metric, level='metric').unstack().T
+    # unstack sorts alphabetically, so manually reorder the columns
+    # to put them in the expected order. this ensures that plots are
+    # created in the same order and thus with the same colors for each
+    # forecast. GH issue 204, pull 244
     idx = pd.unique(metrics_series.index.get_level_values('forecast'))
     cds = ColumnDataSource(df[idx])
     return cds

--- a/solarforecastarbiter/reports/tests/test_figures.py
+++ b/solarforecastarbiter/reports/tests/test_figures.py
@@ -1,32 +1,73 @@
 from solarforecastarbiter.reports import figures
 
 import pandas as pd
+import numpy as np
+
+import pandas.testing as pdt
 
 import pytest
 
 
-def test_construct_metrics_cds():
+@pytest.fixture
+def metrics():
+    # important that these are not ordered alphabetically (GH 204)
     metrics = [
-        {
-            'name': 'Forecast 1 AAAA',
-            'total': {'mae': 74.},
-            'month': {'mae': pd.Series(74., index=[8])},
-            'day': {'mae': pd.Series(74., index=[21])},
-            'hour': {'mae': pd.Series([74., 75.], index=[12, 13])}
-        },
         {
             'name': 'Forecast 1 BBBB',
             'total': {'mae': 74.},
             'month': {'mae': pd.Series(74., index=[8])},
             'day': {'mae': pd.Series(74., index=[21])},
             'hour': {'mae': pd.Series([74., 75.], index=[12, 13])}
+        },
+        {
+            'name': 'Forecast 1 AAAA',
+            'total': {'mae': 74.},
+            'month': {'mae': pd.Series(74., index=[8])},
+            'day': {'mae': pd.Series(74., index=[21])},
+            'hour': {'mae': pd.Series([74., 75.], index=[12, 13])}
         }
     ]
+    return metrics
+
+
+@pytest.fixture
+def metrics_month():
+    index = pd.MultiIndex(
+        levels=[['mae'], ['Forecast 1 BBBB', 'Forecast 1 AAAA'], [8]],
+        codes=[[0, 0], [0, 1], [0, 0]],
+        names=['metric', 'forecast', 'month'])
+    return pd.Series([74., 74.], index=index)
+
+
+def test_construct_metrics_cds(metrics):
     cds = figures.construct_metrics_cds(metrics, 'total')
-    assert cds.data['forecast'][0] == 'Forecast 1 AAAA'
+    assert cds.data['forecast'][0] == 'Forecast 1 BBBB'
     cds = figures.construct_metrics_cds(metrics, 'total',
                                         rename=figures.abbreviate)
-    assert cds.data['forecast'][0] == 'For. 1 AAAA'
+    assert cds.data['forecast'][0] == 'For. 1 BBBB'
+
+
+def test_construct_metrics_series(metrics, metrics_month):
+    # same idea applies to month, day, hour, etc groupings
+    # could test more, but wait for refactoring
+    out = figures.construct_metrics_series(metrics, 'month')
+    pdt.assert_series_equal(out, metrics_month)
+
+
+def test_construct_metric_series_total(metrics):
+    # does not work for total
+    with pytest.raises(AttributeError):
+        figures.construct_metrics_series(metrics, 'total')
+
+
+def test_construct_metrics_cds2(metrics, metrics_month):
+    out = figures.construct_metrics_cds2(metrics_month, 'mae')
+    expected = {
+        'month': np.array([8]),
+        'Forecast 1 BBBB': np.array([74]),
+        'Forecast 1 AAAA': np.array([74])
+    }
+    assert out.data == expected
 
 
 @pytest.mark.parametrize('arg,expected', [


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #204 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
