### PR TITLE
metrics: handle exceptions in pearson_correlation_coeff

### DIFF
--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -224,7 +224,7 @@ def pearson_correlation_coeff(obs, fx):
 
     try:
         r, _ = sp.stats.pearsonr(obs, fx)
-    except ValueError as e:
+    except ValueError:
         r = np.nan
 
     return r

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -221,10 +221,14 @@ def pearson_correlation_coeff(obs, fx):
         The correlation coefficient (r [-]) of the observations and forecasts.
 
     """
-    if len(obs) == 1 or len(fx) == 1:
-        return np.nan
 
-    r, _ = sp.stats.pearsonr(obs, fx)
+    try:
+        r, _ = sp.stats.pearsonr(obs, fx)
+    except ValueError as e:
+        #print(e)
+        #r = np.nan
+        raise e
+
     return r
 
 

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -225,9 +225,7 @@ def pearson_correlation_coeff(obs, fx):
     try:
         r, _ = sp.stats.pearsonr(obs, fx)
     except ValueError as e:
-        #print(e)
-        #r = np.nan
-        raise e
+        r = np.nan
 
     return r
 

--- a/solarforecastarbiter/metrics/tests/test_deterministic.py
+++ b/solarforecastarbiter/metrics/tests/test_deterministic.py
@@ -93,7 +93,20 @@ def test_skill(obs, fx, ref, value):
 ])
 def test_r(obs, fx, value):
     r = deterministic.pearson_correlation_coeff(obs, fx)
-    assert pytest.approx(r) == value
+    assert r == value
+
+
+@pytest.mark.parametrize("obs,fx", [
+    # len(obs) < 2 or len(fx) < 2
+    (np.array([0]), np.array([1])),
+
+    # len(obs) != len(fx)
+    (np.array([0, 1, 2]), np.array([0, 1, 2, 3])),
+    (np.array([2, 3, 4]), np.array([2, 3, 5, 6])),
+])
+def test_r_nan(obs, fx):
+    r = deterministic.pearson_correlation_coeff(obs, fx)
+    assert np.isnan(r)
 
 
 @pytest.mark.parametrize("obs,fx,value", [


### PR DESCRIPTION
  - [x] Closes #277 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This PR adds exception handling to `solarforecastarbiter.metrics.deterministic.pearson_correlation_coeff()` to deal with cases where a) `len(obs) < 2` or `len(fx) < 2` or b) `len(obs) != len(fx)`. In those two cases, the function returns NaN.
