### PR TITLE
add base_url to Report, make report links work on dev

### DIFF
--- a/solarforecastarbiter/cli.py
+++ b/solarforecastarbiter/cli.py
@@ -316,7 +316,8 @@ def report(verbose, user, password, base_url, report_file, output_file):
         start=pd.Timestamp(params['start']),
         end=pd.Timestamp(params['end']),
         forecast_observations=fx_obs,
-        metrics=params['metrics']
+        metrics=params['metrics'],
+        base_url=base_url
     )
     data = reports.get_data_for_report(session, report)
     raw_report = reports.create_raw_report_from_data(report, data)

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -943,6 +943,7 @@ class ReportMetadata(BaseModel):
     timezone: str
     versions: dict
     validation_issues: dict
+    base_url: Union[str, None] = None
 
 
 # need apply filtering + resampling to each forecast obs pair
@@ -1002,6 +1003,10 @@ class Report(BaseModel):
         Status of the report
     report_id : str
         ID of the report in the API
+    base_url : str or None
+        URL of the API for which Report, Observations, and Forecasts
+        can be found. If None, uses default set in
+        :py:ref:`~solarforecastarbiter.io.api`.
     raw_report : RawReport or None
         Once computed, the raw report should be stored here
     __version__ : str
@@ -1017,6 +1022,7 @@ class Report(BaseModel):
         default_factory=lambda: (QualityFlagFilter(), ))
     status: str = 'pending'
     report_id: str = ''
+    base_url: Union[str, None] = None
     raw_report: Union[None, RawReport] = None
     __version__: int = 0  # should add version to api
 

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -629,6 +629,7 @@ class APISession(requests.Session):
             datamodel.ForecastObservation(self.get_forecast(o[0]),
                                           self.get_observation(o[1]))
             for o in req_dict['object_pairs']])
+        req_dict['base_url'] = self.base_url
         return datamodel.Report.from_dict(req_dict)
 
     def get_report(self, report_id):

--- a/solarforecastarbiter/reports/main.py
+++ b/solarforecastarbiter/reports/main.py
@@ -110,7 +110,7 @@ def create_metadata(report_request):
         name=report_request.name, start=report_request.start,
         end=report_request.end, now=pd.Timestamp.utcnow(),
         timezone=timezone, versions=versions,
-        validation_issues=validation_issues)
+        validation_issues=validation_issues, base_url=report_request.base_url)
     return metadata
 
 

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -49,7 +49,14 @@ def template_report(report, metadata, metrics,
 
     strftime = '%Y-%m-%d %H:%M:%S %z'
 
+    if metadata.base_url:
+        dash_url = metadata.base_url.replace('api', 'dashboard')
+        dash_url = dash_url if dash_url.endswith('/') else dash_url + '/'
+    else:
+        dash_url = ''
+
     rendered = template.render(
+        dash_url=dash_url,
         name=metadata.name,
         start=metadata.start.strftime(strftime),
         end=metadata.end.strftime(strftime),

--- a/solarforecastarbiter/reports/templates/template.md
+++ b/solarforecastarbiter/reports/templates/template.md
@@ -5,13 +5,13 @@
 {# 2. jinja renders the "full report" - a markdown file with bokeh html/js with the above plus timeseries and scatter plots #}
 {# 3. pandoc renders the html or pdf version of the full report #}
 
-{# fix this #}
-{% set dash_url = 'https://dashboard.solarforecastarbiter.org' %}
+{# use empty string for relative urls. if provided, must end in / #}
+{% set dash_url = '' %}
 
 This report of solar forecast accuracy was automatically generated using the [Solar Forecast Arbiter](https://solarforecastarbiter.org).
 
 {{ '::: {.download}' }}
-{# Download as [html]({{ dash_url|safe }}/reports/download/{{ html_link|safe }}) or pdf]({{ dash_url|safe }}/reports/download/{{ pdf_link|safe }}) #}
+{# Download as [html]({{ dash_url|safe }}reports/download/{{ html_link|safe }}) or pdf]({{ dash_url|safe }}reports/download/{{ pdf_link|safe }}) #}
 Download as [html]() or [pdf]()
 :::
 
@@ -63,7 +63,7 @@ The table below shows the observation, forecast pairs analyzed in this report. T
 |:--------|---|---|---|---|:--------|---|---|---|---|
 Name|Interval label|Interval length|Aligned interval label|Resampled interval length|Name|Interval label|Interval length|Aligned interval label|Resampled interval length
 {% for fx_ob in proc_fx_obs -%}
-[{{ fx_ob.original.observation.name|safe }}]({{ dash_url|safe }}/observations/{{ fx_ob.original.observation.observation_id|safe }}) | {{ fx_ob.original.observation.interval_label | safe}} | {{ (fx_ob.original.observation.interval_length.total_seconds()/60)|int|safe }} min | {{ fx_ob.interval_label|safe }} | {{ (fx_ob.interval_length.total_seconds()/60)|int|safe }} min | [{{ fx_ob.original.forecast.name|safe }}]({{ dash_url|safe }}/forecasts/single/{{ fx_ob.original.forecast.forecast_id|safe }}) | {{ fx_ob.original.forecast.interval_label|safe }} | {{ (fx_ob.original.forecast.interval_length.total_seconds()/60)|int|safe }} min | {{ fx_ob.interval_label|safe }} | {{ (fx_ob.interval_length.total_seconds()/60)|int|safe }} min
+[{{ fx_ob.original.observation.name|safe }}]({{ dash_url|safe }}observations/{{ fx_ob.original.observation.observation_id|safe }}) | {{ fx_ob.original.observation.interval_label | safe}} | {{ (fx_ob.original.observation.interval_length.total_seconds()/60)|int|safe }} min | {{ fx_ob.interval_label|safe }} | {{ (fx_ob.interval_length.total_seconds()/60)|int|safe }} min | [{{ fx_ob.original.forecast.name|safe }}]({{ dash_url|safe }}forecasts/single/{{ fx_ob.original.forecast.forecast_id|safe }}) | {{ fx_ob.original.forecast.interval_label|safe }} | {{ (fx_ob.original.forecast.interval_length.total_seconds()/60)|int|safe }} min | {{ fx_ob.interval_label|safe }} | {{ (fx_ob.interval_length.total_seconds()/60)|int|safe }} min
 {% endfor %}
 
 The plots below show the realigned and resampled time series of observation and forecast data as well as a scatter plot of forecast vs observation data.

--- a/solarforecastarbiter/reports/templates/template.md
+++ b/solarforecastarbiter/reports/templates/template.md
@@ -5,9 +5,6 @@
 {# 2. jinja renders the "full report" - a markdown file with bokeh html/js with the above plus timeseries and scatter plots #}
 {# 3. pandoc renders the html or pdf version of the full report #}
 
-{# use empty string for relative urls. if provided, must end in / #}
-{% set dash_url = '' %}
-
 This report of solar forecast accuracy was automatically generated using the [Solar Forecast Arbiter](https://solarforecastarbiter.org).
 
 {{ '::: {.download}' }}


### PR DESCRIPTION


  - [ ] Closes #175 .
  - [ ] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

@alorenzo175 I'll fix the tests if you're ok with the approach. Could also scrap this and wait for a reports refactor. I kinda wanted to put `base_url` on the Observations and Forecasts, too, but that felt like a step too far for now.
