### PR TITLE
datamodel.__check__metrics(): support probabilistic forecasts

### DIFF
--- a/docs/source/whatsnew/1.0.0b4.rst
+++ b/docs/source/whatsnew/1.0.0b4.rst
@@ -18,6 +18,7 @@ API Changes
 Enhancements
 ~~~~~~~~~~~~
 * Automatically verify selected metrics are valid for deterministic forecasts. (:issue:`267`) (:pull:`301`)
+* Automatically verify selected metrics are valid for probabilistic forecasts. (:issue:`302`) (:pull:`306`)
 * Add schema for de/serializing timeseries in :py:mod:`solarforecastarbiter.io.utils` (:pull:`291`)
 
 Bug fixes

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1026,13 +1026,15 @@ def __check_metrics__(fx, metrics):
 
     """
 
-    if isinstance(fx, (
-            ProbabilisticForecast, ProbabilisticForecastConstantValue
-    )) and not set(metrics) <= ALLOWED_PROBABILISTIC_METRICS.keys():
-        raise ValueError("Metrics must be in ALLOWED_PROBABILISTIC_METRICS.")
-    elif isinstance(fx, Forecast) and not set(metrics) <= \
-            ALLOWED_DETERMINISTIC_METRICS.keys():
-        raise ValueError("Metrics must be in ALLOWED_DETERMINISTIC_METRICS.")
+    if isinstance(fx, (ProbabilisticForecast,
+                       ProbabilisticForecastConstantValue)):
+        if not set(metrics) <= ALLOWED_PROBABILISTIC_METRICS.keys():
+            raise ValueError("Metrics must be in "
+                             "ALLOWED_PROBABILISTIC_METRICS.")
+    elif isinstance(fx, Forecast):
+        if not set(metrics) <= ALLOWED_DETERMINISTIC_METRICS.keys():
+            raise ValueError("Metrics must be in "
+                             "ALLOWED_DETERMINISTIC_METRICS.")
 
 
 def __check_categories__(categories):

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -19,7 +19,6 @@ from solarforecastarbiter.metrics.probabilistic import \
     _MAP as probabilistic_mapping
 from solarforecastarbiter.validation.quality_mapping import \
     DESCRIPTION_MASK_MAPPING
-from solarforecastarbiter.metrics import calculator
 
 
 ALLOWED_VARIABLES = {
@@ -1027,13 +1026,15 @@ def __check_metrics__(fx, metrics):
 
     """
 
-    #ALLOWED_DETERMINISTIC_FORECASTS = (Forecast)
-    #ALLOWED_PROBABILISTIC_FORECASTS = (ProbabilisticForecast,
-    #                                   ProbabilisticForecastConstantValue)
+    ALLOWED_DETERMINISTIC_FORECASTS = [Forecast]
+    ALLOWED_PROBABILISTIC_FORECASTS = [ProbabilisticForecast,
+                                       ProbabilisticForecastConstantValue]
 
-    if type(fx) in [Forecast] and not set(metrics) <= ALLOWED_DETERMINISTIC_METRICS.keys():
+    if type(fx) in ALLOWED_DETERMINISTIC_FORECASTS and not set(metrics) \
+            <= ALLOWED_DETERMINISTIC_METRICS.keys():
         raise ValueError("Deterministic:", type(fx), type(metrics), metrics)
-    elif type(fx) in [ProbabilisticForecast, ProbabilisticForecastConstantValue] and not set(metrics) <= ALLOWED_PROBABILISTIC_METRICS.keys():
+    elif type(fx) in ALLOWED_PROBABILISTIC_FORECASTS and not set(metrics) \
+            <= ALLOWED_PROBABILISTIC_METRICS.keys():
         raise ValueError("Probabilistic:", type(fx), type(metrics), metrics)
 
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1029,9 +1029,9 @@ def __check_metrics__(fx, metrics):
     if type(fx) in [Forecast] and not set(metrics) <= \
             ALLOWED_DETERMINISTIC_METRICS.keys():
         raise ValueError("Metrics must be in ALLOWED_DETERMINISTIC_METRICS.")
-    elif type(fx) in [ProbabilisticForecast, \
-            ProbabilisticForecastConstantValue] and not set(metrics) <= \
-            ALLOWED_PROBABILISTIC_METRICS.keys():
+    elif type(fx) in [ProbabilisticForecast,
+                      ProbabilisticForecastConstantValue] and \
+            not set(metrics) <= ALLOWED_PROBABILISTIC_METRICS.keys():
         raise ValueError("Metrics must be in ALLOWED_PROBABILISTIC_METRICS.")
 
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1026,11 +1026,12 @@ def __check_metrics__(fx, metrics):
 
     """
 
-    if fx in [Forecast] and not set(metrics) <= \
+    if type(fx) in [Forecast] and not set(metrics) <= \
             ALLOWED_DETERMINISTIC_METRICS.keys():
         raise ValueError("Metrics must be in ALLOWED_DETERMINISTIC_METRICS.")
-    elif fx in [ProbabilisticForecast, ProbabilisticForecastConstantValue] \
-            and not set(metrics) <= ALLOWED_PROBABILISTIC_METRICS.keys():
+    elif type(fx) in [ProbabilisticForecast, \
+            ProbabilisticForecastConstantValue] and not set(metrics) <= \
+            ALLOWED_PROBABILISTIC_METRICS.keys():
         raise ValueError("Metrics must be in ALLOWED_PROBABILISTIC_METRICS.")
 
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1017,19 +1017,22 @@ def __check_metrics__(fx, metrics):
 
     Raises
     ------
-    TypeError
+    ValueError
         If the selected metrics are not valid for the given forecast type.
 
     TODO
     ----
-    * validate probabilistic forecast metrics
     * validate event forecast metrics
 
     """
 
-    if isinstance(fx, Forecast) and not set(metrics) <= \
+    if (type(fx) == Forecast) and not set(metrics) <= \
             ALLOWED_DETERMINISTIC_METRICS.keys():
         raise ValueError("Metrics must be in ALLOWED_DETERMINISTIC_METRICS")
+    elif (type(fx) == any([
+            ProbabilisticForecast, ProbabilisticForecastConstantValue
+         ])) and not set(metrics) <= ALLOWED_PROBABILISTIC_METRICS.keys():
+        raise ValueError("Metrics must be in ALLOWED_PROBABILISTIC_METRICS")
     else:
         pass
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1006,7 +1006,7 @@ def __check_metrics__(fx, metrics):
 
     Parameters
     ----------
-    fx : Forecast, ProbailisticForecast
+    fx : Forecast, ProbabilisticForecast, ProbabilisticForecastConstantValue
         Forecast to be evaluated by metrics.
     metrics : Tuple of str
         Metrics to be computed in the report.
@@ -1026,16 +1026,12 @@ def __check_metrics__(fx, metrics):
 
     """
 
-    ALLOWED_DETERMINISTIC_FORECASTS = [Forecast]
-    ALLOWED_PROBABILISTIC_FORECASTS = [ProbabilisticForecast,
-                                       ProbabilisticForecastConstantValue]
-
-    if type(fx) in ALLOWED_DETERMINISTIC_FORECASTS and not set(metrics) \
-            <= ALLOWED_DETERMINISTIC_METRICS.keys():
-        raise ValueError("Deterministic:", type(fx), type(metrics), metrics)
-    elif type(fx) in ALLOWED_PROBABILISTIC_FORECASTS and not set(metrics) \
-            <= ALLOWED_PROBABILISTIC_METRICS.keys():
-        raise ValueError("Probabilistic:", type(fx), type(metrics), metrics)
+    if fx in [Forecast] and not set(metrics) <= \
+            ALLOWED_DETERMINISTIC_METRICS.keys():
+        raise ValueError("Metrics must be in ALLOWED_DETERMINISTIC_METRICS.")
+    elif fx in [ProbabilisticForecast, ProbabilisticForecastConstantValue] \
+            and not set(metrics) <= ALLOWED_PROBABILISTIC_METRICS.keys():
+        raise ValueError("Metrics must be in ALLOWED_PROBABILISTIC_METRICS.")
 
 
 def __check_categories__(categories):

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1026,13 +1026,13 @@ def __check_metrics__(fx, metrics):
 
     """
 
-    if type(fx) in [Forecast] and not set(metrics) <= \
+    if isinstance(fx, (
+            ProbabilisticForecast, ProbabilisticForecastConstantValue
+    )) and not set(metrics) <= ALLOWED_PROBABILISTIC_METRICS.keys():
+        raise ValueError("Metrics must be in ALLOWED_PROBABILISTIC_METRICS.")
+    elif isinstance(fx, Forecast) and not set(metrics) <= \
             ALLOWED_DETERMINISTIC_METRICS.keys():
         raise ValueError("Metrics must be in ALLOWED_DETERMINISTIC_METRICS.")
-    elif type(fx) in [ProbabilisticForecast,
-                      ProbabilisticForecastConstantValue] and \
-            not set(metrics) <= ALLOWED_PROBABILISTIC_METRICS.keys():
-        raise ValueError("Metrics must be in ALLOWED_PROBABILISTIC_METRICS.")
 
 
 def __check_categories__(categories):

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -19,6 +19,7 @@ from solarforecastarbiter.metrics.probabilistic import \
     _MAP as probabilistic_mapping
 from solarforecastarbiter.validation.quality_mapping import \
     DESCRIPTION_MASK_MAPPING
+from solarforecastarbiter.metrics import calculator
 
 
 ALLOWED_VARIABLES = {
@@ -1006,7 +1007,7 @@ def __check_metrics__(fx, metrics):
 
     Parameters
     ----------
-    fx : Forecast.
+    fx : Forecast, ProbailisticForecast
         Forecast to be evaluated by metrics.
     metrics : Tuple of str
         Metrics to be computed in the report.
@@ -1026,15 +1027,14 @@ def __check_metrics__(fx, metrics):
 
     """
 
-    if (type(fx) == Forecast) and not set(metrics) <= \
-            ALLOWED_DETERMINISTIC_METRICS.keys():
-        raise ValueError("Metrics must be in ALLOWED_DETERMINISTIC_METRICS")
-    elif (type(fx) == any([
-            ProbabilisticForecast, ProbabilisticForecastConstantValue
-         ])) and not set(metrics) <= ALLOWED_PROBABILISTIC_METRICS.keys():
-        raise ValueError("Metrics must be in ALLOWED_PROBABILISTIC_METRICS")
-    else:
-        pass
+    #ALLOWED_DETERMINISTIC_FORECASTS = (Forecast)
+    #ALLOWED_PROBABILISTIC_FORECASTS = (ProbabilisticForecast,
+    #                                   ProbabilisticForecastConstantValue)
+
+    if type(fx) in [Forecast] and not set(metrics) <= ALLOWED_DETERMINISTIC_METRICS.keys():
+        raise ValueError("Deterministic:", type(fx), type(metrics), metrics)
+    elif type(fx) in [ProbabilisticForecast, ProbabilisticForecastConstantValue] and not set(metrics) <= ALLOWED_PROBABILISTIC_METRICS.keys():
+        raise ValueError("Probabilistic:", type(fx), type(metrics), metrics)
 
 
 def __check_categories__(categories):

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -470,7 +470,6 @@ def test___check_metrics__(metrics, single_forecast):
     ),
 ])
 def test___check_metrics__probabilistic(metrics, prob_forecast_constant_value):
-    print(type(prob_forecast_constant_value))
     datamodel.__check_metrics__(prob_forecast_constant_value, metrics)
 
 

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -442,20 +442,35 @@ def test___check_categories__():
 
 
 @pytest.mark.parametrize('metrics', [
-    (datamodel.ALLOWED_DETERMINISTIC_METRICS),
-    pytest.param(datamodel.ALLOWED_PROBABILISTIC_METRICS,
-                 marks=pytest.mark.xfail(raises=ValueError, strict=True)),
+    (['rmse']),
+    (list(datamodel.ALLOWED_DETERMINISTIC_METRICS.keys())),
+    pytest.param(
+        ["bss"],
+        marks=pytest.mark.xfail(raises=ValueError, strict=True)
+    ),
+    pytest.param(
+        list(datamodel.ALLOWED_PROBABILISTIC_METRICS.keys()),
+        marks=pytest.mark.xfail(raises=ValueError, strict=True)
+    ),
 ])
 def test___check_metrics__(metrics, single_forecast):
     datamodel.__check_metrics__(single_forecast, metrics)
 
 
 @pytest.mark.parametrize('metrics', [
-    (datamodel.ALLOWED_PROBABILISTIC_METRICS),
-    pytest.param(datamodel.ALLOWED_DETERMINISTIC_METRICS,
-                 marks=pytest.mark.xfail(raises=ValueError, stric=True)),
+    (['crps']),
+    (list(datamodel.ALLOWED_PROBABILISTIC_METRICS.keys())),
+    pytest.param(
+        ('rmse'),
+        marks=pytest.mark.xfail(raises=ValueError, stric=True)
+    ),
+    pytest.param(
+        list(datamodel.ALLOWED_DETERMINISTIC_METRICS.keys()),
+        marks=pytest.mark.xfail(raises=ValueError, stric=True)
+    ),
 ])
 def test___check_metrics__probabilistic(metrics, prob_forecast_constant_value):
+    print(type(prob_forecast_constant_value))
     datamodel.__check_metrics__(prob_forecast_constant_value, metrics)
 
 

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -444,10 +444,19 @@ def test___check_categories__():
 @pytest.mark.parametrize('metrics', [
     (datamodel.ALLOWED_DETERMINISTIC_METRICS),
     pytest.param(datamodel.ALLOWED_PROBABILISTIC_METRICS,
-                 marks=pytest.mark.xfail(raises=ValueError)),
+                 marks=pytest.mark.xfail(raises=ValueError, strict=True)),
 ])
 def test___check_metrics__(metrics, single_forecast):
     datamodel.__check_metrics__(single_forecast, metrics)
+
+
+@pytest.mark.parametrize('metrics', [
+    (datamodel.ALLOWED_PROBABILISTIC_METRICS),
+    pytest.param(datamodel.ALLOWED_DETERMINISTIC_METRICS,
+                 marks=pytest.mark.xfail(raises=ValueError, stric=True)),
+])
+def test___check_metrics__probabilistic(metrics, prob_forecast_constant_value):
+    datamodel.__check_metrics__(prob_forecast_constant_value, metrics)
 
 
 @pytest.fixture

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -462,11 +462,11 @@ def test___check_metrics__(metrics, single_forecast):
     (list(datamodel.ALLOWED_PROBABILISTIC_METRICS.keys())),
     pytest.param(
         ('rmse'),
-        marks=pytest.mark.xfail(raises=ValueError, stric=True)
+        marks=pytest.mark.xfail(raises=ValueError, strict=True)
     ),
     pytest.param(
         list(datamodel.ALLOWED_DETERMINISTIC_METRICS.keys()),
-        marks=pytest.mark.xfail(raises=ValueError, stric=True)
+        marks=pytest.mark.xfail(raises=ValueError, strict=True)
     ),
 ])
 def test___check_metrics__probabilistic(metrics, prob_forecast_constant_value):


### PR DESCRIPTION
  - [x] Closes #302 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This PR is meant to add support for checking whether the selected metrics are valid for probabilistic forecasts via the `datamodel.__check__metrics()` function. Per the discussion last week, this PR is to be merged against the 1.0beta4` branch (instead of `master`).