### PR TITLE
metrics: deterministic: add NMAE and NMBE

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -413,6 +413,8 @@ Functions to compute forecast deterministic performance metrics:
    metrics.deterministic.mean_absolute
    metrics.deterministic.mean_bias
    metrics.deterministic.root_mean_square
+   metrics.deterministic.normalized_mean_absolute
+   metrics.deterministic.normalized_mean_bias
    metrics.deterministic.normalized_root_mean_square
    metrics.deterministic.centered_root_mean_square
    metrics.deterministic.mean_absolute_percentage

--- a/docs/source/whatsnew/1.0.0b3.rst
+++ b/docs/source/whatsnew/1.0.0b3.rst
@@ -27,6 +27,9 @@ API Changes
   where `obs` = observations and `fx` = forecasts (:issue:`262`) (:pull:`263`)
 * Add valuation metric for evaluating forecast errors
   :py:mod:`solarforecastarbiter.metrics.valuation.fixed_error_cost` (:issue:`258`) (:pull:`261`)
+* Add additional normalized deterministic metrics
+  :py:mod:`solarforecastarbiter.metrics.deterministic.normalized_mean_absolute`, and
+  :py:mod:`solarforecastarbiter.metrics.deterministic.normalized_mean_bias`. (:issue:`118`) (:pull:`268`)
 
 Enhancements
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -430,6 +430,8 @@ _MAP = {
     'mbe': mean_bias,
     'rmse': root_mean_square,
     'mape': mean_absolute_percentage,
+    'nmae': normalized_mean_absolute,
+    'nmbe': normalized_mean_bias,
     'nrmse': normalized_root_mean_square,
     's': forecast_skill,
     'r': pearson_correlation_coeff,
@@ -443,4 +445,4 @@ __all__ = [m.__name__ for m in _MAP.values()]
 _REQ_REF_FX = ['s']
 
 # Functions that require normalized factor
-_REQ_NORM = ['nrmse']
+_REQ_NORM = ['nmae', 'nmbe', 'nrmse']

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -93,6 +93,54 @@ def mean_absolute_percentage(obs, fx):
     return np.mean(np.abs((obs - fx) / obs)) * 100.0
 
 
+def normalized_mean_absolute(obs, fx, norm):
+    """Normalized mean absolute error (NMAE).
+
+        NMAE = MAE / norm * 100%
+
+    Parameters
+    ----------
+    obs : (n,) array-like
+        Observed values.
+    fx : (n,) array-like
+        Forecasted values.
+    norm : float
+        Normalized factor, in the same units as obs and fx.
+
+    Returns
+    -------
+    nmae : float
+        The NMAE [%] of the forecast.
+
+    """
+
+    return mean_absolute(obs, fx) / norm * 100.0
+
+
+def normalized_mean_bias(obs, fx, norm):
+    """Normalized mean bias error (NMBE).
+
+        NMBE = MBE / norm * 100%
+
+    Parameters
+    ----------
+    obs : (n,) array-like
+        Observed values.
+    fx : (n,) array-like
+        Forecasted values.
+    norm : float
+        Normalized factor, in the same units as obs and fx.
+
+    Returns
+    -------
+    nmbe : float
+        The NMBE [%] of the forecast.
+
+    """
+
+    return mean_bias(obs, fx) / norm * 100.0
+
+
 def normalized_root_mean_square(obs, fx, norm):
     """Normalized root mean square error (NRMSE).
 

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -39,6 +39,24 @@ def test_mape(obs, fx, value):
     assert mape == value
 
 
+@pytest.mark.parametrize("obs,fx,norm,value", [
+    (np.array([0, 1, 2]), np.array([0, 1, 2]), 55, 0.0),
+    (np.array([0, 1, 2]), np.array([0, 1, 1]), 20, 1 / 3 / 20 * 100),
+])
+def test_nmae(obs, fx, norm, value):
+    nmae = deterministic.normalized_mean_absolute(obs, fx, norm)
+    assert nmae == value
+
+
+@pytest.mark.parametrize("obs,fx,norm,value", [
+    (np.array([0, 1, 2]), np.array([0, 1, 2]), 55, 0.0),
+    (np.array([0, 1, 2]), np.array([1, 0, 2]), 20, 0.0),
+])
+def test_nmbe(obs, fx, norm, value):
+    nmbe = deterministic.normalized_mean_bias(obs, fx, norm)
+    assert nmbe == value
+
+
 @pytest.mark.parametrize("obs,fx,y_norm,value", [
     (np.array([0, 1, 2]), np.array([0, 1, 2]), 1.0, 0.0),
     (np.array([0, 1, 2]), np.array([0, 1, 2]), 55.0, 0.0),


### PR DESCRIPTION
  - [x] Closes #118 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Add normalized MAE and MBE (NMAE and NMBE) to the deterministic metrics as separate functions (same format as normalized RMSE (NRMSE)).
