### PR TITLE
metrics: preprocessing: clarify `interval_label` mismatch behavior

### DIFF
--- a/docs/source/whatsnew/1.0.0b4.rst
+++ b/docs/source/whatsnew/1.0.0b4.rst
@@ -18,6 +18,8 @@ Bug fixes
 * Fix handling of empty observation timeseries in metrics preprocessing. (:issue:`295`) (:pull:`296`)
 * Fix handling of `interval_label == ending` in the `groupby` categories in
   `metrics.calculator`. (:issue:`234`) (:pull:`297`)
+* Document `resample_and_align()` behavior when the `interval_label` of the
+  forecast and observation don't match. (:issue:`300`) (:pull:`303`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -79,10 +79,9 @@ def resample_and_align(fx_obs, data, tz):
     Notes
     -----
     In the case where the `interval_label` of the `obs` and `fx` do not match,
-    this function does the following:
-
-    - if `obs.interval_length` < `fx.interval_length`:
-    - if `obs.interval_length` == `fx.interval_length`:
+    this function currently returns a `ProcessedForecastObservation` object
+    with a `interval_label` the same as the `fx`, regardless of whether the
+    `interval_length` of the `fx` and `obs` are the same or different.
 
     Todo
     ----

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -76,9 +76,19 @@ def resample_and_align(fx_obs, data, tz):
     -------
     solarforecastarbiter.datamodel.ProcessedForecastObservation
 
+    Notes
+    -----
+    In the case where the `interval_label` of the `obs` and `fx` do not match,
+    this function does the following:
+
+    - if `obs.interval_length` < `fx.interval_length`:
+    - if `obs.interval_length` == `fx.interval_length`:
+
     Todo
     ----
       * Add other resampling functions (besides mean like first, last, median)
+
+
     """  # noqa: E501
     fx = fx_obs.forecast
     obs = fx_obs.data_object

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -103,6 +103,60 @@ def test_resample_and_align(site_metadata, interval_label,
                                   check_categorical=False)
 
 
+@pytest.mark.parametrize("label_obs,label_fx,length_obs,length_fx", [
+    ("beginning", "ending", "5min", "5min"),
+    ("beginning", "ending", "5min", "1h"),
+    ("ending", "beginning", "5min", "5min"),
+    ("ending", "beginning", "5min", "1h"),
+])
+def test_resample_and_align_interval_label(site_metadata, label_obs, label_fx,
+                                           length_obs, length_fx):
+
+    observation = datamodel.Observation(
+        site=site_metadata, name='dummy obs', variable='ghi',
+        interval_value_type='instantaneous', uncertainty=1,
+        interval_length=pd.Timedelta(length_obs),
+        interval_label=label_obs
+    )
+    forecast = datamodel.Forecast(
+        site=site_metadata, name='dummy fx', variable='ghi',
+        interval_value_type='instantaneous',
+        interval_length=pd.Timedelta(length_fx),
+        interval_label=label_fx,
+        issue_time_of_day=datetime.time(hour=5),
+        lead_time_to_start=pd.Timedelta('1h'),
+        run_length=pd.Timedelta('12h')
+    )
+    fx_obs = datamodel.ForecastObservation(forecast=forecast,
+                                           observation=observation)
+
+    ts_obs = pd.date_range(
+        start='2019-03-31T12:00:00',
+        end='2019-05-01T00:00:00',
+        freq=length_obs,
+        tz='MST',
+        name='timestamp'
+    )
+    ts_fx = pd.date_range(
+        start='2019-03-31T12:00:00',
+        end='2019-05-01T00:00:00',
+        freq=length_fx,
+        tz='MST',
+        name='timestamp'
+    )
+    obs_series = pd.Series(index=ts_obs, data=np.random.rand(len(ts_obs)) + 10)
+    fx_series = pd.Series(index=ts_fx, data=np.random.rand(len(ts_fx)) + 10)
+
+    # Use local tz
+    local_tz = f"Etc/GMT{int(time.timezone/3600):+d}"
+
+    data = {
+        fx_obs.forecast: fx_series,
+        fx_obs.observation: obs_series
+    }
+    result = preprocessing.resample_and_align(fx_obs, data, local_tz)
+
+
 @pytest.mark.parametrize('fx0', [
     pd.Series(index=pd.DatetimeIndex([], name='timestamp'), name='value'),
     THREE_HOUR_SERIES

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -103,14 +103,14 @@ def test_resample_and_align(site_metadata, interval_label,
                                   check_categorical=False)
 
 
-@pytest.mark.parametrize("label_obs,label_fx,length_obs,length_fx", [
-    ("beginning", "ending", "5min", "5min"),
-    ("beginning", "ending", "5min", "1h"),
-    ("ending", "beginning", "5min", "5min"),
-    ("ending", "beginning", "5min", "1h"),
+@pytest.mark.parametrize("label_obs,label_fx,length_obs,length_fx,freq", [
+    ("beginning", "ending", "5min", "5min", "5min"),
+    ("beginning", "ending", "5min", "1h", "1h"),
+    ("ending", "beginning", "5min", "5min", "5min"),
+    ("ending", "beginning", "5min", "1h", "1h"),
 ])
 def test_resample_and_align_interval_label(site_metadata, label_obs, label_fx,
-                                           length_obs, length_fx):
+                                           length_obs, length_fx, freq):
 
     observation = datamodel.Observation(
         site=site_metadata, name='dummy obs', variable='ghi',
@@ -154,7 +154,10 @@ def test_resample_and_align_interval_label(site_metadata, label_obs, label_fx,
         fx_obs.forecast: fx_series,
         fx_obs.observation: obs_series
     }
-    result = preprocessing.resample_and_align(fx_obs, data, local_tz)
+    proc_fx_obs = preprocessing.resample_and_align(fx_obs, data, local_tz)
+
+    assert proc_fx_obs.interval_label == label_fx
+    assert proc_fx_obs.interval_length == pd.Timedelta(freq)
 
 
 @pytest.mark.parametrize('fx0', [


### PR DESCRIPTION
  - [x] Closes #300 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.


Add a note to the docstring of `resample_and_align()` regarding the behavior in the case of the `interval_label` not being the same between the forecast and observation. Also revise tests to explicitly check this behavior.

Note: this behavior is likely to be revised in the future; the goal of this commit is to document the current behavior as a first step towards revising the behavior.