### PR TITLE
Fix report links

### DIFF
--- a/docs/source/whatsnew/1.0.0b3.rst
+++ b/docs/source/whatsnew/1.0.0b3.rst
@@ -30,6 +30,8 @@ API Changes
 * Add additional normalized deterministic metrics
   :py:mod:`solarforecastarbiter.metrics.deterministic.normalized_mean_absolute`, and
   :py:mod:`solarforecastarbiter.metrics.deterministic.normalized_mean_bias`. (:issue:`118`) (:pull:`268`)
+* Add `base_url` keyword to :py:mod:`solarforecastarbiter.reports.template.full_html` (:pull:`287`)
+
 
 Enhancements
 ~~~~~~~~~~~~
@@ -61,6 +63,7 @@ Bug fixes
 * Fix metric plot limits for newer metrics. (:issue:`276`)
 * Fix bug in which metrics table width was not calculated correctly,
   leading to not all metrics being displayed. (:issue:`284`)
+* Fix report links (:issue:`175`) (:pull:`287`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/cli.py
+++ b/solarforecastarbiter/cli.py
@@ -310,7 +310,7 @@ def report(verbose, user, password, base_url, report_file, output_file):
     raw_report = reports.create_raw_report_from_data(report, data)
     report_md = reports.render_raw_report(raw_report)
     body = template.report_md_to_html(report_md)
-    full_report = template.full_html(body)
+    full_report = template.full_html(body, base_url)
     with open(output_file, 'w') as f:
         f.write(full_report)
 

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -188,7 +188,7 @@ def report_md_to_html(report_md):
     return out.stdout.decode()
 
 
-def full_html(body):
+def full_html(body, base_url=None):
     """Create full html file.
 
     The Solar Forecast Arbiter dashboard will likely use its own
@@ -208,6 +208,9 @@ def full_html(body):
         autoescape=select_autoescape(['html', 'xml']))
     base_template = env.get_template('base.html')
 
-    base = base_template.render(body=body)
+    args = {'body': body}
+    if base_url is not None:
+        args['base_url'] = base_url.replace('api.', 'dashboard.')
 
+    base = base_template.render(**args)
     return base

--- a/solarforecastarbiter/reports/templates/head.html
+++ b/solarforecastarbiter/reports/templates/head.html
@@ -10,3 +10,6 @@
 <script src="https://cdn.pydata.org/bokeh/release/bokeh-1.3.4.min.js"></script>
 <script src="https://cdn.pydata.org/bokeh/release/bokeh-widgets-1.3.4.min.js"></script>
 <script src="https://cdn.pydata.org/bokeh/release/bokeh-tables-1.3.4.min.js"></script>
+{%- if base_url is defined %}
+<base href="{{ base_url }}">
+{% endif -%}

--- a/solarforecastarbiter/reports/templates/metrics_date.md
+++ b/solarforecastarbiter/reports/templates/metrics_date.md
@@ -1,8 +1,7 @@
-
 ### <a name="date-analysis"></a>Date analysis
 
 Metrics for each date of the analysis period are displayed in tables and figures below.
 
-{% for figure in figures['date'] %}
+{% for figure in figures['date'] -%}
   {{ figure | safe }}
-{% endfor %}
+{%- endfor %}

--- a/solarforecastarbiter/reports/templates/metrics_day.md
+++ b/solarforecastarbiter/reports/templates/metrics_day.md
@@ -1,8 +1,0 @@
-
-### <a name="day-analysis"></a>Day of the month analysis
-
-Metrics for each day of the analysis period are displayed in tables and figures below. Each day is represented by an increasing integer.
-
-{% for figure in figures['Day of the month'] %}
-  {{ figure | safe }}
-{% endfor %}

--- a/solarforecastarbiter/reports/templates/metrics_hour.md
+++ b/solarforecastarbiter/reports/templates/metrics_hour.md
@@ -1,8 +1,7 @@
-
 ### <a name="hour-analysis"></a>Hour of the day analysis
 
 Metrics for each hour (0-23) of the analysis period are displayed in tables and figures below.
 
-{% for figure in figures['hour'] %}
+{% for figure in figures['hour'] -%}
   {{ figure | safe }}
-{% endfor %}
+{%- endfor %}

--- a/solarforecastarbiter/reports/templates/metrics_month.md
+++ b/solarforecastarbiter/reports/templates/metrics_month.md
@@ -1,8 +1,7 @@
-
 ### <a name="month-analysis"></a>Month of the year analysis
 
 Metrics for each month of the analysis period are displayed in tables and figures below.
 
-{% for figure in figures['month'] %}
+{% for figure in figures['month'] -%}
   {{ figure | safe }}
-{% endfor %}
+{%- endfor %}

--- a/solarforecastarbiter/reports/templates/metrics_total.md
+++ b/solarforecastarbiter/reports/templates/metrics_total.md
@@ -1,9 +1,8 @@
-
 ### <a name="total-analysis"></a>Total analysis
 
 Metrics for the total analysis period are displayed in tables and figures below.
 
 {{ tables | safe }}
-{% for figure in figures['total'] %}
+{% for figure in figures['total'] -%}
   {{ figure | safe }}
-{% endfor %}
+{%- endfor %}

--- a/solarforecastarbiter/reports/templates/metrics_weekday.md
+++ b/solarforecastarbiter/reports/templates/metrics_weekday.md
@@ -1,8 +1,7 @@
-
 ### <a name="weekday-analysis"></a>Day of the week analysis
 
 Metrics for weekday of the analysis period are displayed in tables and figures below.
 
-{% for figure in figures['weekday'] %}
+{% for figure in figures['weekday'] -%}
   {{ figure | safe }}
-{% endfor %}
+{%- endfor %}

--- a/solarforecastarbiter/reports/templates/metrics_year.md
+++ b/solarforecastarbiter/reports/templates/metrics_year.md
@@ -1,8 +1,7 @@
-
 ### <a name='year-analysis'></a>Year analysis
 
 Metrics for each year contained the analysis period are displayed in tables and figures below.
 
-{% for figure in figures['year'] %}
+{% for figure in figures['year'] -%}
   {{ figure | safe }}
-{% endfor %}
+{%- endfor %}

--- a/solarforecastarbiter/reports/templates/template.md
+++ b/solarforecastarbiter/reports/templates/template.md
@@ -1,12 +1,12 @@
 # {{ name }}
 
-{# this document is designed to be rendered in 3 steps #}
-{# 1. jinja renders the "prereport" - a markdown file with bokeh html/js tables and metrics graphics #}
-{# 2. jinja renders the "full report" - a markdown file with bokeh html/js with the above plus timeseries and scatter plots #}
-{# 3. pandoc renders the html or pdf version of the full report #}
 
 {# fix this #}
 {% set dash_url = 'https://dashboard.solarforecastarbiter.org' %}
+{#- this document is designed to be rendered in 3 steps #}
+{#- 1. jinja renders the "prereport" - a markdown file with bokeh html/js tables and metrics graphics #}
+{#- 2. jinja renders the "full report" - a markdown file with bokeh html/js with the above plus timeseries and scatter plots #}
+{#- 3. pandoc renders the html or pdf version of the full report #}
 
 This report of solar forecast accuracy was automatically generated using the [Solar Forecast Arbiter](https://solarforecastarbiter.org).
 
@@ -24,17 +24,16 @@ Contents:
   * [Observations and forecasts](#observations-and-forecasts)
   * [Data validation](#data-validation)
 * [Metrics](#metrics)
-{% for met_key, met_val in metrics_toc.items() %}
-  {% if met_key in figures.keys() %}
+{%- for met_key, met_val in metrics_toc.items() %}
+  {%- if met_key in figures.keys() %}
   * [{{met_val}} analysis](#{{met_key}}-analysis)
-  {% endif %}
-{% endfor %}
+  {%- endif %}
+{%- endfor %}
 * [Versions](#versions)
-* [Hash](#hash)
 
 ## Report metadata
 
-{# jinja requires that we escape the markdown div specification #}
+{#- jinja requires that we escape the markdown div specification #}
 {{ '::: {.metadata-table}' }}
 
 * Name: {{ name }}
@@ -45,12 +44,12 @@ Contents:
 
 ## Data
 
-{# replace with warning if not all forecast/obs data is accessible #}
-{% if checksum_failure %}
+{#- replace with warning if not all forecast/obs data is accessible #}
+{%- if checksum_failure %}
 {{ '::: warning' }}
 WARNING: One or more of the observation or forecast data has changed since this report was created. Consider creating a new report.
 :::
-{% endif %}
+{%- endif %}
 
 This report includes forecast and observation data available from {{ start }} to {{ end }}.
 
@@ -73,7 +72,6 @@ Controls to pan, zoom, and save the plot are shown on the right. Clicking on an 
 {# endif #}
 
 {{ script_data | safe }}
-
 {{ figures_timeseries_scatter | safe }}
 
 ### Data validation
@@ -88,20 +86,18 @@ These intervals were removed from the raw time series before resampling and real
 
 ## Metrics
 
-{{ '{%' }} raw {{ '%}' }}
+{{- '{%' }} raw {{ '%}' }}
 {{ script_metrics | safe }}
-{{ '{%' }} endraw {{ '%}' }}
+{{- '{%' }} endraw {{ '%}' }}
 
 Metrics are displayed in tables and figures below for one or more time periods. Metrics may be downloaded in csv format.
 
-{# Loop through each metric as keys in figures_bar by calling the markdown #}
+{#- Loop through each metric as keys in figures_bar by calling the markdown #}
 
-{#{ figures | safe }#}
-
-{% for met_key in metrics_toc.keys() %}
-{% if met_key in figures.keys() %}
-  {% include 'metrics_' + met_key + '.md' %}
-{% endif %}
+{% for met_key in metrics_toc.keys() -%}
+{%- if met_key in figures.keys() %}
+{% include 'metrics_' + met_key + '.md' %}
+{%- endif %}
 {% endfor %}
 
 ## Versions

--- a/solarforecastarbiter/reports/templates/template.md
+++ b/solarforecastarbiter/reports/templates/template.md
@@ -109,10 +109,3 @@ This report was created using open source software packages. The relevant packag
 {% for package, version in versions.items() -%}
     | {{ package|e }} | {{ version|e }} |
 {% endfor %}
-
-## Hash
-
-{# fix this #}
-The report signature is: a46d9d6e1fbd85b1023a95835a09f5f42491cf5a
-
-The signature can be verified using the Solar Forecast Arbiter [public key](solarforecastarbiter.org).

--- a/solarforecastarbiter/reports/templates/template.md
+++ b/solarforecastarbiter/reports/templates/template.md
@@ -1,8 +1,6 @@
 # {{ name }}
 
 
-{# fix this #}
-{% set dash_url = 'https://dashboard.solarforecastarbiter.org' %}
 {#- this document is designed to be rendered in 3 steps #}
 {#- 1. jinja renders the "prereport" - a markdown file with bokeh html/js tables and metrics graphics #}
 {#- 2. jinja renders the "full report" - a markdown file with bokeh html/js with the above plus timeseries and scatter plots #}
@@ -63,7 +61,7 @@ The table below shows the observation, forecast pairs analyzed in this report. T
 |:--------|---|---|---|---|:--------|---|---|---|---|
 Name|Interval label|Interval length|Aligned interval label|Resampled interval length|Name|Interval label|Interval length|Aligned interval label|Resampled interval length
 {% for fx_ob, route, id in proc_fx_obs -%}
-[{{ fx_ob.original.data_object.name|safe }}]({{ dash_url|safe }}/{{ route|safe }}/{{ id|safe }}) | {{ fx_ob.original.data_object.interval_label | safe}} | {{ (fx_ob.original.data_object.interval_length.total_seconds()/60)|int|safe }} min | {{ fx_ob.interval_label|safe }} | {{ (fx_ob.interval_length.total_seconds()/60)|int|safe }} min | [{{ fx_ob.original.forecast.name|safe }}]({{ dash_url|safe }}/forecasts/single/{{ fx_ob.original.forecast.forecast_id|safe }}) | {{ fx_ob.original.forecast.interval_label|safe }} | {{ (fx_ob.original.forecast.interval_length.total_seconds()/60)|int|safe }} min | {{ fx_ob.interval_label|safe }} | {{ (fx_ob.interval_length.total_seconds()/60)|int|safe }} min
+[{{ fx_ob.original.data_object.name|safe }}](/{{ route|safe }}/{{ id|safe }}) | {{ fx_ob.original.data_object.interval_label | safe}} | {{ (fx_ob.original.data_object.interval_length.total_seconds()/60)|int|safe }} min | {{ fx_ob.interval_label|safe }} | {{ (fx_ob.interval_length.total_seconds()/60)|int|safe }} min | [{{ fx_ob.original.forecast.name|safe }}](/forecasts/single/{{ fx_ob.original.forecast.forecast_id|safe }}) | {{ fx_ob.original.forecast.interval_label|safe }} | {{ (fx_ob.original.forecast.interval_length.total_seconds()/60)|int|safe }} min | {{ fx_ob.interval_label|safe }} | {{ (fx_ob.interval_length.total_seconds()/60)|int|safe }} min
 {% endfor %}
 
 The plots below show the realigned and resampled time series of observation and forecast data as well as a scatter plot of forecast vs observation data.

--- a/solarforecastarbiter/tests/data/report_metadata.json
+++ b/solarforecastarbiter/tests/data/report_metadata.json
@@ -24,9 +24,9 @@
             "mbe"
         ],
         "categories": [
-          "Total",
-          "Date",
-          "Hour of the day"
+          "total",
+          "date",
+          "hour"
         ],
         "report_id": "56c67770-9832-11e9-a535-f4939feddd82",
         "object_pairs": [


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #175
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

by making them relative and including ``<base>`` to set what the URLs are relative to. This way, the links should work both when on the dashboard and when the html file is downloaded. Also fixes the table of contents formatting and removes other new lines in the template.