### PR TITLE
Add metrics mappings to data model

### DIFF
--- a/docs/source/whatsnew/1.0.0b3.rst
+++ b/docs/source/whatsnew/1.0.0b3.rst
@@ -51,6 +51,10 @@ Enhancements
 * Dictionary of metric results from metrics.calculator now has structure with
   levels of  1) category type 2) metric type 3) pandas.Series of metrics values
   with index of category values (:pull:`224`)
+* Added ``datamodel.ALLOWED_DETERMINISTIC_METRICS`` and 
+  ``datamodel.ALLOWED_PROBABILISTIC_METRICS`` dictionaries for importing
+  metrics options outside of core. (:pull:`286`)
+
 
 Bug fixes
 ~~~~~~~~~

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -13,6 +13,8 @@ from typing import Tuple, Union
 import pandas as pd
 
 
+from solarforecastarbiter.metrics.deterministic import _MAP as deterministic
+from solarforecastarbiter.metrics.probabilistic import _MAP as probabilistic
 from solarforecastarbiter.validation.quality_mapping import \
     DESCRIPTION_MASK_MAPPING
 
@@ -66,31 +68,10 @@ ALLOWED_CATEGORIES = {
 }
 
 ALLOWED_DETERMINISTIC_METRICS = {
-    'mae': 'MAE',
-    'mbe': 'MBE',
-    'rmse': 'RMSE',
-    'mape': 'MAPE',
-    'nmae': 'NMAE',
-    'nmbe': 'NMBE',
-    'nrmse': 'NRMSE',
-    's': 'Skill',
-    'r': 'r',
-    'r^2': 'R^2',
-    'crmse': 'CRMSE',
-    'ksi': 'KSI',
-    'over': 'OVER',
-    'cpi': 'CPI'
-}
+    k: v[1] for k, v in deterministic.items()}
 
 ALLOWED_PROBABILISTIC_METRICS = {
-    'bs': 'BS',
-    'bss': 'BSS',
-    'rel': 'REL',
-    'res': 'RES',
-    'unc': 'UNC',
-    'sh': 'SH',
-    'crps': 'CRPS',
-}
+    k: v[1] for k, v in probabilistic.items()}
 
 
 def _dict_factory(inp):

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -74,7 +74,7 @@ ALLOWED_DETERMINISTIC_METRICS = {
     'nmbe': 'NMBE',
     'nrmse': 'NRMSE',
     's': 'Skill',
-    'r': 'R',
+    'r': 'r',
     'r^2': 'R^2',
     'crmse': 'CRMSE',
     'ksi': 'KSI',

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -82,7 +82,7 @@ ALLOWED_DETERMINISTIC_METRICS = {
     'cpi': 'CPI'
 }
 
-ALLOWED_DETERMINISTIC_METRICS = {
+ALLOWED_PROBABILISTIC_METRICS = {
     'bs': 'BS',
     'bss': 'BSS',
     'rel': 'REL',

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -13,8 +13,10 @@ from typing import Tuple, Union
 import pandas as pd
 
 
-from solarforecastarbiter.metrics.deterministic import _MAP as deterministic
-from solarforecastarbiter.metrics.probabilistic import _MAP as probabilistic
+from solarforecastarbiter.metrics.deterministic import \
+    _MAP as deterministic_mapping
+from solarforecastarbiter.metrics.probabilistic import \
+    _MAP as probabilistic_mapping
 from solarforecastarbiter.validation.quality_mapping import \
     DESCRIPTION_MASK_MAPPING
 
@@ -68,10 +70,10 @@ ALLOWED_CATEGORIES = {
 }
 
 ALLOWED_DETERMINISTIC_METRICS = {
-    k: v[1] for k, v in deterministic.items()}
+    k: v[1] for k, v in deterministic_mapping.items()}
 
 ALLOWED_PROBABILISTIC_METRICS = {
-    k: v[1] for k, v in probabilistic.items()}
+    k: v[1] for k, v in probabilistic_mapping.items()}
 
 
 def _dict_factory(inp):

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -65,6 +65,33 @@ ALLOWED_CATEGORIES = {
     'weekday': 'Day of the week'
 }
 
+ALLOWED_DETERMINISTIC_METRICS = {
+    'mae': 'MAE',
+    'mbe': 'MBE',
+    'rmse': 'RMSE',
+    'mape': 'MAPE',
+    'nmae': 'NMAE',
+    'nmbe': 'NMBE',
+    'nrmse': 'NRMSE',
+    's': 'S',
+    'r': 'R',
+    'r^2': 'R^2',
+    'crmse': 'CRMSE',
+    'ksi': 'KSI',
+    'over': 'OVER',
+    'cpi': 'CPI'
+}
+
+ALLOWED_DETERMINISTIC_METRICS = {
+    'bs': 'BS',
+    'bss': 'BSS',
+    'rel': 'REL',
+    'res': 'RES',
+    'unc': 'UNC',
+    'sh': 'SH',
+    'crps': 'CRPS',
+}
+
 
 def _dict_factory(inp):
     dict_ = dict(inp)

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -73,7 +73,7 @@ ALLOWED_DETERMINISTIC_METRICS = {
     'nmae': 'NMAE',
     'nmbe': 'NMBE',
     'nrmse': 'NRMSE',
-    's': 'S',
+    's': 'Skill',
     'r': 'R',
     'r^2': 'R^2',
     'crmse': 'CRMSE',

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -74,7 +74,7 @@ def calculate_metrics(processed_pairs, categories, metrics,
 def _apply_deterministic_metric_func(metric, fx, obs, **kwargs):
     """Helper function to deal with variable number of arguments possible for
     metric functions. """
-    metric_func = deterministic._MAP[metric]
+    metric_func = deterministic._MAP[metric][0]
     if metric in deterministic._REQ_REF_FX:
         return metric_func(obs, fx, kwargs['ref_fx'])
     elif metric in deterministic._REQ_NORM:

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -428,23 +428,23 @@ def combined_performance_index(obs, fx):
 
 # Add new metrics to this map to map shorthand to function
 _MAP = {
-    'mae': mean_absolute,
-    'mbe': mean_bias,
-    'rmse': root_mean_square,
-    'mape': mean_absolute_percentage,
-    'nmae': normalized_mean_absolute,
-    'nmbe': normalized_mean_bias,
-    'nrmse': normalized_root_mean_square,
-    's': forecast_skill,
-    'r': pearson_correlation_coeff,
-    'r^2': coeff_determination,
-    'crmse': centered_root_mean_square,
-    'ksi': kolmogorov_smirnov_integral,
-    'over': over,
-    'cpi': combined_performance_index,
+    'mae': (mean_absolute, 'MAE'),
+    'mbe': (mean_bias, 'MBE'),
+    'rmse': (root_mean_square, 'RMSE'),
+    'mape': (mean_absolute_percentage, 'MAPE'),
+    'nmae': (normalized_mean_absolute, 'NMAE'),
+    'nmbe': (normalized_mean_bias, 'NMBE'),
+    'nrmse': (normalized_root_mean_square, 'NRMSE'),
+    's': (forecast_skill, 'Skill'),
+    'r': (pearson_correlation_coeff, 'r'),
+    'r^2': (coeff_determination, 'R^2'),
+    'crmse': (centered_root_mean_square, 'CRMSE'),
+    'ksi': (kolmogorov_smirnov_integral, 'KSI'),
+    'over': (over, 'OVER'),
+    'cpi': (combined_performance_index, 'CPI'),
 }
 
-__all__ = [m.__name__ for m in _MAP.values()]
+__all__ = [m[0].__name__ for m in _MAP.values()]
 
 # Functions that require a reference forecast
 _REQ_REF_FX = ['s']

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -406,7 +406,7 @@ _MAP = {
     'crps': (continuous_ranked_probability_score, 'CRPS'),
 }
 
-__all__ = [m.__name__ for m in _MAP.values()]
+__all__ = [m[0].__name__ for m in _MAP.values()]
 
 # Functions that require a reference forecast
 _REQ_REF_FX = ['bss']

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -397,13 +397,13 @@ def continuous_ranked_probability_score(obs, fx, fx_prob):
 
 # Add new metrics to this map to map shorthand to function
 _MAP = {
-    'bs': brier_score,
-    'bss': brier_skill_score,
-    'rel': reliability,
-    'res': resolution,
-    'unc': uncertainty,
-    'sh': sharpness,
-    'crps': continuous_ranked_probability_score,
+    'bs': (brier_score, 'BS'),
+    'bss': (brier_skill_score, 'BSS'),
+    'rel': (reliability, 'REL'),
+    'res': (resolution, 'RES'),
+    'unc': (uncertainty, 'UNC'),
+    'sh': (sharpness, 'SH'),
+    'crps': (continuous_ranked_probability_score, 'CRPS'),
 }
 
 __all__ = [m.__name__ for m in _MAP.values()]


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [ ] Closes #xxxx .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Adds an `ALLOWED_DETERMINISTIC_METRICS` and `ALLOWED_PROBABILISTIC_METRICS` dictionaries mapping abbreviated names to display names. e.g. 'mae' => 'mae', so that we can import this elsewhere without touching the private `_MAP` variable in metrics modules, and so that there is a centralized location to define display names for each metric.
