### PR TITLE
datamodel: add `__check_metrics__()`

### DIFF
--- a/docs/source/whatsnew/1.0.0b4.rst
+++ b/docs/source/whatsnew/1.0.0b4.rst
@@ -11,6 +11,7 @@ API Changes
 
 Enhancements
 ~~~~~~~~~~~~
+* Automatically verify selected metrics are valid for deterministic forecasts. (:issue:`267`) (:pull:`301`)
 
 Bug fixes
 ~~~~~~~~~

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1009,7 +1009,7 @@ class ValueFilter(BaseFilter):
     value_range: Tuple[float, float]
 
 
-def __check_metrics__():
+def __check_metrics__(fx, metrics):
     """Validate metrics selection.
 
     Check that the selected metrics are valid for the given scenario (e.g.
@@ -1017,6 +1017,8 @@ def __check_metrics__():
 
     Parameters
     ----------
+    fx : Forecast, ProbabilisticForecast
+    metrics :
 
     Returns
     -------
@@ -1027,18 +1029,21 @@ def __check_metrics__():
     TypeError
         If the selected metrics are not valid for the given forecast type.
 
-    """
-    # maybe belongs in the metrics package
-    # deterministic forecasts --> deterministic metrics
-    # probabilistic forecasts --> probabilistic metrics
-    # event forecasts --> event metrics
+    TODO
+    ----
+    * validate event forecast metrics
 
-    if isinstance() and not isinstance():      # deterministic
-        raise TypeError("Invalid")
-    elif isinstance() and not isinstance():    # probilistic
-        raise TypeError("")
-    elif isinstance() and not isinstance():    # event
-        raise TypeError("")
+    """
+
+    if isinstance(fx, Forecast) and not set(metrics) <= \
+            ALLOWED_PROBABILISTIC_METRICS.keys():
+        raise TypeError("Invalid metric(s) for deterministic forecasts.")
+    elif isinstance(fx, ProbabilisticForecast) and not set(metrics) <= \
+            ALLOWED_PROBABILISTIC_METRICS.keys():
+        raise TypeError("Invalid metric(s) for probabilistic forecasts.")
+    #elif isinstance(fx, EventForecast) and not set(metrics) <= \
+    #        ALLOWED_EVENT_METRICS.keys():
+    #    raise TypeError("Invalid metric(s) for event forecasts.")
     else:
         pass
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1043,9 +1043,6 @@ def __check_metrics__(fx, metrics):
     elif isinstance(fx, ProbabilisticForecast) and not set(metrics) <= \
             ALLOWED_PROBABILISTIC_METRICS.keys():
         raise ValueError("Metrics must be in ALLOWED_PROBABILISTIC_METRICS")
-    #elif isinstance(fx, EventForecast) and not set(metrics) <= \
-    #        ALLOWED_EVENT_METRICS.keys():
-    #    raise ValueError("Metrics must be in ALLOWED_EVENT_METRICS")
     else:
         pass
 
@@ -1159,7 +1156,5 @@ class Report(BaseModel):
         # ensure the metrics can be applied to the forecasts and observations
         for k in self.forecast_observations:
             __check_metrics__(k.forecast, self.metrics)
-        #__check_metrics__(*itertools.chain.from_iterable(
-        #    ((k.forecast, self.metrics) for k in self.forecast_observations)))
         # ensure that categories are valid
         __check_categories__(self.categories)

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1010,11 +1010,37 @@ class ValueFilter(BaseFilter):
 
 
 def __check_metrics__():
+    """Validate metrics selection.
+
+    Check that the selected metrics are valid for the given scenario (e.g.
+    if deterministic forecasts, then deterministic metrics).
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    TypeError
+        If the selected metrics are not valid for the given forecast type.
+
+    """
     # maybe belongs in the metrics package
     # deterministic forecasts --> deterministic metrics
     # probabilistic forecasts --> probabilistic metrics
     # event forecasts --> event metrics
-    pass
+
+    if isinstance() and not isinstance():      # deterministic
+        raise TypeError("Invalid")
+    elif isinstance() and not isinstance():    # probilistic
+        raise TypeError("")
+    elif isinstance() and not isinstance():    # event
+        raise TypeError("")
+    else:
+        pass
 
 
 def __check_categories__(categories):

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1017,8 +1017,8 @@ def __check_metrics__(fx, metrics):
 
     Parameters
     ----------
-    fx : Forecast, ProbabilisticForecast
-        Forecast.
+    fx : Forecast.
+        Forecast to be evaluated by metrics.
     metrics : Tuple of str
         Metrics to be computed in the report.
 
@@ -1033,6 +1033,7 @@ def __check_metrics__(fx, metrics):
 
     TODO
     ----
+    * validate probabilistic forecast metrics
     * validate event forecast metrics
 
     """
@@ -1040,9 +1041,6 @@ def __check_metrics__(fx, metrics):
     if isinstance(fx, Forecast) and not set(metrics) <= \
             ALLOWED_DETERMINISTIC_METRICS.keys():
         raise ValueError("Metrics must be in ALLOWED_DETERMINISTIC_METRICS")
-    elif isinstance(fx, ProbabilisticForecast) and not set(metrics) <= \
-            ALLOWED_PROBABILISTIC_METRICS.keys():
-        raise ValueError("Metrics must be in ALLOWED_PROBABILISTIC_METRICS")
     else:
         pass
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1018,7 +1018,9 @@ def __check_metrics__(fx, metrics):
     Parameters
     ----------
     fx : Forecast, ProbabilisticForecast
-    metrics :
+        Forecast.
+    metrics : Tuple of str
+        Metrics to be computed in the report.
 
     Returns
     -------
@@ -1036,14 +1038,14 @@ def __check_metrics__(fx, metrics):
     """
 
     if isinstance(fx, Forecast) and not set(metrics) <= \
-            ALLOWED_PROBABILISTIC_METRICS.keys():
-        raise TypeError("Invalid metric(s) for deterministic forecasts.")
+            ALLOWED_DETERMINISTIC_METRICS.keys():
+        raise ValueError("Metrics must be in ALLOWED_DETERMINISTIC_METRICS")
     elif isinstance(fx, ProbabilisticForecast) and not set(metrics) <= \
             ALLOWED_PROBABILISTIC_METRICS.keys():
-        raise TypeError("Invalid metric(s) for probabilistic forecasts.")
+        raise ValueError("Metrics must be in ALLOWED_PROBABILISTIC_METRICS")
     #elif isinstance(fx, EventForecast) and not set(metrics) <= \
     #        ALLOWED_EVENT_METRICS.keys():
-    #    raise TypeError("Invalid metric(s) for event forecasts.")
+    #    raise ValueError("Metrics must be in ALLOWED_EVENT_METRICS")
     else:
         pass
 
@@ -1155,6 +1157,9 @@ class Report(BaseModel):
         __check_units__(*itertools.chain.from_iterable(
             ((k.forecast, k.data_object) for k in self.forecast_observations)))
         # ensure the metrics can be applied to the forecasts and observations
-        __check_metrics__()
+        for k in self.forecast_observations:
+            __check_metrics__(k.forecast, self.metrics)
+        #__check_metrics__(*itertools.chain.from_iterable(
+        #    ((k.forecast, self.metrics) for k in self.forecast_observations)))
         # ensure that categories are valid
         __check_categories__(self.categories)

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -400,7 +400,8 @@ def test___check_categories__():
 
 @pytest.mark.parametrize('metrics', [
     (datamodel.ALLOWED_DETERMINISTIC_METRICS),
-    pytest.param(datamodel.ALLOWED_PROBABILISTIC_METRICS, marks=pytest.mark.xfail),
+    pytest.param(datamodel.ALLOWED_PROBABILISTIC_METRICS,
+                 marks=pytest.mark.xfail),
 ])
 def test___check_metrics__(metrics, single_forecast):
     datamodel.__check_metrics__(single_forecast, metrics)

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -396,3 +396,7 @@ def test___check_categories__():
     datamodel.__check_categories__(['total', 'weekday'])
     with pytest.raises(ValueError):
         datamodel.__check_categories__(['bad', 'very bad'])
+
+def test___check_metrics__():
+    with pytest.raises(TypeError):
+        datamodel.__check__metrics(fx, metrics)

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -397,6 +397,7 @@ def test___check_categories__():
     with pytest.raises(ValueError):
         datamodel.__check_categories__(['bad', 'very bad'])
 
+
 @pytest.mark.parametrize('metrics', [
     (datamodel.ALLOWED_DETERMINISTIC_METRICS),
     pytest.param(datamodel.ALLOWED_PROBABILISTIC_METRICS, marks=pytest.mark.xfail),

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -397,6 +397,9 @@ def test___check_categories__():
     with pytest.raises(ValueError):
         datamodel.__check_categories__(['bad', 'very bad'])
 
-def test___check_metrics__():
-    with pytest.raises(TypeError):
-        datamodel.__check__metrics(fx, metrics)
+@pytest.mark.parametrize('metrics', [
+    (datamodel.ALLOWED_DETERMINISTIC_METRICS),
+    pytest.param(datamodel.ALLOWED_PROBABILISTIC_METRICS, marks=pytest.mark.xfail),
+])
+def test___check_metrics__(metrics, single_forecast):
+    datamodel.__check_metrics__(single_forecast, metrics)

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -401,7 +401,7 @@ def test___check_categories__():
 @pytest.mark.parametrize('metrics', [
     (datamodel.ALLOWED_DETERMINISTIC_METRICS),
     pytest.param(datamodel.ALLOWED_PROBABILISTIC_METRICS,
-                 marks=pytest.mark.xfail),
+                 marks=pytest.mark.xfail(raises=ValueError)),
 ])
 def test___check_metrics__(metrics, single_forecast):
     datamodel.__check_metrics__(single_forecast, metrics)


### PR DESCRIPTION
  - [x] Closes #267 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Adds helper function `__check_metrics__()` to determine if the select metrics are valid (e.g. if evaluating a deterministic forecast, then should use deterministic forecast metrics, not probabilistic).