### PR TITLE
metrics: standardize input naming + ordering

### DIFF
--- a/docs/source/whatsnew/1.0.0b3.rst
+++ b/docs/source/whatsnew/1.0.0b3.rst
@@ -18,10 +18,8 @@ API Changes
   objects that were missing it (:pull:`260`)
 * Add :py:mod:`solarforecastarbiter.io.api.APISession.get_user_info`
   to get information about the current API user (:pull:`260`)
-
 * Add additional metric for probabilistic forecasts
   :py:mod:`solarforecastarbiter.metrics.probabilistic.continuous_ranked_probability_score`. (:issue:`250`) (:pull:`257`)
-
 * Standardize metric input naming and order conventions to `function(obs, fx)`,
   where `obs` = observations and `fx` = forecasts (:issue:`262`) (:pull:`263`)
 

--- a/docs/source/whatsnew/1.0.0b3.rst
+++ b/docs/source/whatsnew/1.0.0b3.rst
@@ -22,6 +22,9 @@ API Changes
 * Add additional metric for probabilistic forecasts
   :py:mod:`solarforecastarbiter.metrics.probabilistic.continuous_ranked_probability_score`. (:issue:`250`) (:pull:`257`)
 
+* Standardize metric input naming and order conventions to `function(obs, fx)`,
+  where `obs` = observations and `fx` = forecasts (:issue:`262`) (:pull:`263`)
+
 Enhancements
 ~~~~~~~~~~~~
 * Add capability to analyze aggregates to reports. (:pull:`256`)

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -131,7 +131,7 @@ def normalized_root_mean_square(obs, fx, norm):
     return root_mean_square(obs, fx) / norm * 100.0
 
 
-def forecast_skill(obs, fx, ref):
+def forecast_skill(obs, fx, fx_ref):
     """Forecast skill (s).
 
         s = 1 - RMSE_fx / RMSE_ref
@@ -145,7 +145,7 @@ def forecast_skill(obs, fx, ref):
         Observed values.
     fx : (n,) array-like
         Forecasted values.
-    ref : (n,) array_like
+    fx_ref : (n,) array_like
         A reference forecast.
 
     Returns
@@ -157,7 +157,7 @@ def forecast_skill(obs, fx, ref):
     """
 
     rmse_fx = root_mean_square(obs, fx)
-    rmse_ref = root_mean_square(obs, ref)
+    rmse_ref = root_mean_square(obs, fx_ref)
     return 1.0 - rmse_fx / rmse_ref
 
 

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -19,218 +19,218 @@ __all__ = [
 ]
 
 
-def mean_absolute(y_true, y_pred):
+def mean_absolute(obs, fx):
     """Mean absolute error (MAE).
 
     Parameters
     ----------
-    y_true : array-like
-        True values.
-    y_pred : array-like
-        Predicted values.
+    obs : (n,) array-like
+        Observed values.
+    fx : (n,) array-like
+        Forecasted values.
 
     Returns
     -------
     mae : float
-        The MAE between the true and predicted values.
+        The MAE of the forecast.
+
     """
 
-    return np.mean(np.abs(y_true - y_pred))
+    return np.mean(np.abs(fx - obs))
 
 
-def mean_bias(y_true, y_pred):
+def mean_bias(obs, fx):
     """Mean bias error (MBE).
 
     Parameters
     ----------
-    y_true : array-like
-        True values.
-    y_pred : array-like
-        Predicted values.
+    obs : (n,) array-like
+        Observed values.
+    fx : (n,) array-like
+        Forecasted values.
 
     Returns
     -------
     mbe : float
-        The MBE between the true and predicted values.
+        The MBE of the forecast.
 
     """
 
-    return np.mean(y_pred - y_true)
+    return np.mean(fx - obs)
 
 
-def root_mean_square(y_true, y_pred):
+def root_mean_square(obs, fx):
     """Root mean square error (RMSE).
 
     Parameters
     ----------
-    y_true : array-like
-        True values.
-    y_pred : array-like
-        Predicted values.
+    obs : (n,) array-like
+        Observed values.
+    fx : (n,) array-like
+        Forecasted values.
 
     Returns
     -------
     rmse : float
-        The RMSE between the true and predicted values.
+        The RMSE of the forecast.
 
     """
 
-    return np.sqrt(np.mean((y_true - y_pred) ** 2))
+    return np.sqrt(np.mean((fx - obs) ** 2))
 
 
-def mean_absolute_percentage(y_true, y_pred):
+def mean_absolute_percentage(obs, fx):
     """Mean absolute percentage error (MAPE).
 
     Parameters
     ----------
-    y_true : array-like
-        True values.
-    y_pred : array-like
-        Predicted values.
+    obs : (n,) array-like
+        Observed values.
+    fx : (n,) array-like
+        Forecasted values.
 
     Returns
     -------
     mape : float
-        The MAPE [%] between the true and predicted values.
+        The MAPE [%] of the forecast.
 
     """
 
-    return np.mean(np.abs((y_true - y_pred) / y_true)) * 100.0
+    return np.mean(np.abs((obs - fx) / obs)) * 100.0
 
 
-def normalized_root_mean_square(y_true, y_pred, y_norm):
+def normalized_root_mean_square(obs, fx, norm):
     """Normalized root mean square error (NRMSE).
 
     Parameters
     ----------
-    y_true : array-like
-        True values.
-    y_pred : array-like
-        Predicted values.
-    y_norm : float
-        Normalized factor, in the same units as y_true and y_pred.
+    obs : (n,) array-like
+        Observed values.
+    fx : (n,) array-like
+        Forecasted values.
+    norm : float
+        Normalized factor, in the same units as obs and fx.
 
     Returns
     -------
     nrmse : float
-        The NRMSE [%] between the true and predicted values.
+        The NRMSE [%] of the forecast.
 
     """
 
-    return root_mean_square(y_true, y_pred) / y_norm * 100.0
+    return root_mean_square(obs, fx) / norm * 100.0
 
 
-def forecast_skill(y_true, y_pred, y_ref):
+def forecast_skill(obs, fx, ref):
     """Forecast skill (s).
 
     Parameters
     ----------
-    y_true : array-like
-        True values.
-    y_pred : array-like
-        Predicted values.
-    y_ref: array_like
-        Reference forecast values.
+    obs : (n,) array-like
+        Observed values.
+    fx : (n,) array-like
+        Forecasted values.
+    ref : (n,) array_like
+        A reference forecast.
 
     Returns
     -------
     s : float
-        The forecast skill [-] between the true and predicted values compared
-        to a reference forecast.
+        The forecast skill [-] of the forecast relative to a reference
+        forecast.
 
     """
 
-    rmse_pred = root_mean_square(y_true, y_pred)
-    rmse_ref = root_mean_square(y_true, y_ref)
-    return 1.0 - rmse_pred / rmse_ref
+    rmse_fx = root_mean_square(obs, fx)
+    rmse_ref = root_mean_square(obs, ref)
+    return 1.0 - rmse_fx / rmse_ref
 
 
-def pearson_correlation_coeff(y_true, y_pred):
+def pearson_correlation_coeff(obs, fx):
     """Pearson correlation coefficient (r).
 
     Parameters
     ----------
-    y_true : array-like
-        True values.
-    y_pred : array-like
-        Predicted values.
+    obs : (n,) array-like
+        Observed values.
+    fx : (n,) array-like
+        Forecasted values.
 
     Returns
     -------
     r : float
-        The correlation coefficient (r [-]) between the true and predicted
-        values.
+        The correlation coefficient (r [-]) of the observations and forecasts.
 
     """
 
-    x1 = y_pred - np.mean(y_pred)
-    x2 = y_true - np.mean(y_true)
+    x1 = fx - np.mean(fx)
+    x2 = obs - np.mean(obs)
     return np.sum(x1 * x2) / (
         np.sqrt(np.sum(x1 ** 2)) * np.sqrt(np.sum(x2 ** 2))
     )
 
 
-def coeff_determination(y_true, y_pred):
+def coeff_determination(obs, fx):
     """Coefficient of determination (R^2).
 
     Parameters
     ----------
-    y_true : array-like
-        True values.
-    y_pred : array-like
-        Predicted values.
+    obs : (n,) array-like
+        Observed values.
+    fx : (n,) array-like
+        Forecasted values.
 
     Returns
     -------
     r2 : float
-        The coefficient of determination (R^2 [-]) between the true and
-        predicted values.
+        The coefficient of determination (R^2 [-]) of the observations and
+        forecasts.
 
     """
 
-    ss_res = np.sum((y_true - y_pred) ** 2)
-    ss_tot = np.sum((y_true - np.mean(y_true)) ** 2)
+    ss_res = np.sum((obs - fx) ** 2)
+    ss_tot = np.sum((obs - np.mean(obs)) ** 2)
     return 1.0 - ss_res / ss_tot
 
 
-def centered_root_mean_square(y_true, y_pred):
+def centered_root_mean_square(obs, fx):
     """Centered (unbiased) root mean square error (CRMSE):
 
     Parameters
     ----------
-    y_true : array-like
-        True values.
-    y_pred : array-like
-        Predicted values.
+    obs : (n,) array-like
+        Observed values.
+    fx : (n,) array-like
+        Forecasted values.
 
     Returns
     -------
     crmse : float
-        The CRMSE between the true and predicted values.
+        The CRMSE of the forecast.
 
     """
 
     return np.sqrt(np.mean(
-        ((y_pred - np.mean(y_pred)) - (y_true - np.mean(y_true))) ** 2
+        ((fx - np.mean(fx)) - (obs - np.mean(obs))) ** 2
     ))
 
 
-def kolmogorov_smirnov_integral(y_true, y_pred, normed=False):
+def kolmogorov_smirnov_integral(obs, fx, normed=False):
     """Kolmogorov-Smirnov Test Integral (KSI).
 
     Parameters
     ----------
-    y_true : array-like
-        True values.
-    y_pred : array-like
-        Predicted values.
+    obs : (n,) array-like
+        Observed values.
+    fx : (n,) array-like
+        Forecasted values.
     normed : bool, optional
         If True, return the normalized KSI [%].
 
     Returns
     -------
     ksi : float
-        The KSI between the true and predicted values.
+        The KSI of the forecast.
 
     Notes
     -----
@@ -241,11 +241,11 @@ def kolmogorov_smirnov_integral(y_true, y_pred, normed=False):
     """
 
     # empirical CDF
-    ecdf_obs = ECDF(y_true)
-    ecdf_fx = ECDF(y_pred)
+    ecdf_obs = ECDF(obs)
+    ecdf_fx = ECDF(fx)
 
     # evaluate CDFs
-    x = np.unique(np.concatenate((y_true, y_pred)))
+    x = np.unique(np.concatenate((obs, fx)))
     y_o = ecdf_obs(x)
     y_f = ecdf_fx(x)
 
@@ -254,27 +254,27 @@ def kolmogorov_smirnov_integral(y_true, y_pred, normed=False):
     ksi = np.sum(D[:-1] * np.diff(x))
 
     if normed:
-        Vc = 1.63 / np.sqrt(len(y_true))
+        Vc = 1.63 / np.sqrt(len(obs))
         a_critical = Vc * (x.max() - x.min())
         return ksi / a_critical * 100.0
     else:
         return ksi
 
 
-def over(y_true, y_pred):
-    """OVER metric.
+def over(obs, fx):
+    """The OVER metric.
 
     Parameters
     ----------
-    y_true : array-like
-        True values.
-    y_pred : array-like
-        Predicted values.
+    obs : (n,) array-like
+        Observed values.
+    fx : (n,) array-like
+        Forecasted values.
 
     Returns
     -------
     over : float
-        The OVER metric between the true and predicted values.
+        The OVER metric of the forecast.
 
     Notes
     -----
@@ -285,32 +285,32 @@ def over(y_true, y_pred):
     """
 
     # empirical CDF
-    ecdf_obs = ECDF(y_true)
-    ecdf_fx = ECDF(y_pred)
+    ecdf_obs = ECDF(obs)
+    ecdf_fx = ECDF(fx)
 
     # evaluate CDFs
-    x = np.unique(np.concatenate((y_true, y_pred)))
+    x = np.unique(np.concatenate((obs, fx)))
     y_o = ecdf_obs(x)
     y_f = ecdf_fx(x)
 
     # compute metric
     D = np.abs(y_o - y_f)
-    Vc = 1.63 / np.sqrt(len(y_true))
+    Vc = 1.63 / np.sqrt(len(obs))
     Dstar = D - Vc
     Dstar[D <= Vc] = 0.0
     over = np.sum(Dstar[:-1] * np.diff(x))
     return over
 
 
-def combined_performance_index(y_true, y_pred):
+def combined_performance_index(obs, fx):
     """Combined Performance Index (CPI) metric.
 
     Parameters
     ----------
-    y_true : array-like
-        True values.
-    y_pred : array-like
-        Predicted values.
+    obs : (n,) array-like
+        Observed values.
+    fx : (n,) array-like
+        Forecasted values.
 
     Returns
     -------
@@ -318,8 +318,8 @@ def combined_performance_index(y_true, y_pred):
         The CPI between the true and predicted values.
 
     """
-    ksi = kolmogorov_smirnov_integral(y_true, y_pred)
-    ov = over(y_true, y_pred)
-    rmse = root_mean_square(y_true, y_pred)
+    ksi = kolmogorov_smirnov_integral(obs, fx)
+    ov = over(obs, fx)
+    rmse = root_mean_square(obs, fx)
     cpi = 1 / 4 * (ksi + ov + 2 * rmse)
     return cpi

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -146,7 +146,7 @@ def forecast_skill(obs, fx, fx_ref):
     fx : (n,) array-like
         Forecasted values.
     fx_ref : (n,) array_like
-        A reference forecast.
+        Reference forecast values.
 
     Returns
     -------

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -167,7 +167,7 @@ def pearson_correlation_coeff(obs, fx):
         r = A / (B * C)
 
     where:
-        
+
         A = sum_{i=1}^n (fx_i - fx_avg) * (obs_i - obs_avg)
         B = sqrt( sum_{i=1}^n (fx_i - fx_avg)^2 )
         C = sqrt( sum_{i=1}^n (obs_i - obs_avg)^2 )
@@ -188,32 +188,25 @@ def pearson_correlation_coeff(obs, fx):
 
     """
 
-    #f = fx - np.mean(fx)
-    #o = obs - np.mean(obs)
-    #r = np.sum(f * o) / (
-    #    np.sqrt(np.sum(f ** 2)) * np.sqrt(np.sum(o ** 2))
-    #)
-
     fx_avg = np.mean(fx)
     obs_avg = np.mean(obs)
     A = np.sum((fx - fx_avg) * (obs - obs_avg))
     B = np.sqrt(np.sum((fx - fx_avg) ** 2))
     C = np.sqrt(np.sum((obs - obs_avg) ** 2))
     r = A / (B * C)
-
-    #x1 = fx - np.mean(fx)
-    #x2 = obs - np.mean(obs)
-    #r = np.sum(x1 * x2) / (
-    #    np.sqrt(np.sum(x1 ** 2)) * np.sqrt(np.sum(x2 ** 2))
-    #)
-
     return r
 
 
 def coeff_determination(obs, fx):
     """Coefficient of determination (R^2).
 
-        R^2 = 
+        R^2 = 1 - (A / B)
+
+    where:
+
+        A = sum_{i=1}^n (obs_i - fx_i)^2
+        B = sum_{i=1}^n (obs_i - obs_avg)^2
+        obs_avg = 1/n sum_{i=1} obs_i
 
     Parameters
     ----------
@@ -238,7 +231,12 @@ def coeff_determination(obs, fx):
 def centered_root_mean_square(obs, fx):
     """Centered (unbiased) root mean square error (CRMSE):
 
-        CRMSE = 
+        CRMSE = sqrt( 1/n sum_{i=1}^n ((fx_i - fx_avg) - (obs_i - obs_avg))^2 )
+
+    where:
+
+        fx_avg = 1/n sum_{i=1} fx_i
+        obs_avg = 1/n sum_{i=1} obs_i
 
     Parameters
     ----------
@@ -262,7 +260,21 @@ def centered_root_mean_square(obs, fx):
 def kolmogorov_smirnov_integral(obs, fx, normed=False):
     """Kolmogorov-Smirnov Test Integral (KSI).
 
-        KSI = 
+        KSI = int_{p_min}^{p_max} D_n(p) dp
+
+    where:
+
+        D_n(p) = max(|CDF_obs(p) - CDF_fx(p)|)
+
+    and CDF_obs and CDF_fx are the empirical CDFs of the observations and
+    forecasts, respectively. KSI can be normalized as:
+
+        KSI [%] = KSI / a_critical * 100%
+
+    where:
+
+        a_critical = V_c * (p_max - p_min)
+        V_c = 1.63 / sqrt(n)
 
     Parameters
     ----------
@@ -310,7 +322,13 @@ def kolmogorov_smirnov_integral(obs, fx, normed=False):
 def over(obs, fx):
     """The OVER metric.
 
-        OVER = 
+        OVER = int_{p_min}^{p_max} D_n^*(p) dp
+
+    where:
+
+        D_n^* = (D_n - V_c) if D_n > V_c, else D_n^* = 0
+
+    with D_n and V_c defined the same as in KSI.
 
     Parameters
     ----------

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -1,6 +1,7 @@
 """Deterministic forecast error metrics."""
 
 import numpy as np
+import scipy as sp
 from statsmodels.distributions.empirical_distribution import ECDF
 
 __all__ = [
@@ -188,7 +189,7 @@ def pearson_correlation_coeff(obs, fx):
 
     """
 
-    r = np.corrcoef(obs, fx)[0, 1]
+    r, _ = sp.stats.pearsonr(obs, fx)
     return r
 
 

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -132,7 +132,7 @@ def normalized_root_mean_square(obs, fx, norm):
     return root_mean_square(obs, fx) / norm * 100.0
 
 
-def forecast_skill(obs, fx, fx_ref):
+def forecast_skill(obs, fx, ref):
     """Forecast skill (s).
 
         s = 1 - RMSE_fx / RMSE_ref
@@ -146,7 +146,7 @@ def forecast_skill(obs, fx, fx_ref):
         Observed values.
     fx : (n,) array-like
         Forecasted values.
-    fx_ref : (n,) array_like
+    ref : (n,) array_like
         Reference forecast values.
 
     Returns
@@ -158,7 +158,7 @@ def forecast_skill(obs, fx, fx_ref):
     """
 
     rmse_fx = root_mean_square(obs, fx)
-    rmse_ref = root_mean_square(obs, fx_ref)
+    rmse_ref = root_mean_square(obs, ref)
     return 1.0 - rmse_fx / rmse_ref
 
 

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -188,12 +188,7 @@ def pearson_correlation_coeff(obs, fx):
 
     """
 
-    fx_avg = np.mean(fx)
-    obs_avg = np.mean(obs)
-    A = np.sum((fx - fx_avg) * (obs - obs_avg))
-    B = np.sqrt(np.sum((fx - fx_avg) ** 2))
-    C = np.sqrt(np.sum((obs - obs_avg) ** 2))
-    r = A / (B * C)
+    r = np.corrcoef(obs, fx)[0, 1]
     return r
 
 

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -22,6 +22,8 @@ __all__ = [
 def mean_absolute(obs, fx):
     """Mean absolute error (MAE).
 
+        MAE = 1/n sum_{i=1}^n |fx_i - obs_i|
+
     Parameters
     ----------
     obs : (n,) array-like
@@ -41,6 +43,8 @@ def mean_absolute(obs, fx):
 
 def mean_bias(obs, fx):
     """Mean bias error (MBE).
+
+        MBE = 1/n sum_{i=1}^n (fx_i - obs_i)
 
     Parameters
     ----------
@@ -62,6 +66,8 @@ def mean_bias(obs, fx):
 def root_mean_square(obs, fx):
     """Root mean square error (RMSE).
 
+        RMSE = sqrt( 1/n sum_{i=1}^n (fx_i - obs_i)^2 )
+
     Parameters
     ----------
     obs : (n,) array-like
@@ -82,6 +88,8 @@ def root_mean_square(obs, fx):
 def mean_absolute_percentage(obs, fx):
     """Mean absolute percentage error (MAPE).
 
+        MAPE = 1/n sum_{i=1}^n |(fx_i - obs_i) / obs_i| * 100%
+
     Parameters
     ----------
     obs : (n,) array-like
@@ -101,6 +109,8 @@ def mean_absolute_percentage(obs, fx):
 
 def normalized_root_mean_square(obs, fx, norm):
     """Normalized root mean square error (NRMSE).
+
+        NRMSE = RMSE / norm * 100%
 
     Parameters
     ----------
@@ -123,6 +133,11 @@ def normalized_root_mean_square(obs, fx, norm):
 
 def forecast_skill(obs, fx, ref):
     """Forecast skill (s).
+
+        s = 1 - RMSE_fx / RMSE_ref
+
+    where RMSE_fx is the RMSE of the forecast and RMSE_ref is the RMSE of the
+    reference forecast (e.g. Persistence).
 
     Parameters
     ----------
@@ -149,6 +164,16 @@ def forecast_skill(obs, fx, ref):
 def pearson_correlation_coeff(obs, fx):
     """Pearson correlation coefficient (r).
 
+        r = A / (B * C)
+
+    where:
+        
+        A = sum_{i=1}^n (fx_i - fx_avg) * (obs_i - obs_avg)
+        B = sqrt( sum_{i=1}^n (fx_i - fx_avg)^2 )
+        C = sqrt( sum_{i=1}^n (obs_i - obs_avg)^2 )
+        fx_avg = 1/n sum_{i=1} fx_i
+        obs_avg = 1/n sum_{i=1} obs_i
+
     Parameters
     ----------
     obs : (n,) array-like
@@ -163,15 +188,32 @@ def pearson_correlation_coeff(obs, fx):
 
     """
 
-    x1 = fx - np.mean(fx)
-    x2 = obs - np.mean(obs)
-    return np.sum(x1 * x2) / (
-        np.sqrt(np.sum(x1 ** 2)) * np.sqrt(np.sum(x2 ** 2))
-    )
+    #f = fx - np.mean(fx)
+    #o = obs - np.mean(obs)
+    #r = np.sum(f * o) / (
+    #    np.sqrt(np.sum(f ** 2)) * np.sqrt(np.sum(o ** 2))
+    #)
+
+    fx_avg = np.mean(fx)
+    obs_avg = np.mean(obs)
+    A = np.sum((fx - fx_avg) * (obs - obs_avg))
+    B = np.sqrt(np.sum((fx - fx_avg) ** 2))
+    C = np.sqrt(np.sum((obs - obs_avg) ** 2))
+    r = A / (B * C)
+
+    #x1 = fx - np.mean(fx)
+    #x2 = obs - np.mean(obs)
+    #r = np.sum(x1 * x2) / (
+    #    np.sqrt(np.sum(x1 ** 2)) * np.sqrt(np.sum(x2 ** 2))
+    #)
+
+    return r
 
 
 def coeff_determination(obs, fx):
     """Coefficient of determination (R^2).
+
+        R^2 = 
 
     Parameters
     ----------
@@ -196,6 +238,8 @@ def coeff_determination(obs, fx):
 def centered_root_mean_square(obs, fx):
     """Centered (unbiased) root mean square error (CRMSE):
 
+        CRMSE = 
+
     Parameters
     ----------
     obs : (n,) array-like
@@ -217,6 +261,8 @@ def centered_root_mean_square(obs, fx):
 
 def kolmogorov_smirnov_integral(obs, fx, normed=False):
     """Kolmogorov-Smirnov Test Integral (KSI).
+
+        KSI = 
 
     Parameters
     ----------
@@ -264,6 +310,8 @@ def kolmogorov_smirnov_integral(obs, fx, normed=False):
 def over(obs, fx):
     """The OVER metric.
 
+        OVER = 
+
     Parameters
     ----------
     obs : (n,) array-like
@@ -305,6 +353,8 @@ def over(obs, fx):
 def combined_performance_index(obs, fx):
     """Combined Performance Index (CPI) metric.
 
+        CPI = (KSI + OVER + 2 * RMSE) / 4
+
     Parameters
     ----------
     obs : (n,) array-like
@@ -321,5 +371,5 @@ def combined_performance_index(obs, fx):
     ksi = kolmogorov_smirnov_integral(obs, fx)
     ov = over(obs, fx)
     rmse = root_mean_square(obs, fx)
-    cpi = 1 / 4 * (ksi + ov + 2 * rmse)
+    cpi = (ksi + ov + 2 * rmse) / 4.0
     return cpi

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -12,7 +12,7 @@ __all__ = [
 ]
 
 
-def brier_score(fx, fx_prob, obs):
+def brier_score(obs, fx, fx_prob):
     """Brier Score (BS).
 
         BS = 1/n sum_{i=1}^n (f_i - o_i)^2
@@ -30,13 +30,13 @@ def brier_score(fx, fx_prob, obs):
 
     Parameters
     ----------
+    obs : (n,) array_like
+        Observations (physical unit).
     fx : (n,) array_like
         Forecasts (physical units) of the right-hand-side of a CDF interval,
         e.g., fx = 10 MW is interpreted as forecasting <= 10 MW.
     fx_prob : (n,) array_like
         Probability [%] associated with the forecasts.
-    obs : (n,) array_like
-        Observations (physical unit).
 
     Returns
     -------
@@ -62,7 +62,7 @@ def brier_score(fx, fx_prob, obs):
     return bs
 
 
-def brier_skill_score(fx, fx_prob, ref, ref_prob, obs):
+def brier_skill_score(obs, fx, fx_prob, ref, ref_prob):
     """Brier Skill Score (BSS).
 
         BSS = 1 - BS_fx / BS_ref
@@ -72,6 +72,8 @@ def brier_skill_score(fx, fx_prob, ref, ref_prob, obs):
 
     Parameters
     ----------
+    obs : (n,) array_like
+        Observations (physical unit).
     fx : (n,) array_like
         Forecasts (physical units) of the right-hand-side of a CDF interval,
         e.g., fx = 10 MW is interpreted as forecasting <= 10 MW.
@@ -82,8 +84,6 @@ def brier_skill_score(fx, fx_prob, ref, ref_prob, obs):
         interval.
     ref_prob : (n,) array_like
         Probability [%] associated with the reference forecast.
-    obs : (n,) array_like
-        Observations (physical unit).
 
     Returns
     -------
@@ -91,8 +91,8 @@ def brier_skill_score(fx, fx_prob, ref, ref_prob, obs):
         The Brier Skill Score [unitless].
 
     """
-    bs_fx = brier_score(fx, fx_prob, obs)
-    bs_ref = brier_score(ref, ref_prob, obs)
+    bs_fx = brier_score(obs, fx, fx_prob)
+    bs_ref = brier_score(obs, ref, ref_prob)
     skill = 1.0 - bs_fx / bs_ref
     return skill
 
@@ -138,7 +138,7 @@ def _unique_forecasts(f):
     return f_uniq
 
 
-def brier_decomposition(fx, fx_prob, obs):
+def brier_decomposition(obs, fx, fx_prob):
     """The 3-component decomposition of the Brier Score.
 
         BS = REL - RES + UNC
@@ -148,13 +148,13 @@ def brier_decomposition(fx, fx_prob, obs):
 
     Parameters
     ----------
+    obs : (n,) array_like
+        Observations (physical unit).
     fx : (n,) array_like
         Forecasts (physical units) of the right-hand-side of a CDF interval,
         e.g., fx = 10 MW is interpreted as forecasting <= 10 MW.
     fx_prob : (n,) array_like
         Probability [%] associated with the forecasts.
-    obs : (n,) array_like
-        Observations (physical unit).
 
     Returns
     -------
@@ -207,7 +207,7 @@ def brier_decomposition(fx, fx_prob, obs):
     return rel, res, unc
 
 
-def reliability(fx, fx_prob, obs):
+def reliability(obs, fx, fx_prob):
     """Reliability (REL) of the forecast.
 
         REL = 1/n sum_{i=1}^I N_i (f_i - o_{i,avg})^2
@@ -219,13 +219,13 @@ def reliability(fx, fx_prob, obs):
 
     Parameters
     ----------
+    obs : (n,) array_like
+        Observations (physical unit).
     fx : (n,) array_like
         Forecasts (physical units) of the right-hand-side of a CDF interval,
         e.g., fx = 10 MW is interpreted as forecasting <= 10 MW.
     fx_prob : (n,) array_like
         Probability [%] associated with the forecasts.
-    obs : (n,) array_like
-        Observations (physical unit).
 
     Returns
     -------
@@ -239,11 +239,11 @@ def reliability(fx, fx_prob, obs):
 
     """
 
-    rel = brier_decomposition(fx, fx_prob, obs)[0]
+    rel = brier_decomposition(obs, fx, fx_prob)[0]
     return rel
 
 
-def resolution(fx, fx_prob, obs):
+def resolution(obs, fx, fx_prob):
     """Resolution (RES) of the forecast.
 
         RES = 1/n sum_{i=1}^I N_i (o_{i,avg} - o_{avg})^2
@@ -256,13 +256,13 @@ def resolution(fx, fx_prob, obs):
 
     Parameters
     ----------
+    obs : (n,) array_like
+        Observations (physical unit).
     fx : (n,) array_like
         Forecasts (physical units) of the right-hand-side of a CDF interval,
         e.g., fx = 10 MW is interpreted as forecasting <= 10 MW.
     fx_prob : (n,) array_like
         Probability [%] associated with the forecasts.
-    obs : (n,) array_like
-        Observations (physical unit).
 
     Returns
     -------
@@ -276,11 +276,11 @@ def resolution(fx, fx_prob, obs):
 
     """
 
-    res = brier_decomposition(fx, fx_prob, obs)[1]
+    res = brier_decomposition(obs, fx, fx_prob)[1]
     return res
 
 
-def uncertainty(fx, fx_prob, obs):
+def uncertainty(obs, fx, fx_prob):
     """Uncertainty (UNC) of the forecast.
 
         UNC = base_rate * (1 - base_rate)
@@ -289,13 +289,13 @@ def uncertainty(fx, fx_prob, obs):
 
     Parameters
     ----------
+    obs : (n,) array_like
+        Observations (physical unit).
     fx : (n,) array_like
         Forecasts (physical units) of the right-hand-side of a CDF interval,
         e.g., fx = 10 MW is interpreted as forecasting <= 10 MW.
     fx_prob : (n,) array_like
         Probability [%] associated with the forecasts.
-    obs : (n,) array_like
-        Observations (physical unit).
 
     Returns
     -------
@@ -309,7 +309,7 @@ def uncertainty(fx, fx_prob, obs):
 
     """
 
-    unc = brier_decomposition(fx, fx_prob, obs)[2]
+    unc = brier_decomposition(obs, fx, fx_prob)[2]
     return unc
 
 
@@ -340,7 +340,7 @@ def sharpness(fx_lower, fx_upper):
     return sh
 
 
-def continuous_ranked_probability_score(fx, fx_prob, obs):
+def continuous_ranked_probability_score(obs, fx, fx_prob):
     """Continuous Ranked Probability Score (CRPS).
 
         CRPS = 1/n sum_{i=1}^n int (F_i - O_i)^2 dx
@@ -355,14 +355,14 @@ def continuous_ranked_probability_score(fx, fx_prob, obs):
 
     Parameters
     ----------
+    obs : (n,) array_like
+        Observations (physical unit).
     fx : (n, d) array_like
         Forecasts (physical units) of the right-hand-side of a CDF with d
         intervals (d >= 2), e.g., fx = [10 MW, 20 MW, 30 MW] is interpreted as
         <= 10 MW, <= 20 MW, <= 30 MW.
     fx_prob : (n, d) array_like
         Probability [%] associated with the forecasts.
-    obs : (n,) array_like
-        Observations (physical unit).
 
     Returns
     -------
@@ -376,14 +376,14 @@ def continuous_ranked_probability_score(fx, fx_prob, obs):
     >>> fx = np.array([[10, 20], [10, 20]])
     >>> fx_prob = np.array([[30, 50], [65, 100]])
     >>> obs = np.array([8, 12])
-    >>> continuous_ranked_probability_score(fx, fx_prob, obs)
+    >>> continuous_ranked_probability_score(obs, fx, fx_prob)
     4.5625
 
     Forecast thresholds for constant probabilities (25%, 75%):
     >>> fx = np.array([[5, 15], [8, 14]])
     >>> fx_prob = np.array([[25, 75], [25, 75]])
     >>> obs = np.array([8, 10])
-    >>> continuous_ranked_probability_score(fx, fx_prob, obs)
+    >>> continuous_ranked_probability_score(obs, fx, fx_prob)
     0.5
 
     """

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -9,6 +9,7 @@ __all__ = [
     "resolution",
     "uncertainty",
     "sharpness",
+    "continuous_ranked_probability_score",
 ]
 
 

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -3,120 +3,120 @@ import numpy as np
 from solarforecastarbiter.metrics import deterministic
 
 
-@pytest.mark.parametrize("y_true,y_pred,value", [
+@pytest.mark.parametrize("obs,fx,value", [
     (np.array([0, 1, 2]), np.array([0, 1, 2]), 0.0),
     (np.array([0, 1, 2]), np.array([0, 1, 1]), 1 / 3),
 ])
-def test_mae(y_true, y_pred, value):
-    mae = deterministic.mean_absolute(y_true, y_pred)
+def test_mae(obs, fx, value):
+    mae = deterministic.mean_absolute(obs, fx)
     assert mae == value
 
 
-@pytest.mark.parametrize("y_true,y_pred,value", [
+@pytest.mark.parametrize("obs,fx,value", [
     (np.array([0, 1, 2]), np.array([0, 1, 2]), 0.0),
     (np.array([0, 1, 2]), np.array([1, 0, 2]), 0.0),
 ])
-def test_mbe(y_true, y_pred, value):
-    mbe = deterministic.mean_bias(y_true, y_pred)
+def test_mbe(obs, fx, value):
+    mbe = deterministic.mean_bias(obs, fx)
     assert mbe == value
 
 
-@pytest.mark.parametrize("y_true,y_pred,value", [
+@pytest.mark.parametrize("obs,fx,value", [
     (np.array([0, 1]), np.array([0, 1]), 0.0),
     (np.array([0, 1]), np.array([1, 2]), 1.0),
 ])
-def test_rmse(y_true, y_pred, value):
-    rmse = deterministic.root_mean_square(y_true, y_pred)
+def test_rmse(obs, fx, value):
+    rmse = deterministic.root_mean_square(obs, fx)
     assert rmse == value
 
 
-@pytest.mark.parametrize("y_true,y_pred,value", [
+@pytest.mark.parametrize("obs,fx,value", [
     (np.array([1, 1]), np.array([2, 2]), 100.0),
     (np.array([2, 2]), np.array([3, 3]), 50.0),
 ])
-def test_mape(y_true, y_pred, value):
-    mape = deterministic.mean_absolute_percentage(y_true, y_pred)
+def test_mape(obs, fx, value):
+    mape = deterministic.mean_absolute_percentage(obs, fx)
     assert mape == value
 
 
-@pytest.mark.parametrize("y_true,y_pred,y_norm,value", [
+@pytest.mark.parametrize("obs,fx,y_norm,value", [
     (np.array([0, 1, 2]), np.array([0, 1, 2]), 1.0, 0.0),
     (np.array([0, 1, 2]), np.array([0, 1, 2]), 55.0, 0.0),
     (np.array([0, 1]), np.array([1, 2]), 1.0, 100.0),
     (np.array([0, 1]), np.array([1, 2]), 100.0, 1.0),
 ])
-def test_nrmse(y_true, y_pred, y_norm, value):
-    nrmse = deterministic.normalized_root_mean_square(y_true, y_pred, y_norm)
+def test_nrmse(obs, fx, y_norm, value):
+    nrmse = deterministic.normalized_root_mean_square(obs, fx, y_norm)
     assert nrmse == value
 
 
-@pytest.mark.parametrize("y_true,y_pred,y_ref,value", [
+@pytest.mark.parametrize("obs,fx,ref,value", [
     (np.array([0, 1]), np.array([0, 2]), np.array([0, 2]), 1.0 - 1.0 / 1.0),
     (np.array([0, 1]), np.array([0, 2]), np.array([0, 3]), 1.0 - 1.0 / 2.0),
 ])
-def test_skill(y_true, y_pred, y_ref, value):
-    s = deterministic.forecast_skill(y_true, y_pred, y_ref)
+def test_skill(obs, fx, ref, value):
+    s = deterministic.forecast_skill(obs, fx, ref)
     assert s == value
 
 
-@pytest.mark.parametrize("y_true,y_pred,value", [
+@pytest.mark.parametrize("obs,fx,value", [
     (np.array([0, 1]), np.array([0, 1]), 1.0),
     (np.array([1, 2]), np.array([-1, -2]), -1.0),
 ])
-def test_r(y_true, y_pred, value):
-    r = deterministic.pearson_correlation_coeff(y_true, y_pred)
+def test_r(obs, fx, value):
+    r = deterministic.pearson_correlation_coeff(obs, fx)
     assert pytest.approx(r) == value
 
 
-@pytest.mark.parametrize("y_true,y_pred,value", [
+@pytest.mark.parametrize("obs,fx,value", [
     (np.array([0, 1]), np.array([0, 1]), 1.0),
 ])
-def test_r2(y_true, y_pred, value):
-    r2 = deterministic.coeff_determination(y_true, y_pred)
+def test_r2(obs, fx, value):
+    r2 = deterministic.coeff_determination(obs, fx)
     assert pytest.approx(r2) == value
 
 
-@pytest.mark.parametrize("y_true,y_pred,value", [
+@pytest.mark.parametrize("obs,fx,value", [
     (np.array([0, 1]), np.array([0, 1]), 0.0),
 ])
-def test_crmse(y_true, y_pred, value):
-    crmse = deterministic.centered_root_mean_square(y_true, y_pred)
+def test_crmse(obs, fx, value):
+    crmse = deterministic.centered_root_mean_square(obs, fx)
     assert crmse == value
 
 
-@pytest.mark.parametrize("y_true,y_pred,value", [
+@pytest.mark.parametrize("obs,fx,value", [
     ([0, 1], [0, 1], 0.0),
     ([1, 2], [1, 2], 0.0),
     ([0, 1], [0, 2], 0.5),
     ([0, 1, 2], [0, 0, 2], 1.0 / 3.0),
 ])
-def test_ksi(y_true, y_pred, value):
-    ksi = deterministic.kolmogorov_smirnov_integral(y_true, y_pred)
+def test_ksi(obs, fx, value):
+    ksi = deterministic.kolmogorov_smirnov_integral(obs, fx)
     assert pytest.approx(ksi) == value
 
 
-@pytest.mark.parametrize("y_true,y_pred,value", [
+@pytest.mark.parametrize("obs,fx,value", [
     ([0, 1], [0, 1], 0.0),
     ([1, 2], [1, 2], 0.0),
 ])
-def test_ksi_norm(y_true, y_pred, value):
+def test_ksi_norm(obs, fx, value):
     ksi = deterministic.kolmogorov_smirnov_integral(
-        y_true, y_pred, normed=True
+        obs, fx, normed=True
     )
     assert ksi == value
 
 
-@pytest.mark.parametrize("y_true,y_pred,value", [
+@pytest.mark.parametrize("obs,fx,value", [
     ([0, 1], [0, 1], 0.0),
     ([1, 2], [1, 2], 0.0),
     ([0, 1, 2, 3, 4], [0, 0, 0, 0, 0], 0.8 - 1.63 / np.sqrt(5)),
 ])
-def test_over(y_true, y_pred, value):
-    ov = deterministic.over(y_true, y_pred)
+def test_over(obs, fx, value):
+    ov = deterministic.over(obs, fx)
     assert ov == value
 
 
-@pytest.mark.parametrize("y_true,y_pred,value", [
+@pytest.mark.parametrize("obs,fx,value", [
     (np.array([0, 1]), np.array([0, 1]), 0.0),
     (np.array([1, 2]), np.array([1, 2]), 0.0),
     (
@@ -125,6 +125,6 @@ def test_over(y_true, y_pred, value):
         1/4 * (1/3 + 0 + 2 * np.sqrt(1/3))
     ),
 ])
-def test_cpi(y_true, y_pred, value):
-    cpi = deterministic.combined_performance_index(y_true, y_pred)
+def test_cpi(obs, fx, value):
+    cpi = deterministic.combined_performance_index(obs, fx)
     assert pytest.approx(cpi) == value

--- a/solarforecastarbiter/metrics/tests/test_probabilistic.py
+++ b/solarforecastarbiter/metrics/tests/test_probabilistic.py
@@ -31,7 +31,7 @@ from solarforecastarbiter.metrics import probabilistic as prob
     (np.array([10, 10]), np.array([100, 100]), np.array([2, 14]), 0.5),
 ])
 def test_brier_score(fx, fx_prob, obs, value):
-    assert prob.brier_score(fx, fx_prob, obs) == value
+    assert prob.brier_score(obs, fx, fx_prob) == value
 
 
 @pytest.mark.parametrize("fx,fx_prob,ref,ref_prob,obs,value", [
@@ -39,7 +39,7 @@ def test_brier_score(fx, fx_prob, obs, value):
     (10, 50, 5, 100, 8, 1.0 - 0.25 / 1.0),
 ])
 def test_brier_skill_score(fx, fx_prob, ref, ref_prob, obs, value):
-    assert prob.brier_skill_score(fx, fx_prob, ref, ref_prob, obs) == value
+    assert prob.brier_skill_score(obs, fx, fx_prob, ref, ref_prob) == value
 
 
 @pytest.mark.parametrize("f,value", [
@@ -95,7 +95,7 @@ def test_unique_forecasts(f, value):
     ),
 ])
 def test_reliability(fx, fx_prob, obs, value):
-    assert prob.reliability(fx, fx_prob, obs) == pytest.approx(value)
+    assert prob.reliability(obs, fx, fx_prob) == pytest.approx(value)
 
 
 @pytest.mark.parametrize("fx,fx_prob,obs,value", [
@@ -139,7 +139,7 @@ def test_reliability(fx, fx_prob, obs, value):
     ),
 ])
 def test_resolution(fx, fx_prob, obs, value):
-    assert prob.resolution(fx, fx_prob, obs) == value
+    assert prob.resolution(obs, fx, fx_prob) == value
 
 
 @pytest.mark.parametrize("fx,fx_prob,obs,value", [
@@ -156,7 +156,7 @@ def test_resolution(fx, fx_prob, obs, value):
     (np.array([8, 8]), np.array([33, 31]), np.array([10, 10]), 0.0),
 ])
 def test_unc(fx, fx_prob, obs, value):
-    assert prob.uncertainty(fx, fx_prob, obs) == value
+    assert prob.uncertainty(obs, fx, fx_prob) == value
 
 
 @pytest.mark.parametrize("fx,fx_prob,obs", [
@@ -171,8 +171,8 @@ def test_unc(fx, fx_prob, obs, value):
     (np.array([8, 8]), np.array([100, 100]), np.array([10, 10])),
 ])
 def test_brier_decomposition(fx, fx_prob, obs):
-    bs = prob.brier_score(fx, fx_prob, obs)
-    rel, res, unc = prob.brier_decomposition(fx, fx_prob, obs)
+    bs = prob.brier_score(obs, fx, fx_prob)
+    rel, res, unc = prob.brier_decomposition(obs, fx, fx_prob)
     assert pytest.approx(bs) == rel - res + unc
 
 
@@ -259,5 +259,5 @@ def test_sharpness(fx_lower, fx_upper, value):
     ),
 ])
 def test_crps(fx, fx_prob, obs, value):
-    crps = prob.continuous_ranked_probability_score(fx, fx_prob, obs)
+    crps = prob.continuous_ranked_probability_score(obs, fx, fx_prob)
     assert crps == value


### PR DESCRIPTION
  - [x] Closes #262 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Work on standardizing the naming and ordering conventions for inputs to all metric functions:
- naming: `obs` = observations, `fx` = forecasts
- order: `obs` then `fx` then other inputs (e.g. `obs, fx, norm`)