### PR TITLE
add missing datamodel.Report and more classes to api.rst

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -55,6 +55,34 @@ Aggregates:
    datamodel.AggregateObservation
    datamodel.Aggregate
 
+Data validation toolkit filters for use with reports:
+
+.. autosummary::
+   :toctree: generated/
+
+   datamodel.BaseFilter
+   datamodel.QualityFlagFilter
+   datamodel.TimeOfDayFilter
+   datamodel.ValueFilter
+
+Containers to associate forecasts and observations for use with reports:
+
+.. autosummary::
+   :toctree: generated/
+
+   datamodel.ForecastObservation
+   datamodel.ProcessedForecastObservation
+
+Reports:
+
+.. autosummary::
+   :toctree: generated/
+
+   datamodel.ReportMetadata
+   datamodel.RawReport
+   datamodel.Report
+
+
 All :py:mod:`~solarforecastarbiter.datamodel` objects have ``from_dict`` and
 ``to_dict`` methods:
 

--- a/docs/source/whatsnew/1.0.0b2.rst
+++ b/docs/source/whatsnew/1.0.0b2.rst
@@ -49,6 +49,8 @@ Bug fixes
   prevent them from blocking the data. (:issue:`218`)
 * Fix inconsistent forecast ordering and coloring in report bar charts.
   (:issue:`204`)
+* :py:class:`datamodel.Report` and associated classes were missing from
+  :ref:`api` documentation. Fixed. (:issue:`228`)
 
 
 Contributors


### PR DESCRIPTION


  - [x] Closes #228  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).

  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).

  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
