### PR TITLE
metrics: complete `_MAP`, `_REQ_REF_FX`, `_REQ_NORM`

### DIFF
--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -436,7 +436,10 @@ _MAP = {
     's': forecast_skill,
     'r': pearson_correlation_coeff,
     'r^2': coeff_determination,
-    'crmse': centered_root_mean_square
+    'crmse': centered_root_mean_square,
+    'ksi': kolmogorov_smirnov_integral,
+    'over': over,
+    'cpi': combined_performance_index,
 }
 
 __all__ = [m.__name__ for m in _MAP.values()]

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -2,16 +2,6 @@
 
 import numpy as np
 
-__all__ = [
-    "brier_score",
-    "brier_skill_score",
-    "reliability",
-    "resolution",
-    "uncertainty",
-    "sharpness",
-    "continuous_ranked_probability_score",
-]
-
 
 def brier_score(obs, fx, fx_prob):
     """Brier Score (BS).
@@ -403,3 +393,23 @@ def continuous_ranked_probability_score(obs, fx, fx_prob):
     dx = np.diff(fx, axis=1)
     crps = np.mean(np.sum(integrand[:, :-1] * dx, axis=1))
     return crps
+
+
+# Add new metrics to this map to map shorthand to function
+_MAP = {
+    'bs': brier_score,
+    'bss': brier_skill_score,
+    'rel': reliability,
+    'res': resolution,
+    'unc': uncertainty,
+    'sh': sharpness,
+    'crps': continuous_ranked_probability_score,
+}
+
+__all__ = [m.__name__ for m in _MAP.values()]
+
+# Functions that require a reference forecast
+_REQ_REF_FX = ['bss']
+
+# Functions that require normalized factor
+_REQ_NORM = []


### PR DESCRIPTION
  - [x] Closes #275 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Complete `_MAP`, `_REQ_REF_FX`, and `_REQ_NORM` in both the deterministic and probabilistic metrics.