### PR TITLE
metrics: preprocessing: handle empty obs Series

### DIFF
--- a/docs/source/whatsnew/1.0.0b4.rst
+++ b/docs/source/whatsnew/1.0.0b4.rst
@@ -1,0 +1,29 @@
+.. _whatsnew_100b4:
+
+1.0.0b4 (???)
+-------------
+
+This is the fourth 1.0 beta release.
+
+
+API Changes
+~~~~~~~~~~~
+
+Enhancements
+~~~~~~~~~~~~
+
+Bug fixes
+~~~~~~~~~
+* Fix handling of empty observation timeseries in metrics preprocessing. (:issue:`295`) (:pull:`296`)
+
+Contributors
+~~~~~~~~~~~~
+
+* Will Holmgren (:ghuser:`wholmgren`)
+* Leland Boeman (:ghuser:`lboeman`)
+* Cliff Hansen (:ghuser:`cwhanse`)
+* Tony Lorenzo (:ghuser:`alorenzo175`)
+* Justin Sharp (:ghuser:`MrWindAndSolar`)
+* Aidan Tuohy
+* Adam Wigington (:ghuser:`awig`)
+* David Larson (:ghuser:`dplarson`)

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -83,11 +83,9 @@ def resample_and_align(fx_obs, data, tz):
     fx = fx_obs.forecast
     obs = fx_obs.data_object
 
-    # Resample observation, checking for invalid interval_length pairs or empty
-    # Series (fx or obs)
-    if fx.interval_length > obs.interval_length and not (
-        data[obs].empty or data[fx].empty
-    ):
+    # Resample observation, checking for invalid interval_length and that the
+    # Series has data:
+    if fx.interval_length > obs.interval_length and not data[obs].empty:
         closed = datamodel.CLOSED_MAPPING[fx.interval_label]
         obs_resampled = data[obs].resample(
             fx.interval_length,

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -83,8 +83,11 @@ def resample_and_align(fx_obs, data, tz):
     fx = fx_obs.forecast
     obs = fx_obs.data_object
 
-    # Resample observation
-    if fx.interval_length > obs.interval_length:
+    # Resample observation, checking for invalid interval_length pairs or empty
+    # Series (fx or obs)
+    if fx.interval_length > obs.interval_length and not (
+        data[obs].empty or data[fx].empty
+    ):
         closed = datamodel.CLOSED_MAPPING[fx.interval_label]
         obs_resampled = data[obs].resample(
             fx.interval_length,

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -27,6 +27,13 @@ THREE_HOURS_EMPTY = pd.DatetimeIndex([], name="timestamp", freq="60min",
 
 THREE_HOUR_EMPTY_SERIES = pd.Series([], index=THREE_HOURS_EMPTY, name="value")
 
+EMPTY_OBJ_SERIES = pd.Series(
+    [],
+    dtype=object,
+    name="value",
+    index=pd.DatetimeIndex([], freq="10min", tz="MST", name="timestamp")
+)
+
 THIRTEEN_10MIN = pd.date_range(start='2019-03-31T12:00:00',
                                periods=13,
                                freq='10min',
@@ -53,6 +60,7 @@ OK = int(0b10)  # OK version 0 (2)
     (THREE_HOUR_NAN_SERIES, THREE_HOUR_NAN_SERIES, THREE_HOURS_NAN),
     (THREE_HOUR_SERIES, THREE_HOUR_EMPTY_SERIES, THREE_HOURS_EMPTY),
     (THREE_HOUR_EMPTY_SERIES, THREE_HOUR_SERIES, THREE_HOURS_EMPTY),
+    (THREE_HOUR_SERIES, EMPTY_OBJ_SERIES, THREE_HOURS_EMPTY),
 ])
 def test_resample_and_align(site_metadata, interval_label,
                             fx_series, obs_series, expected_dt):

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -52,6 +52,7 @@ OK = int(0b10)  # OK version 0 (2)
     (THREE_HOUR_NAN_SERIES, THREE_HOUR_SERIES, THREE_HOURS_NAN),
     (THREE_HOUR_NAN_SERIES, THREE_HOUR_NAN_SERIES, THREE_HOURS_NAN),
     (THREE_HOUR_SERIES, THREE_HOUR_EMPTY_SERIES, THREE_HOURS_EMPTY),
+    (THREE_HOUR_EMPTY_SERIES, THREE_HOUR_SERIES, THREE_HOURS_EMPTY),
 ])
 def test_resample_and_align(site_metadata, interval_label,
                             fx_series, obs_series, expected_dt):

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -22,6 +22,11 @@ THREE_HOUR_NAN_SERIES = pd.Series([1.0, np.nan, 4.0], index=THREE_HOURS,
 
 THREE_HOURS_NAN = THREE_HOURS[[True, False, True]]
 
+THREE_HOURS_EMPTY = pd.DatetimeIndex([], name="timestamp", freq="60min",
+                                     tz="MST")
+
+THREE_HOUR_EMPTY_SERIES = pd.Series([], index=THREE_HOURS_EMPTY, name="value")
+
 THIRTEEN_10MIN = pd.date_range(start='2019-03-31T12:00:00',
                                periods=13,
                                freq='10min',
@@ -46,6 +51,7 @@ OK = int(0b10)  # OK version 0 (2)
     (THREE_HOUR_SERIES, THREE_HOUR_NAN_SERIES, THREE_HOURS_NAN),
     (THREE_HOUR_NAN_SERIES, THREE_HOUR_SERIES, THREE_HOURS_NAN),
     (THREE_HOUR_NAN_SERIES, THREE_HOUR_NAN_SERIES, THREE_HOURS_NAN),
+    (THREE_HOUR_SERIES, THREE_HOUR_EMPTY_SERIES, THREE_HOURS_EMPTY),
 ])
 def test_resample_and_align(site_metadata, interval_label,
                             fx_series, obs_series, expected_dt):


### PR DESCRIPTION
  - [x] Closes #295 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.