### PR TITLE
metrics: preprocessing: drop NaNs explicitly

### DIFF
--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1059,7 +1059,7 @@ def report_objects(aggregate):
         name="University of Arizona OASIS ghi",
         variable="ghi",
         interval_value_type="interval_mean",
-        interval_length=pd.Timedelta("0 days 00:01:00"),
+        interval_length=pd.Timedelta("1h"),
         interval_label="ending",
         site=site,
         uncertainty=0.0,

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1059,7 +1059,7 @@ def report_objects(aggregate):
         name="University of Arizona OASIS ghi",
         variable="ghi",
         interval_value_type="interval_mean",
-        interval_length=pd.Timedelta("1h"),
+        interval_length=pd.Timedelta("15min"),
         interval_label="ending",
         site=site,
         uncertainty=0.0,

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -93,7 +93,7 @@ def resample_and_align(fx_obs, data, tz):
         ).agg(["mean", "count"])
 
         # Drop intervals if too many samples missing
-        count_threshold = int(fx.interval_length / obs.interval_length * 0.5)
+        count_threshold = int(fx.interval_length / obs.interval_length * 0.1)
         obs_resampled = obs_resampled["mean"].where(
             obs_resampled["count"] >= count_threshold
         )

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -67,10 +67,10 @@ def resample_and_align(fx_obs, data, tz):
     fx_obs : solarforecastarbiter.datamodel.ForecastObservation, solarforecastarbiter.datamodel.ForecastAggregate
         Pair of forecast and observation.
     data : dict
-        Keys are Observation and Forecast models and values
-        the validated timeseries data as pandas.Series.
+        Keys are Observation and Forecast models and values the validated
+        timeseries data as pandas.Series.
     tz : str
-        Timezone to witch processed data will be converted.
+        Timezone to which processed data will be converted.
 
     Returns
     -------

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -95,6 +95,9 @@ def resample_and_align(fx_obs, data, tz):
         obs_resampled = obs_resampled["mean"].where(
             obs_resampled["count"] >= count_threshold
         )
+    elif fx.interval_length < obs.interval_length:
+        raise ValueError('observation.interval_length cannot be greater than '
+                         'forecast.interval_length.')
     else:
         obs_resampled = obs_resampled["mean"]
 

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -84,13 +84,15 @@ def resample_and_align(fx_obs, data, tz):
     obs = fx_obs.data_object
 
     # Resample observation
-    closed = datamodel.CLOSED_MAPPING[fx.interval_label]
-    obs_resampled = data[obs].resample(fx.interval_length,
-                                       label=closed,
-                                       closed=closed).agg(["mean", "count"])
-
-    # Drop periods if too many samples missing
     if fx.interval_length > obs.interval_length:
+        closed = datamodel.CLOSED_MAPPING[fx.interval_label]
+        obs_resampled = data[obs].resample(
+            fx.interval_length,
+            label=closed,
+            closed=closed
+        ).agg(["mean", "count"])
+
+        # Drop intervals if too many samples missing
         count_threshold = int(fx.interval_length / obs.interval_length * 0.5)
         obs_resampled = obs_resampled["mean"].where(
             obs_resampled["count"] >= count_threshold
@@ -99,7 +101,7 @@ def resample_and_align(fx_obs, data, tz):
         raise ValueError('observation.interval_length cannot be greater than '
                          'forecast.interval_length.')
     else:
-        obs_resampled = obs_resampled["mean"]
+        obs_resampled = data[obs]
 
     # Align (forecast is unchanged)
     # Remove non-corresponding observations and

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -89,10 +89,14 @@ def resample_and_align(fx_obs, data, tz):
                                        label=closed,
                                        closed=closed).mean()
 
+    # Remove NaNs
+    obs_resampled = obs_resampled.dropna(how="any")
+    data[fx] = data[fx].dropna(how="any")
+
     # Align (forecast is unchanged)
     # Remove non-corresponding observations and
     # fill missing observations with NaN
-    fx_aligned, obs_aligned = data[fx].align(obs_resampled, 'left')
+    fx_aligned, obs_aligned = data[fx].align(obs_resampled, 'inner')
 
     # Determine series with timezone conversion
     forecast_values = fx_aligned.tz_convert(tz)

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -89,14 +89,12 @@ def resample_and_align(fx_obs, data, tz):
                                        label=closed,
                                        closed=closed).mean()
 
-    # Remove NaNs
-    obs_resampled = obs_resampled.dropna(how="any")
-    data[fx] = data[fx].dropna(how="any")
-
     # Align (forecast is unchanged)
     # Remove non-corresponding observations and
-    # fill missing observations with NaN
-    fx_aligned, obs_aligned = data[fx].align(obs_resampled, 'inner')
+    # forecasts, and missing periods
+    obs_resampled = obs_resampled.dropna(how="any")
+    obs_aligned, fx_aligned = obs_resampled.align(data[fx].dropna(how="any"),
+                                                  'inner')
 
     # Determine series with timezone conversion
     forecast_values = fx_aligned.tz_convert(tz)

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -17,6 +17,11 @@ THREE_HOURS = pd.date_range(start='2019-03-31T12:00:00',
 THREE_HOUR_SERIES = pd.Series(np.arange(1., 4., 1.), index=THREE_HOURS,
                               name='value')
 
+THREE_HOUR_NAN_SERIES = pd.Series([1.0, np.nan, 4.0], index=THREE_HOURS,
+                                  name="value")
+
+THREE_HOURS_NAN = THREE_HOURS[[True, False, True]]
+
 THIRTEEN_10MIN = pd.date_range(start='2019-03-31T12:00:00',
                                periods=13,
                                freq='10min',
@@ -37,7 +42,8 @@ OK = int(0b10)  # OK version 0 (2)
 @pytest.mark.parametrize('fx_series,obs_series,expected_dt', [
     (THREE_HOUR_SERIES, THREE_HOUR_SERIES, THREE_HOURS),
     (THREE_HOUR_SERIES, THIRTEEN_10MIN_SERIES, THREE_HOURS),
-    (THIRTEEN_10MIN_SERIES, THIRTEEN_10MIN_SERIES, THIRTEEN_10MIN)
+    (THIRTEEN_10MIN_SERIES, THIRTEEN_10MIN_SERIES, THIRTEEN_10MIN),
+    (THREE_HOUR_SERIES, THREE_HOUR_NAN_SERIES, THREE_HOURS_NAN),
 ])
 def test_resample_and_align(site_metadata, interval_label,
                             fx_series, obs_series, expected_dt):

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -44,6 +44,8 @@ OK = int(0b10)  # OK version 0 (2)
     (THREE_HOUR_SERIES, THIRTEEN_10MIN_SERIES, THREE_HOURS),
     (THIRTEEN_10MIN_SERIES, THIRTEEN_10MIN_SERIES, THIRTEEN_10MIN),
     (THREE_HOUR_SERIES, THREE_HOUR_NAN_SERIES, THREE_HOURS_NAN),
+    (THREE_HOUR_NAN_SERIES, THREE_HOUR_SERIES, THREE_HOURS_NAN),
+    (THREE_HOUR_NAN_SERIES, THREE_HOUR_NAN_SERIES, THREE_HOURS_NAN),
 ])
 def test_resample_and_align(site_metadata, interval_label,
                             fx_series, obs_series, expected_dt):

--- a/solarforecastarbiter/tests/test_cli.py
+++ b/solarforecastarbiter/tests/test_cli.py
@@ -228,8 +228,8 @@ def test_report(cli_token, mocker, report_objects):
     index = pd.date_range(
         start="2019-04-01T00:00:00Z", end="2019-04-04T23:59:00Z",
         freq='1h')
-    data = pd.Series([0] * len(index), index=index)
-    obs = pd.DataFrame({'value': data, 'quality_flag': data + 3})
+    data = pd.Series(0, index=index)
+    obs = pd.DataFrame({'value': data, 'quality_flag': 2})
     mocker.patch('solarforecastarbiter.cli.reports.get_data_for_report',
                  return_value={report_objects[2]: data,
                                report_objects[3]: data,


### PR DESCRIPTION
Modify `resample_and_align()` to explicitly drop any timestamps where there is either a NaN in the observation or forecast time-series.

  - [x] Closes #285 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This partially solves #285 by explicitly dropping timestamps where there is a NaN in either the observations or forecasts.