### PR TITLE
Adjust functions that will be used in scheduled jobs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -289,6 +289,7 @@ Class for communicating with the Solar Forecast Arbiter API.
 
    io.api.APISession
    io.api.APISession.request
+   io.api.APISession.get_user_info
 
 Sites
 

--- a/docs/source/whatsnew/1.0.0b3.rst
+++ b/docs/source/whatsnew/1.0.0b3.rst
@@ -14,8 +14,8 @@ API Changes
   (:pull:`256`)
 * Add :py:meth:`~solarforecastarbiter.io.api.APISession.get_values`.
   (:pull:`256`)
-* Added the `provider` parameter to :py:mod:`solarforecastarbiter.Datamodel`
-  objects that were missing it
+* Add the `provider` parameter to :py:mod:`solarforecastarbiter.Datamodel`
+  objects that were missing it (:pull:`260`)
 * Add :py:mod:`solarforecastarbiter.io.api.APISession.get_user_info`
   to get information about the current API user (:pull:`260`)
 
@@ -24,7 +24,7 @@ Enhancements
 * Add capability to analyze aggregates to reports. (:pull:`256`)
 * :py:mod:`solarforecastarbiter.reference_forecasts.main.make_latest_nwp_forecasts`
   now only tries to update forecasts that have the same provider as the user's
-  organization
+  organization (:pull:`260`)
 * :py:mod:`solarforecastarbiter.validation.tasks.daily_observation_validation`
   only validates data for observations with the same provider as the user's
   organization (:pull:`260`)

--- a/docs/source/whatsnew/1.0.0b3.rst
+++ b/docs/source/whatsnew/1.0.0b3.rst
@@ -14,6 +14,8 @@ API Changes
   (:pull:`256`)
 * Add :py:meth:`~solarforecastarbiter.io.api.APISession.get_values`.
   (:pull:`256`)
+* Added the `provider` parameter to :py:mod:`solarforecastarbiter.Datamodel`
+  objects that were missing it
 
 Enhancements
 ~~~~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0b3.rst
+++ b/docs/source/whatsnew/1.0.0b3.rst
@@ -16,6 +16,8 @@ API Changes
   (:pull:`256`)
 * Added the `provider` parameter to :py:mod:`solarforecastarbiter.Datamodel`
   objects that were missing it
+* Add :py:mod:`solarforecastarbiter.io.api.APISession.get_user_info`
+  to get information about the current API user
 
 Enhancements
 ~~~~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0b3.rst
+++ b/docs/source/whatsnew/1.0.0b3.rst
@@ -17,7 +17,7 @@ API Changes
 * Added the `provider` parameter to :py:mod:`solarforecastarbiter.Datamodel`
   objects that were missing it
 * Add :py:mod:`solarforecastarbiter.io.api.APISession.get_user_info`
-  to get information about the current API user
+  to get information about the current API user (:pull:`260`)
 
 Enhancements
 ~~~~~~~~~~~~
@@ -27,16 +27,16 @@ Enhancements
   organization
 * :py:mod:`solarforecastarbiter.validation.tasks.daily_observation_validation`
   only validates data for observations with the same provider as the user's
-  organization
+  organization (:pull:`260`)
 * Merge multiple quality flag filters together before applying in report
-  generation.
+  generation. (:pull:`260`)
 
 Bug fixes
 ~~~~~~~~~
 * Log MIDC CSV parsing errors, but continue with other sites (:issue:`254`)
 * Fix issue of assuming the first report filter is a QualityFlagFilter,
-  partially addressing (:pull:`251`)
-* Test that pandoc report generation actually generates the HTML body
+  partially addressing (:issue:`251`) (:pull:`260`)
+* Test that pandoc report generation actually generates the HTML body (:pull:`260`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0b3.rst
+++ b/docs/source/whatsnew/1.0.0b3.rst
@@ -28,10 +28,15 @@ Enhancements
 * :py:mod:`solarforecastarbiter.validation.tasks.daily_observation_validation`
   only validates data for observations with the same provider as the user's
   organization
+* Merge multiple quality flag filters together before applying in report
+  generation.
 
 Bug fixes
 ~~~~~~~~~
 * Log MIDC CSV parsing errors, but continue with other sites (:issue:`254`)
+* Fix issue of assuming the first report filter is a QualityFlagFilter,
+  partially addressing (:pull:`251`)
+* Test that pandoc report generation actually generates the HTML body
 
 Contributors
 ~~~~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0b3.rst
+++ b/docs/source/whatsnew/1.0.0b3.rst
@@ -22,6 +22,9 @@ API Changes
 Enhancements
 ~~~~~~~~~~~~
 * Add capability to analyze aggregates to reports. (:pull:`256`)
+* :py:mod:`solarforecastarbiter.reference_forecasts.main.make_latest_nwp_forecasts`
+  now only tries to update forecasts that have the same provider as the user's
+  organization
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0b3.rst
+++ b/docs/source/whatsnew/1.0.0b3.rst
@@ -25,6 +25,9 @@ Enhancements
 * :py:mod:`solarforecastarbiter.reference_forecasts.main.make_latest_nwp_forecasts`
   now only tries to update forecasts that have the same provider as the user's
   organization
+* :py:mod:`solarforecastarbiter.validation.tasks.daily_observation_validation`
+  only validates data for observations with the same provider as the user's
+  organization
 
 Bug fixes
 ~~~~~~~~~

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -629,6 +629,7 @@ def _observation_from_dict(get_site):
             site=get_site(obs_dict['site_id']),
             uncertainty=obs_dict['uncertainty'],
             observation_id=obs_dict.get('observation_id', ''),
+            provider=obs_dict.get('provider', ''),
             extra_parameters=obs_dict.get('extra_parameters', ''))
     return f
 
@@ -782,6 +783,7 @@ def _forecast_from_dict(single_site, get_site, get_aggregate):
             lead_time_to_start=pd.Timedelta(f"{fx_dict['lead_time_to_start']}min"),  # NOQA
             run_length=pd.Timedelta(f"{fx_dict['run_length']}min"),
             forecast_id=fx_dict.get('forecast_id', ''),
+            provider=fx_dict.get('provider', ''),
             extra_parameters=fx_dict.get('extra_parameters', ''))
     return f
 
@@ -971,6 +973,7 @@ def _prob_forecast_constant_value_from_dict(get_site, get_aggregate):
             lead_time_to_start=pd.Timedelta(f"{fx_dict['lead_time_to_start']}min"),  # NOQA
             run_length=pd.Timedelta(f"{fx_dict['run_length']}min"),
             forecast_id=fx_dict.get('forecast_id', ''),
+            provider=fx_dict.get('provider', ''),
             extra_parameters=fx_dict.get('extra_parameters', ''),
             axis=fx_dict['axis'],
             constant_value=fx_dict['constant_value'])
@@ -997,6 +1000,7 @@ def _prob_forecast_from_dict(get_site, prob_forecast_constant_value,
             lead_time_to_start=pd.Timedelta(f"{fx_dict['lead_time_to_start']}min"),  # NOQA
             run_length=pd.Timedelta(f"{fx_dict['run_length']}min"),
             forecast_id=fx_dict.get('forecast_id', ''),
+            provider=fx_dict.get('provider', ''),
             extra_parameters=fx_dict.get('extra_parameters', ''),
             axis=fx_dict['axis'],
             constant_values=(cv,))
@@ -1411,6 +1415,7 @@ def aggregateforecast(aggregate_forecast_text, aggregate):
         lead_time_to_start=pd.Timedelta(f"{fx_dict['lead_time_to_start']}min"),  # NOQA
         run_length=pd.Timedelta(f"{fx_dict['run_length']}min"),
         forecast_id=fx_dict.get('forecast_id', ''),
+        provider=fx_dict.get('provider', ''),
         extra_parameters=fx_dict.get('extra_parameters', ''))
 
 
@@ -1491,17 +1496,18 @@ def aggregate_prob_forecast(aggregate_prob_forecast_text,
     fx_dict = json.loads(aggregate_prob_forecast_text)
     fx_dict['constant_values'] = agg_prob_forecast_constant_value
     return datamodel.ProbabilisticForecast(
-            name=fx_dict['name'], variable=fx_dict['variable'],
-            interval_value_type=fx_dict['interval_value_type'],
-            interval_length=pd.Timedelta(f"{fx_dict['interval_length']}min"),
-            interval_label=fx_dict['interval_label'],
-            site=None,
-            aggregate=aggregate,
-            issue_time_of_day=dt.time(int(fx_dict['issue_time_of_day'][:2]),
-                                      int(fx_dict['issue_time_of_day'][3:])),
-            lead_time_to_start=pd.Timedelta(f"{fx_dict['lead_time_to_start']}min"),  # NOQA
-            run_length=pd.Timedelta(f"{fx_dict['run_length']}min"),
-            forecast_id=fx_dict.get('forecast_id', ''),
-            extra_parameters=fx_dict.get('extra_parameters', ''),
-            axis=fx_dict['axis'],
-            constant_values=(agg_prob_forecast_constant_value, ))
+        name=fx_dict['name'], variable=fx_dict['variable'],
+        interval_value_type=fx_dict['interval_value_type'],
+        interval_length=pd.Timedelta(f"{fx_dict['interval_length']}min"),
+        interval_label=fx_dict['interval_label'],
+        site=None,
+        aggregate=aggregate,
+        issue_time_of_day=dt.time(int(fx_dict['issue_time_of_day'][:2]),
+                                  int(fx_dict['issue_time_of_day'][3:])),
+        lead_time_to_start=pd.Timedelta(f"{fx_dict['lead_time_to_start']}min"),
+        run_length=pd.Timedelta(f"{fx_dict['run_length']}min"),
+        forecast_id=fx_dict.get('forecast_id', ''),
+        extra_parameters=fx_dict.get('extra_parameters', ''),
+        provider=fx_dict.get('provider', ''),
+        axis=fx_dict['axis'],
+        constant_values=(agg_prob_forecast_constant_value, ))

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -743,7 +743,7 @@ class ProbabilisticForecastConstantValue(
     forecast_id : str, optional
         UUID of the forecast in the API
     provider : str, optional
-        Provider of the ProbabilisticForecast information.
+        Provider of the ProbabilisticForecastConstantValue information.
     extra_parameters : str, optional
         Extra configuration parameters of forecast.
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -433,6 +433,8 @@ class Observation(BaseModel):
         will be determined later.
     observation_id : str, optional
         UUID of the observation in the API
+    provider : str, optional
+        Provider of the Observation information.
     extra_parameters : str, optional
         Any extra parameters for the observation
 
@@ -448,6 +450,7 @@ class Observation(BaseModel):
     site: Site
     uncertainty: float
     observation_id: str = ''
+    provider: str = ''
     extra_parameters: str = ''
     units: str = field(init=False)
     __post_init__ = __set_units__
@@ -602,6 +605,7 @@ class _ForecastDefaultsBase:
     site: Union[Site, None] = None
     aggregate: Union[Aggregate, None] = None
     forecast_id: str = ''
+    provider: str = ''
     extra_parameters: str = ''
     units: str = field(init=False)
 
@@ -655,6 +659,8 @@ class Forecast(BaseModel, _ForecastDefaultsBase, _ForecastBase):
         The predefined aggregate that the forecast is for, e.g. Aggregate Y.
     forecast_id : str, optional
         UUID of the forecast in the API
+    provider : str, optional
+        Provider of the Forecast information.
     extra_parameters : str, optional
         Extra configuration parameters of forecast.
 
@@ -736,6 +742,8 @@ class ProbabilisticForecastConstantValue(
         The variable value or percentile.
     forecast_id : str, optional
         UUID of the forecast in the API
+    provider : str, optional
+        Provider of the ProbabilisticForecast information.
     extra_parameters : str, optional
         Extra configuration parameters of forecast.
 
@@ -804,6 +812,8 @@ class ProbabilisticForecast(
         be converted to ProbabilisticForecastConstantValue objects.
     forecast_id : str, optional
         UUID of the forecast in the API
+    provider : str, optional
+        Provider of the ProbabilisticForecast information.
     extra_parameters : str, optional
         Extra configuration parameters of forecast.
 
@@ -1059,6 +1069,8 @@ class Report(BaseModel):
         ID of the report in the API
     raw_report : RawReport or None
         Once computed, the raw report should be stored here
+    provider : str, optional
+        Provider of the Report information.
     __version__ : str
         Should be used to version reports to ensure even older
         reports can be properly rendered
@@ -1074,6 +1086,7 @@ class Report(BaseModel):
     status: str = 'pending'
     report_id: str = ''
     raw_report: Union[None, RawReport] = None
+    provider: str = ''
     __version__: int = 0  # should add version to api
 
     def __post_init__(self):

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -222,6 +222,7 @@ class APISession(requests.Session):
         """
         obs_dict = observation.to_dict()
         obs_dict.pop('observation_id')
+        obs_dict.pop('provider')
         site = obs_dict.pop('site')
         obs_dict['site_id'] = site['site_id']
         obs_json = json.dumps(obs_dict)
@@ -292,6 +293,7 @@ class APISession(requests.Session):
         """
         fx_dict = forecast.to_dict()
         fx_dict.pop('forecast_id')
+        fx_dict.pop('provider')
         site = fx_dict.pop('site')
         agg = fx_dict.pop('aggregate')
         if site is None and agg is not None:
@@ -435,6 +437,7 @@ class APISession(requests.Session):
         """
         fx_dict = forecast.to_dict()
         fx_dict.pop('forecast_id')
+        fx_dict.pop('provider')
         site = fx_dict.pop('site')
         agg = fx_dict.pop('aggregate')
         if site is None and agg is not None:
@@ -716,6 +719,7 @@ class APISession(requests.Session):
         """
         report_dict = report.to_dict()
         report_dict.pop('report_id')
+        report_dict.pop('provider')
         name = report_dict.pop('name')
         for key in ('raw_report', '__version__', 'status'):
             del report_dict[key]

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -1017,3 +1017,14 @@ class APISession(requests.Session):
             f = self.get_observation_values
             obj_id = obj.observation_id
         return f(obj_id, start, end, interval_label=interval_label)
+
+    def get_user_info(self):
+        """
+        Get information about the current user from the API
+
+        Returns
+        -------
+        dict
+        """
+        req = self.get('/users/current')
+        return req.json()

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -813,6 +813,14 @@ def test_apisession_create_aggregate(requests_mock, aggregate, aggregate_text,
     assert new_aggregate == aggregate
 
 
+def test_apisession_get_user_info(requests_mock):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/users/current')
+    requests_mock.register_uri('GET', matcher, content=b'{"test": "key"}')
+    out = session.get_user_info()
+    assert out['test'] == 'key'
+
+
 @pytest.fixture(scope='session')
 def auth_token():
     try:
@@ -1114,3 +1122,8 @@ def test_real_apisession_get_aggregate_values(real_session):
     assert set(agg.columns) == set(['value', 'quality_flag'])
     assert len(agg.index) > 0
     pdt.assert_frame_equal(agg.loc[start:end], agg)
+
+
+def test_real_apisession_get_user_info(real_session):
+    user_info = real_session.get_user_info()
+    assert user_info['organization'] == 'Organization 1'

--- a/solarforecastarbiter/reference_forecasts/tests/test_main.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_main.py
@@ -309,7 +309,9 @@ def forecast_list(ac_power_forecast_metadata):
             replace(ac_power_forecast_metadata,
                     extra_parameters='{"piggyback_on": "0", "model": "%s", "is_reference_forecast": true}' % model,  # NOQA
                     forecast_id='3',
-                    variable='dni'),
+                    variable='dni',
+                    provider='Organization 2'
+            ),
             replace(ac_power_forecast_metadata,
                     extra_parameters='{"piggyback_on": "0", "model": "badmodel", "is_reference_forecast": true}',  # NOQA
                     forecast_id='4'),
@@ -496,10 +498,12 @@ def test__post_forecast_values_cdf_no_cv_match(mocker, forecast_list):
 ])
 def test_make_latest_nwp_forecasts(forecast_list, mocker, issue_buffer, empty):
     session = mocker.patch('solarforecastarbiter.io.api.APISession')
+    session.return_value.get_user_info.return_value = {'organization': ''}
     session.return_value.list_forecasts.return_value = forecast_list[:-3]
     session.return_value.list_probabilistic_forecasts.return_value = []
     run_time = pd.Timestamp('20190501T0000Z')
-    fxdf = main.find_reference_nwp_forecasts(forecast_list[:-3], run_time)
+    # last fx has different org
+    fxdf = main.find_reference_nwp_forecasts(forecast_list[:-4], run_time)
     process = mocker.patch(
         'solarforecastarbiter.reference_forecasts.main.process_nwp_forecast_groups')  # NOQA
     main.make_latest_nwp_forecasts('', run_time, issue_buffer)

--- a/solarforecastarbiter/reports/main.py
+++ b/solarforecastarbiter/reports/main.py
@@ -155,6 +155,15 @@ def get_validation_issues():
     return test
 
 
+def _merge_quality_filters(filters):
+    """Merge any quality flag filters into one single QualityFlagFilter"""
+    combo = set()
+    for filter_ in filters:
+        if isinstance(filter_, datamodel.QualityFlagFilter):
+            combo |= set(filter_.quality_flags)
+    return datamodel.QualityFlagFilter(tuple(combo))
+
+
 def validate_resample_align(report, metadata, data):
     """
     Validate the data and resample.
@@ -176,8 +185,9 @@ def validate_resample_align(report, metadata, data):
     ----
     * Support different apply_validation fillin functions.
     """
+    qfilter = _merge_quality_filters(report.filters)
     data_validated = preprocessing.apply_validation(data,
-                                                    report.filters[0],
+                                                    qfilter,
                                                     preprocessing.exclude)
     processed_fxobs = [preprocessing.resample_and_align(
                             fxobs, data_validated, metadata.timezone)

--- a/solarforecastarbiter/reports/tests/test_reports_main.py
+++ b/solarforecastarbiter/reports/tests/test_reports_main.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 import shutil
 
 
@@ -82,6 +83,10 @@ def test_full_render(mock_data, report_objects):
     report_md = main.render_raw_report(raw_report)
     body = template.report_md_to_html(report_md)
     full_report = template.full_html(body)
+    # at least one non whitespace character in body, usually caused
+    # by pandoc version error
+    assert re.search(
+        r'<body>(.*\S.*)</body>', full_report, re.S) is not None
     with open('bokeh_report.html', 'w') as f:
         f.write(full_report)
 

--- a/solarforecastarbiter/reports/tests/test_reports_main.py
+++ b/solarforecastarbiter/reports/tests/test_reports_main.py
@@ -91,9 +91,35 @@ def test_full_render(mock_data, report_objects):
         f.write(full_report)
 
 
-def test_validate_resample_align(mock_data, report_objects):
-    report, observation, forecast_0, forecast_1, aggregate, forecast_agg = \
-        report_objects
+def test_merge_quality_filters():
+    filters = [
+        datamodel.QualityFlagFilter(('USER FLAGGED', 'NIGHTTIME',
+                                     'CLIPPED VALUES')),
+        datamodel.QualityFlagFilter(('SHADED', 'NIGHTTIME',)),
+        datamodel.QualityFlagFilter(())
+    ]
+    out = main._merge_quality_filters(filters)
+    assert set(out.quality_flags) == {'USER FLAGGED', 'NIGHTTIME',
+                                      'CLIPPED VALUES', 'SHADED'}
+
+
+@pytest.fixture(scope='module', params=[0, 1, 2])
+def more_report_objects(report_objects, request):
+    report, observation, forecast_0, forecast_1, *_ = report_objects
+    if request.param == 0:
+        return report, observation, forecast_0, forecast_1
+    elif request.param == 1:
+        new_filters = ()
+        return (report.replace(filters=new_filters), observation, forecast_0,
+                forecast_1)
+    elif request.param == 2:
+        new_filters = (datamodel.QualityFlagFilter(()),)
+        return (report.replace(filters=new_filters), observation, forecast_0,
+                forecast_1)
+
+
+def test_validate_resample_align(mock_data, more_report_objects):
+    report, observation, forecast_0, forecast_1 = more_report_objects
     meta = main.create_metadata(report)
     session = api.APISession('nope')
     data = main.get_data_for_report(session, report)

--- a/solarforecastarbiter/reports/tests/test_reports_main.py
+++ b/solarforecastarbiter/reports/tests/test_reports_main.py
@@ -103,7 +103,7 @@ def test_merge_quality_filters():
                                       'CLIPPED VALUES', 'SHADED'}
 
 
-@pytest.fixture(scope='module', params=[0, 1, 2])
+@pytest.fixture(params=[0, 1, 2])
 def more_report_objects(report_objects, request):
     report, observation, forecast_0, forecast_1, *_ = report_objects
     if request.param == 0:

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -335,6 +335,7 @@ def test_probabilistic_forecast_float_constant_values(prob_forecasts):
         forecast_id=prob_forecasts.forecast_id,
         axis=prob_forecasts.axis,
         extra_parameters=prob_forecasts.extra_parameters,
+        provider=prob_forecasts.provider,
         constant_values=tuple(cv.constant_value
                               for cv in prob_forecasts.constant_values),
     )

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -427,10 +427,12 @@ def daily_single_observation_validation(access_token, observation_id, start,
 def daily_observation_validation(access_token, start, end, base_url=None):
     """
     Run the daily observation validation for all observations that the user
-    has access to.
+    has access to in their organization.
     """
     session = APISession(access_token, base_url=base_url)
-    observations = session.list_observations()
+    user_info = session.get_user_info()
+    observations = [obs for obs in session.list_observations()
+                    if obs.provider == user_info['organization']]
     for observation in observations:
         try:
             _daily_validation(session, observation, start, end, base_url)

--- a/solarforecastarbiter/validation/tests/test_validation_tasks.py
+++ b/solarforecastarbiter/validation/tests/test_validation_tasks.py
@@ -16,7 +16,7 @@ def make_observation(single_site):
             name='test', variable=variable, interval_value_type='mean',
             interval_length=pd.Timedelta('1hr'), interval_label='beginning',
             site=single_site, uncertainty=0.1, observation_id='OBSID',
-            extra_parameters='')
+            provider='Organization 1', extra_parameters='')
     return f
 
 
@@ -736,6 +736,7 @@ def test_daily_observation_validation_other(var, mocker, make_observation,
 def test_daily_observation_validation_many(mocker, make_observation,
                                            daily_index):
     obs = [make_observation('dhi'), make_observation('dni')]
+    obs += [make_observation('ghi').replace(provider='Organization 2')]
     data = pd.DataFrame(
         [(0, 0), (100, 0), (-100, 0), (100, 0), (300, 0),
          (300, 0), (300, 0), (300, 0), (100, 0), (0, 0),
@@ -744,6 +745,8 @@ def test_daily_observation_validation_many(mocker, make_observation,
         columns=['value', 'quality_flag'])
     mocker.patch('solarforecastarbiter.io.api.APISession.list_observations',
                  return_value=obs)
+    mocker.patch('solarforecastarbiter.io.api.APISession.get_user_info',
+                 return_value={'organization': obs[0].provider})
     mocker.patch(
         'solarforecastarbiter.io.api.APISession.get_observation_values',
         return_value=data)
@@ -792,6 +795,8 @@ def test_daily_observation_validation_not_enough(mocker, make_observation):
         columns=['value', 'quality_flag'])
     mocker.patch('solarforecastarbiter.io.api.APISession.list_observations',
                  return_value=obs)
+    mocker.patch('solarforecastarbiter.io.api.APISession.get_user_info',
+                 return_value={'organization': obs[0].provider})
     mocker.patch(
         'solarforecastarbiter.io.api.APISession.get_observation_values',
         return_value=data)


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #xxxx .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Primarily adjusts the functions to make reference nwp forecasts and the daily observation validation to only apply to forecasts/observation in the same organization as the user executing said functions. This is required for the scheduled job executors that only alter data within their organization. The adjustments also required that the provider parameter be added to the datamodel objects that were missing it. 

Also fix the assumption that the first filter in a report is a quality flag filter.
