### PR TITLE
add subsubsections to metrics api doc

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -396,6 +396,9 @@ Entry points for calculating metrics for
    metrics.calculator.calculate_metrics
    metrics.calculator.calculate_deterministic_metrics
 
+Preprocessing
+-------------
+
 Functions for preparing the timeseries data before calculating metrics:
 
 .. autosummary::
@@ -404,6 +407,9 @@ Functions for preparing the timeseries data before calculating metrics:
    metrics.preprocessing.apply_validation
    metrics.preprocessing.resample_and_align
    metrics.preprocessing.exclude
+
+Deterministic
+-------------
 
 Functions to compute forecast deterministic performance metrics:
 
@@ -425,6 +431,9 @@ Functions to compute forecast deterministic performance metrics:
    metrics.deterministic.over
    metrics.deterministic.combined_performance_index
 
+Probabilistic
+-------------
+
 Functions to compute forecast probabilistic performance metrics:
 
 .. autosummary::
@@ -438,6 +447,9 @@ Functions to compute forecast probabilistic performance metrics:
     metrics.probabilistic.uncertainty
     metrics.probabilistic.sharpness
     metrics.probabilistic.continuous_ranked_probability_score
+
+Value
+-----
 
 Functions to compute forecast valuation metrics:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #xxxx .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

minor edits to metrics subsection of API docs. 
