### PR TITLE
metrics: calculator: handle ending interval label

### DIFF
--- a/docs/source/whatsnew/1.0.0b4.rst
+++ b/docs/source/whatsnew/1.0.0b4.rst
@@ -15,6 +15,8 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 * Fix handling of empty observation timeseries in metrics preprocessing. (:issue:`295`) (:pull:`296`)
+* Fix handling of `interval_label == ending` in the `groupby` categories in
+  `metrics.calculator`. (:issue:`234`) (:pull:`297`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -130,6 +130,8 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
     fx = processed_fx_obs.forecast_values
     obs = processed_fx_obs.observation_values
 
+    closed = datamodel.CLOSED_MAPPING[processed_fx_obs.interval_label]
+
     # Check reference forecast is from processed pair, if needed
     ref_fx = None
     if any(m in deterministic._REQ_REF_FX for m in metrics):
@@ -190,9 +192,6 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
 
                     # Change category labels for hour of day depending on
                     # interval_label
-                    closed = datamodel.CLOSED_MAPPING[
-                        processed_fx_obs.interval_label
-                    ]
                     if category == "hour" and closed == "ending":
                         cat += 1   # 0-23 becomes 1-24
 

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -10,7 +10,6 @@ Todo
 * Support event metrics and forecasts with new functions
 """
 import calendar
-import copy
 
 import pandas as pd
 

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -159,8 +159,7 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
 
     # Force `groupby` to be consistent with `interval_label`, i.e., if
     # `interval_label == ending`, then the last interval should be in the bin
-    closed = datamodel.CLOSED_MAPPING[processed_fx_obs.interval_label]
-    if closed == "ending":
+    if processed_fx_obs.interval_label == "ending":
         df.index -= pd.Timedelta("1ns")
 
     # Calculate metrics

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -140,6 +140,9 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
         ref_fx = ref_fx_obs.forecast_values
         if ref_fx.empty:
             raise RuntimeError("No reference forecast timeseries data")
+        elif ref_fx_obs.interval_label != processed_fx_obs.interval_label:
+            raise ValueError("Mismatched `interval_label` between "
+                               "observation and reference forecast.")
 
     # No data or metrics
     if fx.empty:
@@ -148,6 +151,7 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
         raise RuntimeError("No Observation timeseries data.")
     elif len(metrics) == 0:
         raise RuntimeError("No metrics specified.")
+
 
     # Dataframe for grouping
     df = pd.concat({'forecast': fx,

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -142,7 +142,7 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
             raise RuntimeError("No reference forecast timeseries data")
         elif ref_fx_obs.interval_label != processed_fx_obs.interval_label:
             raise ValueError("Mismatched `interval_label` between "
-                               "observation and reference forecast.")
+                             "observation and reference forecast.")
 
     # No data or metrics
     if fx.empty:
@@ -151,7 +151,6 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
         raise RuntimeError("No Observation timeseries data.")
     elif len(metrics) == 0:
         raise RuntimeError("No metrics specified.")
-
 
     # Dataframe for grouping
     df = pd.concat({'forecast': fx,

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -150,19 +150,16 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
     elif len(metrics) == 0:
         raise RuntimeError("No metrics specified.")
 
-    # Force `groupby` to be consistent with `interval_label`, i.e., if
-    # `interval_label == ending`, then the last interval should be in the bin
-    closed = datamodel.CLOSED_MAPPING[processed_fx_obs.interval_label]
-    if closed == "ending":
-        obs = copy.deepcopy(obs)
-        fx = copy.deepcopy(fx)
-        obs.index -= pd.Timedelta("1ns")
-        fx.index -= pd.Timedelta("1ns")
-
     # Dataframe for grouping
     df = pd.concat({'forecast': fx,
                     'observation': obs,
                     'reference': ref_fx}, axis=1)
+
+    # Force `groupby` to be consistent with `interval_label`, i.e., if
+    # `interval_label == ending`, then the last interval should be in the bin
+    closed = datamodel.CLOSED_MAPPING[processed_fx_obs.interval_label]
+    if closed == "ending":
+        df.index -= pd.Timedelta("1ns")
 
     # Calculate metrics
     for category in set(categories):

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -189,10 +189,9 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
                         cat = calendar.month_abbr[cat]
                     elif category == 'weekday':
                         cat = calendar.day_abbr[cat]
-
                     # Change category labels for hour of day depending on
                     # interval_label
-                    if category == "hour" and closed == "ending":
+                    elif category == "hour" and closed == "ending":
                         cat += 1   # 0-23 becomes 1-24
 
                     metric_values.append(res)

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -10,6 +10,7 @@ Todo
 * Support event metrics and forecasts with new functions
 """
 import calendar
+import copy
 
 import pandas as pd
 
@@ -153,6 +154,8 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
     # `interval_label == ending`, then the last interval should be in the bin
     closed = datamodel.CLOSED_MAPPING[processed_fx_obs.interval_label]
     if closed == "ending":
+        obs = copy.deepcopy(obs)
+        fx = copy.deepcopy(fx)
         obs.index -= pd.Timedelta("1ns")
         fx.index -= pd.Timedelta("1ns")
 

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -188,6 +188,14 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
                     elif category == 'weekday':
                         cat = calendar.day_abbr[cat]
 
+                    # Change category labels for hour of day depending on
+                    # interval_label
+                    closed = datamodel.CLOSED_MAPPING[
+                        processed_fx_obs.interval_label
+                    ]
+                    if category == "hour" and closed == "ending":
+                        cat += 1   # 0-23 becomes 1-24
+
                     metric_values.append(res)
                     cat_values.append(cat)
 

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -369,6 +369,14 @@ def test_interval_label(
     proc_ref_obs = create_processed_fxobs(ref_obs, ref, obs)
 
     if any(m in deterministic._REQ_REF_FX for m in metrics):
+        calculator.calculate_metrics(
+            [proc_fx_obs],
+            categories,
+            metrics,
+            ref_pair=None,
+            normalizer=1.0
+        )
+
         with pytest.raises(ValueError):
             calculator.calculate_metrics(
                 [proc_fx_obs],
@@ -378,11 +386,3 @@ def test_interval_label(
                 normalizer=1.0
             )
         return
-
-        calculator.calculate_metrics(
-            [proc_fx_obs],
-            categories,
-            metrics,
-            ref_pair=None,
-            normalizer=1.0
-        )

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -299,19 +299,16 @@ def test_apply_deterministic_bad_metric_func():
                                                     pd.Series())
 
 
-@pytest.mark.parametrize('interval_label_fx, interval_label_ref', [
-    ("beginning", "beginning"),
-    ("ending", "ending"),
-    pytest.param("beginning", "ending",
-                 marks=pytest.mark.xfail(raises=ValueError, strict=True)),
-    pytest.param("ending", "beginning",
-                 marks=pytest.mark.xfail(raises=ValueError, strict=True)),
+@pytest.mark.parametrize('label_fx,label_ref', [
+    ("beginning", "ending"),
+    ("ending", "beginning"),
 ])
-def test_interval_label(site_metadata, interval_label_fx, interval_label_ref,
-                        create_processed_fxobs, many_forecast_observation):
+def test_interval_label_mistmatch(site_metadata, label_fx, label_ref,
+                                  create_processed_fxobs,
+                                  many_forecast_observation):
 
     categories = LIST_OF_CATEGORIES
-    metrics = DETERMINISTIC_METRICS
+    metrics = deterministic._REQ_REF_FX
 
     proc_fx_obs = []
     for fx_obs in many_forecast_observation:
@@ -320,7 +317,7 @@ def test_interval_label(site_metadata, interval_label_fx, interval_label_ref,
                 fx_obs,
                 np.random.randn(10) + 10,
                 np.random.randn(10) + 10,
-                interval_label=interval_label_fx,
+                interval_label=label_fx,
             )
         )
 
@@ -328,16 +325,14 @@ def test_interval_label(site_metadata, interval_label_fx, interval_label_ref,
         many_forecast_observation[0],
         np.random.randn(10) + 10,
         np.random.randn(10) + 10,
-        interval_label=interval_label_ref,
+        interval_label=label_ref,
     )
 
-    all_results = calculator.calculate_metrics(
-        proc_fx_obs,
-        categories,
-        metrics,
-        ref_pair=proc_ref_obs,
-        normalizer=1.0
-    )
-
-    assert isinstance(all_results, list)
-    assert len(all_results) == len(proc_fx_obs)
+    with pytest.raises(ValueError):
+        calculator.calculate_metrics(
+            proc_fx_obs,
+            categories,
+            metrics,
+            ref_pair=proc_ref_obs,
+            normalizer=1.0
+        )

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -335,7 +335,7 @@ def test_interval_label(site_metadata, interval_label_fx, interval_label_ref,
         proc_fx_obs,
         categories,
         metrics,
-        ref_fx_obs=proc_ref_obs,
+        ref_pair=proc_ref_obs,
         normalizer=1.0
     )
 

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -336,14 +336,12 @@ def test_interval_label(site_metadata, label_fx, label_ref,
         interval_label=label_ref,
     )
 
-    results = calculator.calculate_deterministic_metrics(
-        proc_fx_obs[-1],
+    all_results = calculator.calculate_metrics(
+        proc_fx_obs,
         categories,
         metrics,
-        ref_fx_obs=proc_ref_obs,
-        normalizer=1.0
+        ref_pair=proc_ref_obs,
     )
 
-    assert isinstance(results, dict)
-    for cat in categories:
-        assert len(results[cat]) == len(metrics)
+    assert isinstance(all_results, list)
+    assert len(all_results) == len(proc_fx_obs)

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -3,7 +3,6 @@ import pandas as pd
 import pytest
 import itertools
 import calendar
-import datetime
 
 from solarforecastarbiter import datamodel
 from solarforecastarbiter.metrics import (calculator, deterministic)

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -331,14 +331,13 @@ def test_interval_label(site_metadata, interval_label_fx, interval_label_ref,
         interval_label=interval_label_ref,
     )
 
-    results = calculator.calculate_deterministic_metrics(
-        proc_fx_obs[-1],
+    all_results = calculator.calculate_metrics(
+        proc_fx_obs,
         categories,
         metrics,
         ref_fx_obs=proc_ref_obs,
         normalizer=1.0
     )
 
-    assert isinstance(results, dict)
-    for cat in categories:
-        assert len(results[cat]) == len(metrics)
+    assert isinstance(all_results, list)
+    assert len(all_results) == len(proc_fx_obs)

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 import itertools
 import calendar
+import datetime
 
 from solarforecastarbiter import datamodel
 from solarforecastarbiter.metrics import (calculator, deterministic)
@@ -303,6 +304,107 @@ def test_apply_deterministic_bad_metric_func():
                                                     pd.Series())
 
 
+@pytest.mark.parametrize('index,interval_label,category,result', [
+    # category: hour
+    (
+        pd.DatetimeIndex(
+            ['20191210T1300Z', '20191210T1330Z', '20191210T1400Z']
+        ),
+        'ending',
+        'hour',
+        pd.Series(data=[-1.0, 0.5], index=[12, 13]),
+    ),
+    (
+        pd.DatetimeIndex(
+            ['20191210T1300Z', '20191210T1330Z', '20191210T1400Z']
+        ),
+        'beginning',
+        'hour',
+        pd.Series(data=[-0.5, 1.0], index=[13, 14]),
+    ),
+
+    # category: month
+    (
+        pd.DatetimeIndex(
+            ['20191130T2330Z', '20191201T0000Z', '20191201T0030Z']
+        ),
+        'ending',
+        'month',
+        pd.Series(data=[-0.5, 1.0], index=['Nov', 'Dec']),
+    ),
+    (
+        pd.DatetimeIndex(
+            ['20191130T2330Z', '20191201T0000Z', '20191201T0030Z']
+        ),
+        'beginning',
+        'month',
+        pd.Series(data=[-1.0, 0.5], index=['Nov', 'Dec']),
+    ),
+
+    # category: year
+    (
+        pd.DatetimeIndex(
+            ['20191231T2330Z', '20200101T0000Z', '20200101T0030Z']
+        ),
+        'ending',
+        'year',
+        pd.Series(data=[-0.5, 1.0], index=[2019, 2020]),
+    ),
+    (
+        pd.DatetimeIndex(
+            ['20191231T2330Z', '20200101T0000Z', '20200101T0030Z']
+        ),
+        'beginning',
+        'year',
+        pd.Series(data=[-1.0, 0.5], index=[2019, 2020]),
+    ),
+])
+def test_interval_label(index, interval_label, category, result, create_processed_fxobs):
+
+    # Custom metadata to keep all timestamps in UTC for tests
+    site = datamodel.Site(
+        name='Albuquerque Baseline',
+        latitude=35.05,
+        longitude=-106.54,
+        elevation=1657.0,
+        timezone='UTC',
+        provider='Sandia'
+    )
+
+    fx_series = pd.Series([0, 1, 2], index=index)
+    obs_series = pd.Series([1, 1, 1], index=index)
+    fxobs = datamodel.ForecastObservation(
+        observation=datamodel.Observation(
+            site=site, name='dummy obs', variable='ghi',
+            interval_value_type='instantaneous', uncertainty=1,
+            interval_length=pd.Timedelta(obs_series.index.freq),
+            interval_label=interval_label
+        ),
+        forecast=datamodel.Forecast(
+            site=site, name='dummy fx', variable='ghi',
+            interval_value_type='instantaneous',
+            interval_length=pd.Timedelta(fx_series.index.freq),
+            interval_label=interval_label,
+            issue_time_of_day=datetime.time(hour=5),
+            lead_time_to_start=pd.Timedelta('1h'),
+            run_length=pd.Timedelta('1h')
+        )
+    )
+
+    proc_fx_obs = datamodel.ProcessedForecastObservation(
+        fxobs,
+        fxobs.forecast.interval_value_type,
+        fxobs.forecast.interval_length,
+        fxobs.forecast.interval_label,
+        forecast_values=fx_series,
+        observation_values=obs_series,
+    )
+
+    res = calculator.calculate_deterministic_metrics(proc_fx_obs, [category],
+                                                     ['mbe'])
+    pd.testing.assert_series_equal(res[category]['mbe'], result)
+
+
 @pytest.mark.parametrize('label_fx,label_ref', [
     ("beginning", "beginning"),
     ("ending", "ending"),
@@ -311,8 +413,9 @@ def test_apply_deterministic_bad_metric_func():
     pytest.param("ending", "beginning",
                  marks=pytest.mark.xfail(raises=ValueError, strict=True)),
 ])
-def test_interval_label(site_metadata, label_fx, label_ref,
-                        create_processed_fxobs, many_forecast_observation):
+def test_interval_label_match(site_metadata, label_fx, label_ref,
+                              create_processed_fxobs,
+                              many_forecast_observation):
 
     categories = LIST_OF_CATEGORIES
     metrics = list(deterministic._MAP.keys())

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -385,4 +385,3 @@ def test_interval_label(
                 ref_pair=proc_ref_obs,
                 normalizer=1.0
             )
-        return

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -331,13 +331,14 @@ def test_interval_label(site_metadata, interval_label_fx, interval_label_ref,
         interval_label=interval_label_ref,
     )
 
-    all_result = calculator.calculate_metrics(
-        proc_fx_obs,
+    results = calculator.calculate_deterministic_metrics(
+        proc_fx_obs[-1],
         categories,
         metrics,
-        ref_pair=proc_ref_obs,
+        ref_fx_obs=proc_ref_obs,
         normalizer=1.0
     )
 
-    assert isinstance(all_result, list)
-    assert len(all_result) == len(proc_fx_obs)
+    assert isinstance(results, dict)
+    for cat in categories:
+        assert len(results[cat]) == len(metrics)

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -367,21 +367,11 @@ def test_interval_label(
     proc_fx_obs = create_processed_fxobs(fx_obs, fx, obs)
     proc_ref_obs = create_processed_fxobs(ref_obs, ref, obs)
 
-    if any(m in deterministic._REQ_REF_FX for m in metrics):
-        with pytest.raises(ValueError):
-            calculator.calculate_metrics(
-                [proc_fx_obs],
-                categories,
-                metrics,
-                ref_pair=proc_ref_obs,
-                normalizer=1.0
-            )
-        return
-
-    calculator.calculate_metrics(
-        [proc_fx_obs],
-        categories,
-        metrics,
-        ref_pair=None,
-        normalizer=1.0
-    )
+    with pytest.raises(ValueError):
+        calculator.calculate_metrics(
+            [proc_fx_obs],
+            categories,
+            metrics,
+            ref_pair=proc_ref_obs,
+            normalizer=1.0
+        )

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 import itertools
 import calendar
+import datetime
 
 from solarforecastarbiter import datamodel
 from solarforecastarbiter.metrics import (calculator, deterministic)
@@ -14,13 +15,12 @@ LIST_OF_CATEGORIES = list(datamodel.ALLOWED_CATEGORIES.keys())
 
 @pytest.fixture()
 def create_processed_fxobs(create_datetime_index):
-    def _create_processed_fxobs(fxobs, fx_values, obs_values,
-                                interval_label="beginning"):
+    def _create_processed_fxobs(fxobs, fx_values, obs_values):
         return datamodel.ProcessedForecastObservation(
             fxobs,
             fxobs.forecast.interval_value_type,
             fxobs.forecast.interval_length,
-            interval_label,
+            fxobs.forecast.interval_label,
             forecast_values=pd.Series(
                 fx_values, index=create_datetime_index(len(fx_values))),
             observation_values=pd.Series(
@@ -300,39 +300,84 @@ def test_apply_deterministic_bad_metric_func():
 
 
 @pytest.mark.parametrize('label_fx,label_ref', [
-    ("beginning", "ending"),
-    ("ending", "beginning"),
+    ("beginning", "beginning"),
+    ("ending", "ending"),
+    pytest.param("beginning", "ending",
+                 marks=pytest.mark.xfail(raises=ValueError, strict=True)),
+    pytest.param("ending", "beginning",
+                 marks=pytest.mark.xfail(raises=ValueError, strict=True)),
 ])
-def test_interval_label_mistmatch(site_metadata, label_fx, label_ref,
-                                  create_processed_fxobs,
-                                  many_forecast_observation):
+def test_interval_label(site_metadata, label_fx, label_ref,
+                        create_processed_fxobs):
 
     categories = LIST_OF_CATEGORIES
-    metrics = deterministic._REQ_REF_FX
+    metrics = list(deterministic._MAP.keys())
 
-    proc_fx_obs = []
-    for fx_obs in many_forecast_observation:
-        proc_fx_obs.append(
-            create_processed_fxobs(
-                fx_obs,
-                np.random.randn(10) + 10,
-                np.random.randn(10) + 10,
-                interval_label=label_fx,
-            )
+    ts = pd.date_range(
+        start="2019-07-01 00:00:00",
+        end="2019-07-08 00:00:00",
+        freq="5min",
+        tz="MST",
+        name="timestamp"
+    )
+    fx = pd.Series(data=np.random.rand(len(ts)), index=ts, name="value")
+    obs = pd.Series(data=np.random.rand(len(ts)), index=ts, name="value")
+    ref = pd.Series(data=np.random.rand(len(ts)), index=ts, name="value")
+
+    fx_obs = datamodel.ForecastObservation(
+        forecast=datamodel.Forecast(
+            site=site_metadata,
+            name="dummy fx",
+            variable="ghi",
+            interval_value_type="instantaneous",
+            interval_length=pd.Timedelta(fx.index.freq),
+            interval_label=label_fx,
+            issue_time_of_day=datetime.time(hour=5),
+            lead_time_to_start=pd.Timedelta('1h'),
+            run_length=pd.Timedelta('12h')
+        ),
+        observation=datamodel.Observation(
+            site=site_metadata,
+            name="dummy obs",
+            variable="ghi",
+            interval_value_type="instantaneous",
+            interval_length=pd.Timedelta(obs.index.freq),
+            interval_label=label_fx,
+            uncertainty=1,
         )
-
-    proc_ref_obs = create_processed_fxobs(
-        many_forecast_observation[0],
-        np.random.randn(10) + 10,
-        np.random.randn(10) + 10,
-        interval_label=label_ref,
     )
 
-    with pytest.raises(ValueError):
-        calculator.calculate_metrics(
-            proc_fx_obs,
-            categories,
-            metrics,
-            ref_pair=proc_ref_obs,
-            normalizer=1.0
+    ref_obs = datamodel.ForecastObservation(
+        forecast=datamodel.Forecast(
+            site=site_metadata,
+            name="dummy fx",
+            variable="ghi",
+            interval_value_type="instantaneous",
+            interval_length=pd.Timedelta(fx.index.freq),
+            interval_label=label_ref,
+            issue_time_of_day=datetime.time(hour=5),
+            lead_time_to_start=pd.Timedelta('1h'),
+            run_length=pd.Timedelta('12h')
+        ),
+        observation=datamodel.Observation(
+            site=site_metadata,
+            name="dummy obs",
+            variable="ghi",
+            interval_value_type="instantaneous",
+            interval_length=pd.Timedelta(obs.index.freq),
+            interval_label=label_ref,
+            uncertainty=1,
         )
+    )
+
+    proc_fx_obs = create_processed_fxobs(fx_obs, fx, obs)
+    proc_ref_obs = create_processed_fxobs(ref_obs, ref, obs)
+
+    results = calculator.calculate_deterministic_metrics(
+        proc_fx_obs,
+        categories,
+        metrics,
+        ref_fx_obs=proc_ref_obs,
+        normalizer=1.0
+    )
+    assert isinstance(results, dict)

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -380,9 +380,9 @@ def test_interval_label(
         return
 
         calculator.calculate_metrics(
-                [proc_fx_obs],
-                categories,
-                metrics,
-                ref_pair=None,
-                normalizer=1.0
-            )
+            [proc_fx_obs],
+            categories,
+            metrics,
+            ref_pair=None,
+            normalizer=1.0
+        )

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -359,7 +359,8 @@ def test_apply_deterministic_bad_metric_func():
         pd.Series(data=[-1.0, 0.5], index=[2019, 2020]),
     ),
 ])
-def test_interval_label(index, interval_label, category, result, create_processed_fxobs):
+def test_interval_label(index, interval_label, category, result,
+                        create_processed_fxobs):
 
     # Custom metadata to keep all timestamps in UTC for tests
     site = datamodel.Site(

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -303,7 +303,9 @@ def test_apply_deterministic_bad_metric_func():
     ([], []),
     (LIST_OF_CATEGORIES, DETERMINISTIC_METRICS)
 ])
-def test_mismatched_interval_label(site_metadata, categories, metrics, create_processed_fxobs):
+def test_mismatched_interval_label(
+    site_metadata, categories, metrics, create_processed_fxobs
+):
     ts = pd.date_range(
         start="2019-07-01 00:00:00",
         end="2019-07-08 00:00:00",

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -303,7 +303,7 @@ def test_apply_deterministic_bad_metric_func():
     ([], []),
     (LIST_OF_CATEGORIES, DETERMINISTIC_METRICS)
 ])
-def test_mismatched_interval_label(
+def test_interval_label(
     site_metadata, categories, metrics, create_processed_fxobs
 ):
     ts = pd.date_range(
@@ -325,7 +325,7 @@ def test_mismatched_interval_label(
             variable="ghi",
             interval_value_type="instantaneous",
             interval_length=pd.Timedelta(fx.index.freq),
-            interval_label="beginning",
+            interval_label="ending",
             issue_time_of_day=datetime.time(hour=5),
             lead_time_to_start=pd.Timedelta('1h'),
             run_length=pd.Timedelta('12h')
@@ -336,7 +336,7 @@ def test_mismatched_interval_label(
             variable="ghi",
             interval_value_type="instantaneous",
             interval_length=pd.Timedelta(obs.index.freq),
-            interval_label="beginning",
+            interval_label="ending",
             uncertainty=1,
         )
     )
@@ -349,7 +349,7 @@ def test_mismatched_interval_label(
             variable="ghi",
             interval_value_type="instantaneous",
             interval_length=pd.Timedelta(fx.index.freq),
-            interval_label="ending",
+            interval_label="beginning",
             issue_time_of_day=datetime.time(hour=5),
             lead_time_to_start=pd.Timedelta('1h'),
             run_length=pd.Timedelta('12h')
@@ -360,7 +360,7 @@ def test_mismatched_interval_label(
             variable="ghi",
             interval_value_type="instantaneous",
             interval_length=pd.Timedelta(obs.index.freq),
-            interval_label="ending",
+            interval_label="beginning",
             uncertainty=1,
         )
     )
@@ -378,3 +378,11 @@ def test_mismatched_interval_label(
                 normalizer=1.0
             )
         return
+
+        calculator.calculate_metrics(
+                [proc_fx_obs],
+                categories,
+                metrics,
+                ref_pair=None,
+                normalizer=1.0
+            )

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -15,12 +15,13 @@ LIST_OF_CATEGORIES = list(datamodel.ALLOWED_CATEGORIES.keys())
 
 @pytest.fixture()
 def create_processed_fxobs(create_datetime_index):
-    def _create_processed_fxobs(fxobs, fx_values, obs_values):
+    def _create_processed_fxobs(fxobs, fx_values, obs_values,
+                                interval_label="beginning"):
         return datamodel.ProcessedForecastObservation(
             fxobs,
             fxobs.forecast.interval_value_type,
             fxobs.forecast.interval_length,
-            fxobs.forecast.interval_label,
+            interval_label,
             forecast_values=pd.Series(
                 fx_values, index=create_datetime_index(len(fx_values))),
             observation_values=pd.Series(
@@ -299,93 +300,43 @@ def test_apply_deterministic_bad_metric_func():
                                                     pd.Series())
 
 
-@pytest.mark.parametrize('categories,metrics,interval_label', [
-    (LIST_OF_CATEGORIES, DETERMINISTIC_METRICS, "beginning"),
-    (LIST_OF_CATEGORIES, DETERMINISTIC_METRICS, "ending")
+@pytest.mark.parametrize('interval_label_fx, interval_label_ref', [
+    ("beginning", "beginning"),
+    ("ending", "ending"),
+    pytest.param("beginning", "ending", marks=pytest.mark.xfail),
+    pytest.param("ending", "beginning", marks=pytest.mark.xfail),
 ])
-def test_interval_label(
-    site_metadata, categories, metrics, interval_label, create_processed_fxobs
-):
+def test_interval_label(site_metadata, interval_label_fx, interval_label_ref,
+                        create_processed_fxobs, many_forecast_observation):
 
-    ts = pd.date_range(
-        start="2019-07-01 00:00:00",
-        end="2019-07-08 00:00:00",
-        freq="1h",
-        tz="MST",
-        name="timestamp"
-    )
-    fx = pd.Series(data=np.random.rand(len(ts)), index=ts, name="value")
-    obs = pd.Series(data=np.random.rand(len(ts)), index=ts, name="value")
-    ref = pd.Series(data=np.random.rand(len(ts)), index=ts, name="value")
+    categories = LIST_OF_CATEGORIES
+    metrics = DETERMINISTIC_METRICS
 
-    # `interval_label == beginning`
-    fx_obs = datamodel.ForecastObservation(
-        forecast=datamodel.Forecast(
-            site=site_metadata,
-            name="dummy fx",
-            variable="ghi",
-            interval_value_type="instantaneous",
-            interval_length=pd.Timedelta(fx.index.freq),
-            interval_label="ending",
-            issue_time_of_day=datetime.time(hour=5),
-            lead_time_to_start=pd.Timedelta('1h'),
-            run_length=pd.Timedelta('12h')
-        ),
-        observation=datamodel.Observation(
-            site=site_metadata,
-            name="dummy obs",
-            variable="ghi",
-            interval_value_type="instantaneous",
-            interval_length=pd.Timedelta(obs.index.freq),
-            interval_label="ending",
-            uncertainty=1,
-        )
-    )
-
-    # `interval_label == ending`
-    ref_obs = datamodel.ForecastObservation(
-        forecast=datamodel.Forecast(
-            site=site_metadata,
-            name="dummy fx",
-            variable="ghi",
-            interval_value_type="instantaneous",
-            interval_length=pd.Timedelta(fx.index.freq),
-            interval_label=interval_label,
-            issue_time_of_day=datetime.time(hour=5),
-            lead_time_to_start=pd.Timedelta('1h'),
-            run_length=pd.Timedelta('12h')
-        ),
-        observation=datamodel.Observation(
-            site=site_metadata,
-            name="dummy obs",
-            variable="ghi",
-            interval_value_type="instantaneous",
-            interval_length=pd.Timedelta(obs.index.freq),
-            interval_label=interval_label,
-            uncertainty=1,
-        )
-    )
-
-    proc_fx_obs = create_processed_fxobs(fx_obs, fx, obs)
-    proc_ref_obs = create_processed_fxobs(ref_obs, ref, obs)
-
-    if proc_ref_obs.interval_label != proc_ref_obs.interval_label:
-        with pytest.raises(ValueError):
-            calculator.calculate_metrics(
-                [proc_fx_obs],
-                categories,
-                metrics,
-                ref_pair=proc_ref_obs,
-                normalizer=1.0
+    proc_fx_obs = []
+    for fx_obs in many_forecast_observation:
+        proc_fx_obs.append(
+            create_processed_fxobs(
+                fx_obs,
+                np.random.randn(10) + 10,
+                np.random.randn(10) + 10,
+                interval_label=interval_label_fx,
             )
-        return
-    else:
-        all_result = calculator.calculate_metrics(
-            [proc_fx_obs],
-            categories,
-            metrics,
-            ref_pair=proc_ref_obs,
-            normalizer=1.0
         )
+
+    proc_ref_obs = create_processed_fxobs(
+        many_forecast_observation[0],
+        np.random.randn(10) + 10,
+        np.random.randn(10) + 10,
+        interval_label=interval_label_ref,
+    )
+
+    all_result = calculator.calculate_metrics(
+        proc_fx_obs,
+        categories,
+        metrics,
+        ref_pair=proc_ref_obs,
+        normalizer=1.0
+    )
 
     assert isinstance(all_result, list)
+    assert len(all_result) == len(proc_fx_obs)

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -300,7 +300,6 @@ def test_apply_deterministic_bad_metric_func():
 
 
 @pytest.mark.parametrize('categories,metrics', [
-    ([], []),
     (LIST_OF_CATEGORIES, DETERMINISTIC_METRICS)
 ])
 def test_interval_label(
@@ -369,14 +368,6 @@ def test_interval_label(
     proc_ref_obs = create_processed_fxobs(ref_obs, ref, obs)
 
     if any(m in deterministic._REQ_REF_FX for m in metrics):
-        calculator.calculate_metrics(
-            [proc_fx_obs],
-            categories,
-            metrics,
-            ref_pair=None,
-            normalizer=1.0
-        )
-
         with pytest.raises(ValueError):
             calculator.calculate_metrics(
                 [proc_fx_obs],
@@ -385,3 +376,12 @@ def test_interval_label(
                 ref_pair=proc_ref_obs,
                 normalizer=1.0
             )
+        return
+
+    calculator.calculate_metrics(
+        [proc_fx_obs],
+        categories,
+        metrics,
+        ref_pair=None,
+        normalizer=1.0
+    )

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -302,8 +302,10 @@ def test_apply_deterministic_bad_metric_func():
 @pytest.mark.parametrize('interval_label_fx, interval_label_ref', [
     ("beginning", "beginning"),
     ("ending", "ending"),
-    pytest.param("beginning", "ending", marks=pytest.mark.xfail),
-    pytest.param("ending", "beginning", marks=pytest.mark.xfail),
+    pytest.param("beginning", "ending",
+                 marks=pytest.mark.xfail(raises=ValueError)),
+    pytest.param("ending", "beginning",
+                 marks=pytest.mark.xfail(raises=ValueError)),
 ])
 def test_interval_label(site_metadata, interval_label_fx, interval_label_ref,
                         create_processed_fxobs, many_forecast_observation):

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -303,9 +303,9 @@ def test_apply_deterministic_bad_metric_func():
     ("beginning", "beginning"),
     ("ending", "ending"),
     pytest.param("beginning", "ending",
-                 marks=pytest.mark.xfail(raises=ValueError)),
+                 marks=pytest.mark.xfail(raises=ValueError, strict=True)),
     pytest.param("ending", "beginning",
-                 marks=pytest.mark.xfail(raises=ValueError)),
+                 marks=pytest.mark.xfail(raises=ValueError, strict=True)),
 ])
 def test_interval_label(site_metadata, interval_label_fx, interval_label_ref,
                         create_processed_fxobs, many_forecast_observation):

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -538,7 +538,14 @@ def bar_subdivisions(cds, category, metric):
             hover_kwargs = dict(tooltips=tooltips)
         else:
             # Numerical x-axis
-            fig.xaxis.ticker = cds.data[category]
+            if category == 'hour':
+                # center bars between xticks
+                fig.xaxis.ticker = cds.data[category] - 0.5
+                fig.xaxis.major_label_overrides = {
+                    i - 0.5: str(i) for i in cds.data[category]
+                }
+            else:
+                fig.xaxis.ticker = cds.data[category]
             tooltips = [
                 (human_category, f'@{{{category}}}'),
                 (f'{metric.upper()}', f'@{{{field}}}'),

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -10,7 +10,7 @@ from bokeh.models import (ColumnDataSource, HoverTool, Legend,
 from bokeh.models.ranges import Range1d
 from bokeh.models.widgets import DataTable, TableColumn, NumberFormatter
 from bokeh.plotting import figure
-from bokeh.transform import factor_cmap
+from bokeh.transform import factor_cmap, dodge
 from bokeh import palettes
 
 import pandas as pd
@@ -488,6 +488,8 @@ def bar_subdivisions(cds, category, metric):
         fig_kwargs['x_range'] = calendar.month_abbr[1:]
     elif category == 'weekday':
         fig_kwargs['x_range'] = calendar.day_abbr[0:]
+    elif category == 'hour':
+        fig_kwargs['x_range'] = [0, 23]
 
     # vertical axis limits
     y_min = min(np.nanmin(d) for k, d in cds.data.items() if k != category)
@@ -501,8 +503,14 @@ def bar_subdivisions(cds, category, metric):
         fig = figure(width=800, height=200, title=title,
                      **fig_kwargs)
 
-        fig.vbar(x=category, top=field, width=width, source=cds,
-                 line_color='white', fill_color=next(palette))
+        # Custom bar alignment
+        if category == 'hour':
+            # Center bars between hour ticks
+            x = dodge(category, 0.5, range=fig.x_range)
+        else:
+            x = category
+        fig.vbar(x=x, top=field, width=width, source=cds, line_color='white',
+                 fill_color=next(palette))
 
         # axes parameters
         fig.xgrid.grid_line_color = None
@@ -538,14 +546,7 @@ def bar_subdivisions(cds, category, metric):
             hover_kwargs = dict(tooltips=tooltips)
         else:
             # Numerical x-axis
-            if category == 'hour':
-                # center bars between xticks
-                fig.xaxis.ticker = cds.data[category] - 0.5
-                fig.xaxis.major_label_overrides = {
-                    i - 0.5: str(i) for i in cds.data[category]
-                }
-            else:
-                fig.xaxis.ticker = cds.data[category]
+            fig.xaxis.ticker = cds.data[category]
             tooltips = [
                 (human_category, f'@{{{category}}}'),
                 (f'{metric.upper()}', f'@{{{field}}}'),


### PR DESCRIPTION
  - [x] Closes #234 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

**EDIT**: This PR was originally made to revise the hourly category labels based on whether `interval_label == ending` or `interval_label == beginning`. As the result of discussions in this PR, email, etc., this PR has now morphed to be more generally aimed at revising how the `metrics.calculator` handles the `interval_label` attribute of the `obs`/`fx`. Hence why I've revised the PR title.