### PR TITLE
metrics: add summary statistics

### DIFF
--- a/solarforecastarbiter/metrics/summary.py
+++ b/solarforecastarbiter/metrics/summary.py
@@ -3,43 +3,14 @@
 import numpy as np
 
 
-def mean(ts):
-    """Mean value.
+# Add new metrics to this map to map shorthand to function
+_MAP = {
+    'mean': (np.mean, 'Max'),
+    'min': (np.min, 'Min'),
+    'max': (np.max, 'Max'),
+    'std': (np.std, 'Std'),
+    'median': (np.median, 'Median'),
+    'var': (np.var, 'Variance'),
+}
 
-    Parameters
-    ----------
-    ts : array_like
-        Time-series of observations or forecasts.
-
-    Returns
-    -------
-    avg : float
-        Mean value.
-
-    """
-
-    return np.nanmean(ts)
-
-
-def std(ts):
-    return np.nanstd(ts)
-
-
-def min(ts):
-    return np.nanmin(ts)
-
-
-def max(ts):
-    return np.nanmax(ts)
-
-
-def median(ts):
-    return np.nanmedian(ts)
-
-
-def var(ts):
-    return np.nanvar(ts)
-
-
-def quantile(ts, q):
-    return np.nanquantile(ts, q)
+__all__ = [m[0].__name__ for m in _MAP.values()]

--- a/solarforecastarbiter/metrics/summary.py
+++ b/solarforecastarbiter/metrics/summary.py
@@ -3,11 +3,6 @@
 import numpy as np
 
 
-# - var: np.nanvar()
-# - percentile: np.nanpercentile()  <== unnecessary with quantile?
-# - quantile: np.nanquantile()      <== unnecessary with percentile?
-
-
 def mean(ts):
     """Mean value.
 

--- a/solarforecastarbiter/metrics/summary.py
+++ b/solarforecastarbiter/metrics/summary.py
@@ -5,7 +5,7 @@ import numpy as np
 
 # Add new metrics to this map to map shorthand to function
 _MAP = {
-    'mean': (np.mean, 'Max'),
+    'mean': (np.mean, 'Mean'),
     'min': (np.min, 'Min'),
     'max': (np.max, 'Max'),
     'std': (np.std, 'Std'),

--- a/solarforecastarbiter/metrics/summary.py
+++ b/solarforecastarbiter/metrics/summary.py
@@ -1,0 +1,50 @@
+"""Summary statistics (observations and forecasts)."""
+
+import numpy as np
+
+
+# - var: np.nanvar()
+# - percentile: np.nanpercentile()  <== unnecessary with quantile?
+# - quantile: np.nanquantile()      <== unnecessary with percentile?
+
+
+def mean(ts):
+    """Mean value.
+
+    Parameters
+    ----------
+    ts : array_like
+        Time-series of observations or forecasts.
+
+    Returns
+    -------
+    avg : float
+        Mean value.
+
+    """
+
+    return np.nanmean(ts)
+
+
+def std(ts):
+    return np.nanstd(ts)
+
+
+def min(ts):
+    return np.nanmin(ts)
+
+
+def max(ts):
+    return np.nanmax(ts)
+
+
+def median(ts):
+    return np.nanmedian(ts)
+
+
+def var(ts):
+    return np.nanvar(ts)
+
+
+def quantile(ts, q):
+    return np.nanquantile(ts, q)

--- a/solarforecastarbiter/metrics/tests/test_summary.py
+++ b/solarforecastarbiter/metrics/tests/test_summary.py
@@ -3,9 +3,12 @@ import numpy as np
 from solarforecastarbiter.metrics import summary
 
 
-@pytest.mark.parametrize("ts,value", [
-    ([1, 2, 3], 2),
-    ([2, np.nan, 4], 3),
+@pytest.mark.parametrize("ts", [
+    [1, 2, 3],
+    np.random.rand(10),
+    np.random.rand(1000),
 ])
-def test_mean(ts, value):
-    assert summary.mean(ts) == value
+def test_scalar(ts):
+    for metric in summary._MAP:
+        f = summary._MAP[metric][0]
+        assert np.isscalar(f(ts))

--- a/solarforecastarbiter/metrics/tests/test_summary.py
+++ b/solarforecastarbiter/metrics/tests/test_summary.py
@@ -1,0 +1,11 @@
+import pytest
+import numpy as np
+from solarforecastarbiter.metrics import summary
+
+
+@pytest.mark.parametrize("ts,value", [
+    ([1, 2, 3], 2),
+    ([2, np.nan, 4], 3),
+])
+def test_mean(ts, value):
+    assert summary.mean(ts) == value


### PR DESCRIPTION
- [x] Closes #231 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This PR adds `solarforecastarbiter.metrics.summary`, which contains functions for computing summary statistics of observations/forecasts (e.g. min, max, mean and std). These summary statistics will eventually be incorporated into the report interface (which will be addressed in subsequent PRs).