### PR TITLE
metrics: add additional tests

### DIFF
--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -129,12 +129,13 @@ def test_ksi(obs, fx, value):
 @pytest.mark.parametrize("obs,fx,value", [
     ([0, 1], [0, 1], 0.0),
     ([1, 2], [1, 2], 0.0),
+    ([0, 1, 2], [0, 0, 2], 1 / 3 / (1.63 / np.sqrt(3) * 2) * 100),
 ])
 def test_ksi_norm(obs, fx, value):
     ksi = deterministic.kolmogorov_smirnov_integral(
         obs, fx, normed=True
     )
-    assert ksi == value
+    assert pytest.approx(ksi) == value
 
 
 @pytest.mark.parametrize("obs,fx,value", [

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -15,6 +15,10 @@ def test_mae(obs, fx, value):
 @pytest.mark.parametrize("obs,fx,value", [
     (np.array([0, 1, 2]), np.array([0, 1, 2]), 0.0),
     (np.array([0, 1, 2]), np.array([1, 0, 2]), 0.0),
+    (np.array([0, 1, 2]), np.array([1, 2, 3]), 1.0),
+    (np.array([0, 1, 2]), np.array([1, 3, 4]), (1 + 2 + 2) / 3),
+    (np.array([5, 5, 5]), np.array([4, 4, 4]), -1.0),
+    (np.array([5, 5, 5]), np.array([4, 3, 3]), -(1 + 2 + 2) / 3),
 ])
 def test_mbe(obs, fx, value):
     mbe = deterministic.mean_bias(obs, fx)
@@ -51,6 +55,9 @@ def test_nmae(obs, fx, norm, value):
 @pytest.mark.parametrize("obs,fx,norm,value", [
     (np.array([0, 1, 2]), np.array([0, 1, 2]), 55, 0.0),
     (np.array([0, 1, 2]), np.array([1, 0, 2]), 20, 0.0),
+    (np.array([0, 1, 2]), np.array([1, 3, 4]), 7, (1 + 2 + 2) / 3 / 7 * 100),
+    (np.array([5, 5, 5]), np.array([4, 4, 4]), 2, -1.0 / 2 * 100),
+    (np.array([5, 5, 5]), np.array([4, 3, 3]), 2, -(1 + 2 + 2) / 3 / 2 * 100),
 ])
 def test_nmbe(obs, fx, norm, value):
     nmbe = deterministic.normalized_mean_bias(obs, fx, norm)

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -107,6 +107,8 @@ def test_r2(obs, fx, value):
 
 @pytest.mark.parametrize("obs,fx,value", [
     (np.array([0, 1]), np.array([0, 1]), 0.0),
+    (np.array([0, 2]), np.array([0, 4]), 1.0),
+    (np.array([0, 2]), np.array([0, 6]), 2.0),
 ])
 def test_crmse(obs, fx, value):
     crmse = deterministic.centered_root_mean_square(obs, fx)

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -6,6 +6,7 @@ from solarforecastarbiter.metrics import deterministic
 @pytest.mark.parametrize("obs,fx,value", [
     (np.array([0, 1, 2]), np.array([0, 1, 2]), 0.0),
     (np.array([0, 1, 2]), np.array([0, 1, 1]), 1 / 3),
+    (np.array([0, 1, 2]), np.array([0, 1, 3]), 1 / 3),
 ])
 def test_mae(obs, fx, value):
     mae = deterministic.mean_absolute(obs, fx)
@@ -28,6 +29,7 @@ def test_mbe(obs, fx, value):
 @pytest.mark.parametrize("obs,fx,value", [
     (np.array([0, 1]), np.array([0, 1]), 0.0),
     (np.array([0, 1]), np.array([1, 2]), 1.0),
+    (np.array([1, 2]), np.array([0, 1]), 1.0),
 ])
 def test_rmse(obs, fx, value):
     rmse = deterministic.root_mean_square(obs, fx)
@@ -37,6 +39,7 @@ def test_rmse(obs, fx, value):
 @pytest.mark.parametrize("obs,fx,value", [
     (np.array([1, 1]), np.array([2, 2]), 100.0),
     (np.array([2, 2]), np.array([3, 3]), 50.0),
+    (np.array([1, 2]), np.array([1, 2]), 0.0),
 ])
 def test_mape(obs, fx, value):
     mape = deterministic.mean_absolute_percentage(obs, fx)
@@ -64,20 +67,20 @@ def test_nmbe(obs, fx, norm, value):
     assert nmbe == value
 
 
-@pytest.mark.parametrize("obs,fx,y_norm,value", [
+@pytest.mark.parametrize("obs,fx,norm,value", [
     (np.array([0, 1, 2]), np.array([0, 1, 2]), 1.0, 0.0),
     (np.array([0, 1, 2]), np.array([0, 1, 2]), 55.0, 0.0),
     (np.array([0, 1]), np.array([1, 2]), 1.0, 100.0),
     (np.array([0, 1]), np.array([1, 2]), 100.0, 1.0),
 ])
-def test_nrmse(obs, fx, y_norm, value):
-    nrmse = deterministic.normalized_root_mean_square(obs, fx, y_norm)
+def test_nrmse(obs, fx, norm, value):
+    nrmse = deterministic.normalized_root_mean_square(obs, fx, norm)
     assert nrmse == value
 
 
 @pytest.mark.parametrize("obs,fx,ref,value", [
-    (np.array([0, 1]), np.array([0, 2]), np.array([0, 2]), 1.0 - 1.0 / 1.0),
-    (np.array([0, 1]), np.array([0, 2]), np.array([0, 3]), 1.0 - 1.0 / 2.0),
+    (np.array([0, 1]), np.array([0, 2]), np.array([0, 2]), 0.0),
+    (np.array([0, 1]), np.array([0, 2]), np.array([0, 3]), 0.5),
 ])
 def test_skill(obs, fx, ref, value):
     s = deterministic.forecast_skill(obs, fx, ref)
@@ -95,6 +98,7 @@ def test_r(obs, fx, value):
 
 @pytest.mark.parametrize("obs,fx,value", [
     (np.array([0, 1]), np.array([0, 1]), 1.0),
+    (np.array([1, 2, 3]), np.array([2, 2, 2]), 0.0),
 ])
 def test_r2(obs, fx, value):
     r2 = deterministic.coeff_determination(obs, fx)


### PR DESCRIPTION
  - [x] Closes #270 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This PR adds tests so that all metrics have non-zero examples.
