### PR TITLE
metrics: add valuation metrics

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -437,6 +437,13 @@ Functions to compute forecast probabilistic performance metrics:
     metrics.probabilistic.sharpness
     metrics.probabilistic.continuous_ranked_probability_score
 
+Functions to compute forecast valuation metrics:
+
+.. autosummary::
+    :toctree: generated/
+
+    metrics.valuation.fixed_error_cost
+
 Reports
 =======
 

--- a/docs/source/whatsnew/1.0.0b3.rst
+++ b/docs/source/whatsnew/1.0.0b3.rst
@@ -22,6 +22,8 @@ API Changes
   :py:mod:`solarforecastarbiter.metrics.probabilistic.continuous_ranked_probability_score`. (:issue:`250`) (:pull:`257`)
 * Standardize metric input naming and order conventions to `function(obs, fx)`,
   where `obs` = observations and `fx` = forecasts (:issue:`262`) (:pull:`263`)
+* Add valuation metric for evaluating forecast errors
+  :py:mod:`solarforecastarbiter.metrics.valuation.fixed_error_cost` (:issue:`258`) (:pull:`261`)
 
 Enhancements
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/metrics/tests/test_valuation.py
+++ b/solarforecastarbiter/metrics/tests/test_valuation.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 from solarforecastarbiter.metrics import valuation
 
+
 @pytest.mark.parametrize("fx,obs,cost,value", [
     # 10 USD per MW
     (np.array([1, 2, 3]), np.array([1, 2, 3]), 10, 0.0),

--- a/solarforecastarbiter/metrics/tests/test_valuation.py
+++ b/solarforecastarbiter/metrics/tests/test_valuation.py
@@ -12,4 +12,4 @@ from solarforecastarbiter.metrics import valuation
     (np.array([500, 600, 650]), np.array([500, 580, 630]), 1, 20 + 20),
 ])
 def test_fixed_cost(fx, obs, cost, value):
-    return valuation.fixed_error_cost(fx, obs, cost) == value
+    return valuation.fixed_error_cost(obs, fx, cost) == value

--- a/solarforecastarbiter/metrics/tests/test_valuation.py
+++ b/solarforecastarbiter/metrics/tests/test_valuation.py
@@ -4,9 +4,12 @@ from solarforecastarbiter.metrics import valuation
 
 
 @pytest.mark.parametrize("fx,obs,cost,value", [
-    # 10 USD per MW
+    # cost: 10 USD per kW
     (np.array([1, 2, 3]), np.array([1, 2, 3]), 10, 0.0),
     (np.array([1, 2, 3]), np.array([2, 3, 4]), 10, 3 * 10),
+
+    # cost: 1 USD per W/m^2
+    (np.array([500, 600, 650]), np.array([500, 580, 630]), 1, 20 + 20),
 ])
 def test_fixed_cost(fx, obs, cost, value):
     return valuation.fixed_error_cost(fx, obs, cost) == value

--- a/solarforecastarbiter/metrics/tests/test_valuation.py
+++ b/solarforecastarbiter/metrics/tests/test_valuation.py
@@ -1,0 +1,11 @@
+import pytest
+import numpy as np
+from solarforecastarbiter.metrics import valuation
+
+@pytest.mark.parametrize("fx,obs,cost,value", [
+    # 10 USD per MW
+    (np.array([1, 2, 3]), np.array([1, 2, 3]), 10, 0.0),
+    (np.array([1, 2, 3]), np.array([2, 3, 4]), 10, 3 * 10),
+])
+def test_fixed_cost(fx, obs, cost, value):
+    return valuation.fixed_error_cost(fx, obs, cost) == value

--- a/solarforecastarbiter/metrics/valuation.py
+++ b/solarforecastarbiter/metrics/valuation.py
@@ -30,7 +30,7 @@ def fixed_error_cost(obs, fx, cost):
 
     Forecast power [kW], cost: 10 USD per kW
     >>> fx = np.array([1, 2, 3])
-    >>> obs = np.array([1, 3, 4])
+    >>> obs = np.array([1, 1, 4])
     >>> cost = 10  # 10 USD per kW
     >>> fixed_error_cost(fx, obs, cost)
     20

--- a/solarforecastarbiter/metrics/valuation.py
+++ b/solarforecastarbiter/metrics/valuation.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 
-def fixed_error_cost(fx, obs, cost):
+def fixed_error_cost(obs, fx, cost):
     """Fixed cost per forecast error.
 
         total_cost = sum_{i=1}^n |fx_i - obs_i| * cost
@@ -13,10 +13,10 @@ def fixed_error_cost(fx, obs, cost):
 
     Parameters
     ----------
-    fx : (n,) array_like
-        Forecasts.
-    obs : (n,) array_like
-        Observations.
+    obs : (n,) array-like
+        Observed values.
+    fx : (n,) array-like
+        Forecasted values.
     cost : float
         The fixed cost per error (e.g. USD per MW).
 

--- a/solarforecastarbiter/metrics/valuation.py
+++ b/solarforecastarbiter/metrics/valuation.py
@@ -38,5 +38,5 @@ def fixed_error_cost(obs, fx, cost):
     """
 
     error = np.abs(fx - obs)
-    total_cost = np.sum(error * cost)
+    total_cost = np.sum(error) * cost  # more efficient than sum(error * cost)
     return total_cost

--- a/solarforecastarbiter/metrics/valuation.py
+++ b/solarforecastarbiter/metrics/valuation.py
@@ -6,9 +6,9 @@ import numpy as np
 def fixed_error_cost(fx, obs, cost):
     """Fixed cost per forecast error.
 
-        C = sum_{i=1}^n |fx_i - obs_i| * cost_i
+        C = sum_{i=1}^n |fx_i - obs_i| * cost
 
-    where cost_i is the fixed cost per forecast error (e.g. USD per MW of
+    where cost is the fixed cost per forecast error (e.g. USD per MW of
     error) and C is the total cost.
 
     Parameters
@@ -24,6 +24,16 @@ def fixed_error_cost(fx, obs, cost):
     -------
     total_cost : float
         Total cost (e.g. USD).
+
+    Examples
+    --------
+
+    Forecast power [kW], cost: 10 USD per kW
+    >>> fx = np.array([1, 2, 3])
+    >>> obs = np.array([1, 3, 4])
+    >>> cost = 10  # 10 USD per kW
+    >>> fixed_error_cost(fx, obs, cost)
+    20
 
     """
 

--- a/solarforecastarbiter/metrics/valuation.py
+++ b/solarforecastarbiter/metrics/valuation.py
@@ -1,0 +1,32 @@
+"""Metrics for quantifying the (monetary) value of forecasts."""
+
+import numpy as np
+
+
+def fixed_error_cost(fx, obs, cost):
+    """Fixed cost per forecast error.
+
+        C = sum_{i=1}^n |fx_i - obs_i| * cost_i
+
+    where cost_i is the fixed cost per forecast error (e.g. USD per MW of
+    error) and C is the total cost.
+
+    Parameters
+    ----------
+    fx : (n,) array_like
+        Forecasts.
+    obs : (n,) array_like
+        Observations.
+    cost : float
+        The fixed cost per error (e.g. USD per MW).
+
+    Returns
+    -------
+    total_cost : float
+        Total cost (e.g. USD).
+
+    """
+
+    error = np.abs(fx - obs)
+    total_cost = np.sum(error * cost)
+    return total_cost

--- a/solarforecastarbiter/metrics/valuation.py
+++ b/solarforecastarbiter/metrics/valuation.py
@@ -6,10 +6,10 @@ import numpy as np
 def fixed_error_cost(fx, obs, cost):
     """Fixed cost per forecast error.
 
-        C = sum_{i=1}^n |fx_i - obs_i| * cost
+        total_cost = sum_{i=1}^n |fx_i - obs_i| * cost
 
-    where cost is the fixed cost per forecast error (e.g. USD per MW of
-    error) and C is the total cost.
+    where cost is the fixed cost per forecast error (e.g. USD per MW of error)
+    and total_cost is cost of the entire forecast time-series.
 
     Parameters
     ----------

--- a/solarforecastarbiter/metrics/valuation.py
+++ b/solarforecastarbiter/metrics/valuation.py
@@ -1,4 +1,4 @@
-"""Metrics for quantifying the (monetary) value of forecasts."""
+"""Metrics for quantifying the monetary value of forecasts."""
 
 import numpy as np
 


### PR DESCRIPTION
  - [x] Closes #258 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This PR is focused on adding some forecast valuation metrics for quantifying the monetary cost of forecast errors. Note: the name (`solarforecastarbiter.metrics.valuation`) was chosen to avoid namespace conflicts with the (more commonly used terms) `cost` and `value`
