### PR TITLE
Docstrings

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -71,7 +71,28 @@ Containers to associate forecasts and observations for use with reports:
    :toctree: generated/
 
    datamodel.ForecastObservation
+   datamodel.ForecastAggregate
    datamodel.ProcessedForecastObservation
+
+
+Report metrics and validation:
+
+.. autosummary::
+   :toctree: generated/
+
+   datamodel.MetricResult
+   datamodel.MetricValue
+   datamodel.ValidationResult
+   datamodel.ReportMessage
+
+Report plots:
+
+.. autosummary::
+   :toctree: generated/
+
+   datamodel.RawReportPlots
+   datamodel.ReportFigure
+
 
 Reports:
 
@@ -467,8 +488,20 @@ Reports
 .. autosummary::
    :toctree: generated/
 
-   reports
-
+   reports.main.compute_report
+   reports.main.create_metadata
+   reports.main.get_data_for_report
+   reports.main.create_raw_report_from_data
+   reports.figures.construct_timeseries_cds
+   reports.figures.construct_metrics_cds
+   reports.figures.timeseries
+   reports.figures.scatter
+   reports.figures.bar
+   reports.figures.bar_subdivisions
+   reports.figures.raw_report_plots
+   reports.figures.timeseries_plots
+   reports.template.render_html
+   reports.template.get_template_and_kwargs
 
 Validation
 ==========

--- a/docs/source/whatsnew/1.0.0b4.rst
+++ b/docs/source/whatsnew/1.0.0b4.rst
@@ -14,6 +14,11 @@ API Changes
 * Rename `io.utils.serialize_data` to :py:mod:`solarforecastarbiter.io.utils.serialize_timeseries` (:pull:`291`)
 * :py:mod:`solarforecastarbiter.metrics.calculator.calculate_metrics` returns a list of `~datamodel.MetridResult` and :py:mod:`solarforecastarbiter.metrics.calculator.calculate_deterministic_metrics` returns a single `~datamodel.MetricResult` (:pull:`291`)
 * :py:mod:`solarforecastarbiter.datamodel.ProcessedForecastObservation` now requires a name parameter (:pull:`291`)
+* :py:func:`solarforecastarbiter.reports.figures.construct_timeseries_cds` now takes a single :py:class:`solarforecastarbiter.datamodel.Report` object and returns separate Bokeh ColumnDataSources for
+timeseries and metadata.
+* :py:func:`solarforecastarbiter.reports.figures.construct_metrics_cds` updated to accept a list of :py:class:`solarforecastarbiter.datamodel.MetricResults` as its first argument.
+* :py:func:`solarforecastarbiter.reports.figures.timeseries` and :py:func:`solarforecastarbiter.figures.scatter` now take two Bokeh ColumnDataSources as their first two arguments in place of a list of (ProcesseForecastObservation, ColumnDataSource) tuples. See the return value of :py:func:`solarforecastarbiter.figures.construct_timeseries_cds` for the format of these ColumnDataSources.
+* Replaced `solarforecastarbiter.reports.full_html` with :py:func:`solarforecastarbiter.reports.template.render_html` which accepts a :py:class:`solarforecastarbiter.datamodel.Report` object, a dashboard url and optional flags to include timeseries plots or generate a standalone html report. 
 
 Enhancements
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -334,8 +334,8 @@ class PVModelingParameters(BaseModel):
 
     See Also
     --------
-    FixedTiltModelingParameters
-    SingleAxisModelingParameters
+    :py:class:`solarforecastarbiter.datamodel.FixedTiltModelingParameters`
+    :py:class:`solarforecastarbiter.datamodel.SingleAxisModelingParameters`
     """
     ac_capacity: float
     dc_capacity: float
@@ -360,7 +360,7 @@ class FixedTiltModelingParameters(PVModelingParameters):
 
     See Also
     --------
-    PVModelingParameters
+    :py:class:`solarforecastarbiter.datamodel.PVModelingParameters`
     """
     surface_tilt: float
     surface_azimuth: float
@@ -391,7 +391,7 @@ class SingleAxisModelingParameters(PVModelingParameters):
 
     See Also
     --------
-    PVModelingParameters
+    :py:class:`solarforecastarbiter.datamodel.PVModelingParameters`
     """
     axis_tilt: float
     axis_azimuth: float
@@ -414,9 +414,9 @@ class SolarPowerPlant(Site):
 
     See Also
     --------
-    Site
-    SingleAxisModelingParameters
-    FixedTiltModelingParameters
+    :py:class:`solarforecastarbiter.datamodel.Site`
+    :py:class:`solarforecastarbiter.datamodel.SingleAxisModelingParameters`
+    :py:class:`solarforecastarbiter.datamodel.FixedTiltModelingParameters`
     """
     modeling_parameters: PVModelingParameters = field(
         default_factory=PVModelingParameters)
@@ -465,7 +465,7 @@ class Observation(BaseModel):
 
     See Also
     --------
-    Site
+    :py:class:`solarforecastarbiter.datamodel.Site`
     """
     name: str
     variable: str
@@ -508,8 +508,8 @@ class AggregateObservation(BaseModel):
 
     See Also
     --------
-    Observation
-    Aggregate
+    :py:class:`solarforecastarbiter.datamodel.Observation`
+    :py:class:`solarforecastarbiter.datamodel.Aggregate`
     """
     observation: Observation
     effective_from: pd.Timestamp
@@ -574,7 +574,7 @@ class Aggregate(BaseModel):
 
     See Also
     --------
-    Observation
+    :py:class:`solarforecastarbiter.datamodel.Observation`
     """
     name: str
     description: str
@@ -682,8 +682,8 @@ class Forecast(BaseModel, _ForecastDefaultsBase, _ForecastBase):
 
     See Also
     --------
-    Site
-    Aggregate
+    :py:class:`solarforecastarbiter.datamodel.Site
+    :py:class:`solarforecastarbiter.datamodel.Aggregate
     """
     def __post_init__(self):
         __set_units__(self)
@@ -751,7 +751,7 @@ class ProbabilisticForecastConstantValue(
 
     See also
     --------
-    ProbabilisticForecast
+    :py:class:`solarforecastarbiter.datamodel.ProbabilisticForecast`
     """
     def __post_init__(self):
         super().__post_init__()
@@ -841,7 +841,7 @@ def __set_constant_values__(self):
             cv_dict.pop('forecast_id', None)
             cv_dict['constant_value'] = cv
             out.append(
-                    ProbabilisticForecastConstantValue.from_dict(cv_dict))
+                ProbabilisticForecastConstantValue.from_dict(cv_dict))
         else:
             raise TypeError(
                 f'Invalid type for a constant value {cv}. '
@@ -882,7 +882,17 @@ class ForecastObservation(BaseModel):
 
     Maybe not needed, but makes Report type spec easier and allows for
     __post_init__ checking.
-    """
+
+
+    Parameters
+    ----------
+    forecast: :py:class:`solarforecastarbiter.datamodel.Forecast`
+    observation: :py:class:`solarforecastarbiter.datamodel.Observation`
+    reference_forecast: :py:class:`solarforecastarbiter.datamodel.Forecast` or None
+    normalization: float
+    cost_per_unit_error: float
+    data_object: :py:class:`solarforecastarbiter.datamodel.Observation`
+    """  # NOQA
     forecast: Forecast
     observation: Observation
     reference_forecast: Union[Forecast, None] = None
@@ -906,7 +916,16 @@ class ForecastAggregate(BaseModel):
 
     Maybe not needed, but makes Report type spec easier and allows for
     __post_init__ checking.
-    """
+
+    Parameters
+    ----------
+    forecast: :py:class:`solarforecastarbiter.datamodel.Forecast`
+    aggregate: :py:class:`solarforecastarbiter.datamodel.Aggregate`
+    reference_forecast: :py:class:`solarforecastarbiter.datamodel.Forecast` or None
+    normalization: float
+    cost_per_unit_error: float
+    data_object: :py:class:`solarforecastarbiter.datamodel.Aggregate`
+    """  # NOQA
     forecast: Forecast
     aggregate: Aggregate
     reference_forecast: Union[Forecast, None] = None
@@ -988,12 +1007,12 @@ class ValueFilter(BaseFilter):
 
     Parameters
     ----------
-    metadata : Observation or Forecast
+    metadata : :py:class:`solarforecastarbiter.datamodel.Forecast` or :py:class:`solarforecastarbiter.datamodel.Observation`
         Object to get values for.
     value_range : (float, float) tuple
         Value range to calculate errors. Range is inclusive
         of both endpoints. Filters are applied before resampling.
-    """
+    """  # NOQA
     metadata: Union[Observation, Forecast]
     value_range: Tuple[float, float]
 
@@ -1046,6 +1065,19 @@ def __check_categories__(categories):
 class ReportMetadata(BaseModel):
     """
     Hold additional metadata about the report
+
+    Parameters
+    ----------
+    name: str
+    start: pandas.Timestamp
+    end: pandas.Timestamp
+    now: pandas.Timestamp
+        The time at report computation.
+    timezone: str
+        The IANA timezone of the report.
+    versions: dict
+        Dictionary of version information to ensure the correct version of
+        the core library is used when rendering or recomputing the report.
     """
     name: str
     start: pd.Timestamp
@@ -1057,6 +1089,17 @@ class ReportMetadata(BaseModel):
 
 @dataclass(frozen=True)
 class ValidationResult(BaseModel):
+    """Stores the validation result for a single flag for a forecast and
+    observation pair.
+
+    Parameters
+    ----------
+    flag: str
+        The quality flag being recorded. See
+        :py:mod:`solarforecastarbiter.validation.quality_mapping`.
+    count: int
+        The number of timestamps that were flagged.
+    """
     flag: str
     count: int
 
@@ -1067,7 +1110,28 @@ class ProcessedForecastObservation(BaseModel):
     """
     Hold the processed forecast and observation data with the resampling
     parameters
-    """
+
+    Parameters
+    ----------
+    name: str
+    original: :py:class:`solarforecastarbiter.datamodel.ForecastObservation` or :py:class:`solarforecastarbiter.ForecastAggregate`
+    interval_value_type: str
+    interval_length: pd.Timedelta
+    interval_label: str
+    valid_point_count: int
+        The number of valid points in the processed forecast.
+    forecast_values: pandas.Series or str or None
+        The values of the forecast, the forecast id or None.
+    observation_values: pandas.Series or str or None
+        The values of the observation, the observation or aggregated id, or
+        None.
+    reference_forecast_values: pandas.Series or str or None
+        The values of the reference forecast, the reference forecast id or
+        None.
+    validation_results: tuple of :py:class:`solarforecastarbiter.datamodel.ValidationResult`
+    normalization_factor: pandas.Series or Float
+    cost_per_unit_error: float
+    """  # NOQA
     name: str
     # do this instead of subclass to compare objects later
     original: Union[ForecastObservation, ForecastAggregate]
@@ -1092,6 +1156,20 @@ class ProcessedForecastObservation(BaseModel):
 
 @dataclass(frozen=True)
 class MetricValue(BaseModel):
+    """Class for storing the result of a single metric calculation.
+
+    Parameters
+    ----------
+    category: str
+        The category of the metric value, e.g. total, monthly, hourly.
+    metric: str
+        The metric that was calculated.
+    index: str
+        The index of the metric value, e.g. '1-12' for monthly metrics or
+        0-23 for hourly.
+    value: float
+        The value calculated for the metric.
+    """
     category: str
     metric: str
     index: str
@@ -1100,6 +1178,25 @@ class MetricValue(BaseModel):
 
 @dataclass(frozen=True)
 class MetricResult(BaseModel):
+    """Class for storing the results of many metric calculations for a single
+    observation and forecast pair.
+
+    Parameters
+    ----------
+    name: str
+        A descriptive name for the MetricResult.
+    forecast_id: str
+        UUID of the forecast being analyzed.
+    values: tuple of :py:class: `solarforecastarbiter.datamodel.MetricValue`
+    observation_id: str
+        UUID of the observation being analyzed.
+    aggregate_id: str
+        UUID of the aggregate being analyzed.
+
+    Notes
+    -----
+    Only one of `aggregate_id` or `observation_id` may be set.
+    """
     name: str
     forecast_id: str
     values: Tuple[MetricValue, ...]
@@ -1120,6 +1217,23 @@ class MetricResult(BaseModel):
 
 @dataclass(frozen=True)
 class ReportFigure(BaseModel):
+    """A class for storing metric plots for a report with associated metadata.
+
+    Parameters
+    ----------
+    name: str
+        A descriptive name for the figure.
+    div: str
+        An html div element to be target of Bokeh javascript.
+    svg: str
+        A static svg copy of the plot, for including in the pdf version.
+    type: str
+        The type of plot, e.g. bar or scatter.
+    category: str
+        The metric category, e.g. total, monthly, hourly.
+    metric: str
+        The metric being plotted.
+    """
     name: str
     div: str
     svg: str
@@ -1130,6 +1244,17 @@ class ReportFigure(BaseModel):
 
 @dataclass(frozen=True)
 class RawReportPlots(BaseModel):
+    """Class for storing collection of all metric plots on a raw report.
+
+    Parameters
+    ----------
+    bokeh_version: str
+        The bokeh version used when generating the plots.
+    script: str
+        The html script tag containing all of the bokeh javascript for the
+        plots.
+    figures: tuple of :py:class:`solarforecastarbiter.datamodel.ReportFigure`
+    """
     bokeh_version: str
     script: str
     figures: Tuple[ReportFigure, ...]
@@ -1137,6 +1262,17 @@ class RawReportPlots(BaseModel):
 
 @dataclass(frozen=True)
 class ReportMessage(BaseModel):
+    """Class for intercepting errors an warnings associated with report
+    processing.
+
+    Parameters
+    ----------
+    messages: str
+    step: str
+    level: str
+    function: str
+        The function where the error originated.
+    """
     message: str
     step: str
     level: str
@@ -1149,7 +1285,15 @@ class RawReport(BaseModel):
     Class for holding the result of processing a report request including
     the calculated metrics, some metadata, the markdown template, and
     the processed forecast/observation data.
-    """
+
+    Parameters
+    ----------
+    metadata: :py:class:`solarforecastarbiter.datamodel.ReportMetatadata`
+    plots: :py:class:`solarforecastarbiter.datamodel.RawReportPlots`
+    metrics: tuple of :py:class:`solarforecastarbiter.datamodel.MetricResult`
+    processed_forecasts_observations: tuple of :py:class:`solarforecastarbiter.datamodel.ReportMetatadata`
+    messages: tuple of :py:class:`solarforecastarbiter.datamodel.ReportMessage`
+    """  # NOQA
     metadata: ReportMetadata
     plots: RawReportPlots
     metrics: Tuple[MetricResult, ...]

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1109,7 +1109,7 @@ class ValidationResult(BaseModel):
 class ProcessedForecastObservation(BaseModel):
     """
     Hold the processed forecast and observation data with the resampling
-    parameters
+    parameters.
 
     Parameters
     ----------

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -880,10 +880,6 @@ class ForecastObservation(BaseModel):
     """
     Class for pairing Forecast and Observation objects for evaluation.
 
-    Maybe not needed, but makes Report type spec easier and allows for
-    __post_init__ checking.
-
-
     Parameters
     ----------
     forecast: :py:class:`solarforecastarbiter.datamodel.Forecast`
@@ -891,7 +887,6 @@ class ForecastObservation(BaseModel):
     reference_forecast: :py:class:`solarforecastarbiter.datamodel.Forecast` or None
     normalization: float
     cost_per_unit_error: float
-    data_object: :py:class:`solarforecastarbiter.datamodel.Observation`
     """  # NOQA
     forecast: Forecast
     observation: Observation
@@ -913,9 +908,6 @@ class ForecastObservation(BaseModel):
 class ForecastAggregate(BaseModel):
     """
     Class for pairing Forecast and Aggregate objects for evaluation.
-
-    Maybe not needed, but makes Report type spec easier and allows for
-    __post_init__ checking.
 
     Parameters
     ----------
@@ -1188,9 +1180,9 @@ class MetricResult(BaseModel):
     forecast_id: str
         UUID of the forecast being analyzed.
     values: tuple of :py:class: `solarforecastarbiter.datamodel.MetricValue`
-    observation_id: str
+    observation_id: str or None
         UUID of the observation being analyzed.
-    aggregate_id: str
+    aggregate_id: str or None
         UUID of the aggregate being analyzed.
 
     Notes

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -916,7 +916,6 @@ class ForecastAggregate(BaseModel):
     reference_forecast: :py:class:`solarforecastarbiter.datamodel.Forecast` or None
     normalization: float
     cost_per_unit_error: float
-    data_object: :py:class:`solarforecastarbiter.datamodel.Aggregate`
     """  # NOQA
     forecast: Forecast
     aggregate: Aggregate

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -619,9 +619,10 @@ def rank_histogram():
 def raw_report_plots(report, metrics):
     """Create a RawReportPlots object from the metrics of a report.
 
-     Parameters
+    Parameters
     ----------
     report: :py:class:`solarforecastarbiter.datamodel.Report`
+    metrics: tuple of :py:class:`solarforecastarbiter.datamodel.MetricResult`
 
     Returns
     -------

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -45,7 +45,7 @@ def construct_timeseries_cds(report):
 
     Parameters
     ----------
-    report: solarforecastarbiter.datamodel.Report
+    report: :py:class:`solarforecastarbiter.datamodel.Report`
 
     Returns
     -------
@@ -154,10 +154,10 @@ def timeseries(timeseries_value_cds, timeseries_meta_cds,
 
     Parameters
     ----------
-    obs_fx_cds : list
-        List of (ProcessedForecastObservation, ColumnDataSource) tuples.
-        ColumnDataSource must have columns timestamp, observation,
-        forecast.
+    timeseries_value_cds: bokeh.models.ColumnDataSource
+        ColumnDataSource of timeseries data. See :py:func:`solarforecastarbiter.reports.reoports.figures.construct_timeseries_cds` for format.
+    timeseries_meta_cds: bokeh.models.ColumnDataSource
+        ColumnDataSource of metadata for each Observation Forecast pair. See :py:func:`solarforecastarbiter.reports.reoports.figures.construct_timeseries_cds` for format.
     start : pandas.Timestamp
         Report start time
     end : pandas.Timestamp
@@ -168,8 +168,7 @@ def timeseries(timeseries_value_cds, timeseries_meta_cds,
     Returns
     -------
     fig : bokeh.plotting.figure
-    """
-
+    """  # NOQA
     palette = cycle(PALETTE)
 
     fig = figure(
@@ -247,15 +246,19 @@ def scatter(timeseries_value_cds, timeseries_meta_cds, units):
 
     Parameters
     ----------
-    obs_fx_cds : list
-        List of (ProcessedForecastObservation, ColumnDataSource) tuples.
-        ColumnDataSource must have columns timestamp, observation,
-        forecast.
+    timeseries_value_cds: bokeh.models.ColumnDataSource
+        ColumnDataSource of timeseries data. See
+        :py:func:`solarforecastarbiter.reports.reoports.figures.construct_timeseries_cds`
+        for format.
+    timeseries_meta_cds: bokeh.models.ColumnDataSource
+        ColumnDataSource of metadata for each Observation Forecast pair. See
+        :py:func:`solarforecastarbiter.reports.reoports.figures.construct_timeseries_cds`
+        for format.
 
     Returns
     -------
     fig : bokeh.plotting.figure
-    """
+    """  # NOQA
     xy_min, xy_max = _get_scatter_limits(timeseries_value_cds)
 
     # match_aspect=True does not work well, so these need to be close
@@ -319,17 +322,14 @@ def construct_metrics_cds(metrics, rename=None):
     metrics : list of datamodel.MetricResults
         Each metric dict is for a different forecast. Forecast name is
         specified by the name key.
-    kind : str
-        One of the available metrics grouping categories (e.g., total)
-    index : str
-        Determines if the index is the array of metrics ('metric') or
-        forecast ('forecast') names
     rename : function or None
         Function of one argument that is applied to each forecast name.
 
     Returns
     -------
     cds : bokeh.models.ColumnDataSource
+        ColumnDataSource with indices 'name', 'abbrev', 'category', 'metric',
+        and 'value'.
     """
 
     if rename:
@@ -383,12 +383,14 @@ def bar(cds, metric):
     Parameters
     ----------
     cds : bokeh.models.ColumnDataSource
-        Fields must be 'forecast' and the names of the metrics
+        Metric cds created by :py:func:`solarforecastarbiter.reports.figures.construct_metrics_cds`
+    metric: str
+        The metric to plot. This value should be found in cds['metric'].
 .
     Returns
     -------
     data_table : bokeh.widgets.DataTable
-    """
+    """  # NOQA
     x_range = np.unique(cds.data['abbrev'])
     palette = cycle(PALETTE)
     palette = [next(palette) for _ in x_range]
@@ -615,6 +617,16 @@ def rank_histogram():
 
 
 def raw_report_plots(report, metrics):
+    """Create a RawReportPlots object from the metrics of a report.
+
+     Parameters
+    ----------
+    report: :py:class:`solarforecastarbiter.datamodel.Report`
+
+    Returns
+    -------
+    :py:class:`solarforecastarbiter.datamodel.RawReportPlots`
+    """
     cds = construct_metrics_cds(metrics, rename=abbreviate)
     # Create initial bar figures
     figure_dict = {}
@@ -643,6 +655,20 @@ def raw_report_plots(report, metrics):
 
 
 def timeseries_plots(report):
+    """Return the bokeh components (script and div element) for timeseries
+    plots of the processed forecasts and observations.
+
+    Parameters
+    ----------
+    report: :py:class:`solarforecastarbiter.datamodel.Report`
+
+    Returns
+    -------
+    script: str
+        A script element to insert into an html template
+    div: str
+        A div element to insert into an html template.
+    """
     value_cds, meta_cds = construct_timeseries_cds(report)
     units = report.forecast_observations[0].forecast.units
     tfig = timeseries(value_cds, meta_cds, report.start, report.end, units,

--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -55,7 +55,7 @@ def construct_timeseries_cds(report):
         `forecast_values`.
 
     metadata_cds : bokeh.models.ColumnDataSource
-       This cds has the following keys:
+        This cds has the following keys:
         `pair_index` : Integer for pairing metadata with the values in
             the value_cds.
         `observation_name`: Observation name.

--- a/solarforecastarbiter/reports/main.py
+++ b/solarforecastarbiter/reports/main.py
@@ -71,9 +71,9 @@ def get_data_for_report(session, report):
 
     Parameters
     ----------
-    session : solarforecastarbiter.api.APISession
+    session : :py:class:`solarforecastarbiter.api.APISession`
         API session for getting and posting data
-    report : solarforecastarbiter.datamodel.Report
+    report : :py:class:`solarforecastarbiter.datamodel.Report`
         Metadata describing report
 
     Returns
@@ -102,7 +102,7 @@ def create_metadata(report_request):
 
     Returns
     -------
-    metadata: solarforecastarbiter.datamodel.ReportMetadata
+    metadata: :py:class:`solarforecastarbiter.datamodel.ReportMetadata`
     """
     versions = get_versions()
     timezone = infer_timezone(report_request)
@@ -188,7 +188,7 @@ def create_raw_report_from_data(report, data):
 
     Parameters
     ----------
-    report : solarforecastarbiter.datamodel.Report
+    report : :py:class:`solarforecastarbiter.datamodel.Report`
         Metadata describing report
     data : dict
         Keys are all Forecast and Observation objects in the report,
@@ -196,7 +196,7 @@ def create_raw_report_from_data(report, data):
 
     Returns
     -------
-    raw_report : datamodel.RawReport
+    raw_report : :py:class:`solarforecastarbiterdatamodel.RawReport`
 
     Todo
     ----
@@ -236,7 +236,7 @@ def compute_report(access_token, report_id, base_url=None):
 
     Parameters
     ----------
-    session : solarforecastarbiter.api.APISession
+    session : :py:class:`solarforecastarbiter.api.APISession`
         API session for getting and posting data
     report_id : str
         ID of the report to fetch from the API and generate the raw
@@ -244,7 +244,7 @@ def compute_report(access_token, report_id, base_url=None):
 
     Returns
     -------
-    raw_report : datamodel.RawReport
+    raw_report : :py:class:`solarforecastarbiter.datamodel.RawReport`
     """
     session = APISession(access_token, base_url=base_url)
     try:

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -69,9 +69,9 @@ def get_template_and_kwargs(report, dash_url, with_timeseries, body_only):
     with_timeseries: bool
         Whether or not to include timeseries plots.
     body_only: bool
-        When True, returns a standalone report template with the required
-        <html> and <head> tags. Otherwise returns a div for injecting into
-        another template.
+        When True, returns a div for injecting into another template,
+        otherwise returns a standalone report template with the required
+        <html> and <head> tags.
 
     Returns
     -------
@@ -109,9 +109,9 @@ def render_html(report, dash_url='https://dashboard.solarforecastarbiter.org',
     with_timeseries: bool
         Whether or not to include timeseries plots.
     body_only: bool
-        When True, returns a standalone report template with the required
-        <html> and <head> tags. Otherwise returns a div for injecting into
-        another template.
+        When True, returns a div for injecting into another template,
+        otherwise returns a standalone report template with the required
+        <html> and <head> tags.
 
     Returns
     -------

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -15,6 +15,25 @@ logger = logging.getLogger(__name__)
 
 
 def _get_render_kwargs(report, dash_url, with_timeseries):
+    """Creates a dictionary of key word template arguments for a jinja2
+    report template.
+
+    Parameters
+    ----------
+    report: :py:class:`solarforecastarbiter.datamodel.Report`
+    dash_url: str
+        URL of the Solar Forecast arbiter dashboard to use when building links.
+    with_timeseries: bool
+        Whether or not to include timeseries plots. If an error occurs, sets
+        `timeseries_script` to an empty string and `timeseries_div` will
+        contain a <div> element for warning the user of the failure.
+
+    Returns
+    -------
+    kwargs: dict
+        Dictionary of template variables to unpack as key word arguments when
+        rendering.
+    """
     kwargs = dict(
         human_categories=datamodel.ALLOWED_CATEGORIES,
         human_metrics=datamodel.ALLOWED_METRICS,
@@ -39,6 +58,28 @@ def _get_render_kwargs(report, dash_url, with_timeseries):
 
 
 def get_template_and_kwargs(report, dash_url, with_timeseries, body_only):
+    """Returns the jinja2 Template object and a dict of template variables for
+    the report.
+
+    Parameters
+    ----------
+    report: :py:class:`solarforecastarbiter.datamodel.Report`
+    dash_url: str
+        URL of the Solar Forecast arbiter dashboard to use when building links.
+    with_timeseries: bool
+        Whether or not to include timeseries plots.
+    body_only: bool
+        When True, returns a standalone report template with the required
+        <html> and <head> tags. Otherwise returns a div for injecting into
+        another template.
+
+    Returns
+    -------
+    template: jinja2.environment.Template
+    kwargs: dict
+        Dictionary of template variables to use as keyword arguments to
+        template.render().
+    """
     env = Environment(
         loader=PackageLoader('solarforecastarbiter.reports', 'templates'),
         autoescape=select_autoescape(['html', 'xml']),
@@ -62,12 +103,20 @@ def render_html(report, dash_url='https://dashboard.solarforecastarbiter.org',
 
     Parameters
     ----------
-    body : html
+    report: :py:class:`solarforecastarbiter.datamodel.Report`
+    dash_url: str
+        URL of the Solar Forecast arbiter dashboard to use when building links.
+    with_timeseries: bool
+        Whether or not to include timeseries plots.
+    body_only: bool
+        When True, returns a standalone report template with the required
+        <html> and <head> tags. Otherwise returns a div for injecting into
+        another template.
 
     Returns
     -------
-        head : str, html
-        Header for the full report.
+    str
+        The rendered html report
     """
     template, kwargs = get_template_and_kwargs(
         report, dash_url, with_timeseries, body_only)

--- a/solarforecastarbiter/reports/tests/test_macros.py
+++ b/solarforecastarbiter/reports/tests/test_macros.py
@@ -8,7 +8,7 @@ from solarforecastarbiter import datamodel
 @pytest.fixture
 def macro_test_template():
     def fn(macro_name_and_args):
-        macro_template = f"{{% import 'macros.j2' as macros with context%}}{{{{macros.{macro_name_and_args} | safe }}}}"  # noqa
+        macro_template = f"{{% import 'macros.j2' as macros with context%}}{{{{macros.{macro_name_and_args} | safe }}}}"
         env = Environment(
             loader=PackageLoader('solarforecastarbiter.reports', 'templates'),
             autoescape=select_autoescape(['html', 'xml']),
@@ -40,12 +40,12 @@ metric_format = """<table style="width:100%;">
 </table>
 """
 
-
 def test_metric_table(report_with_raw, macro_test_template):
     metric_table_template = macro_test_template('metric_table(report_metrics,category,metric_ordering)')  # noqa
     metrics = report_with_raw.raw_report.metrics
     category = 'total'
     for i in range(3):
+
         expected_metric = (metrics[i],)
         rendered_metric_table = metric_table_template.render(
             report_metrics=expected_metric,

--- a/solarforecastarbiter/reports/tests/test_macros.py
+++ b/solarforecastarbiter/reports/tests/test_macros.py
@@ -8,7 +8,7 @@ from solarforecastarbiter import datamodel
 @pytest.fixture
 def macro_test_template():
     def fn(macro_name_and_args):
-        macro_template = f"{{% import 'macros.j2' as macros with context%}}{{{{macros.{macro_name_and_args} | safe }}}}"
+        macro_template = f"{{% import 'macros.j2' as macros with context%}}{{{{macros.{macro_name_and_args} | safe }}}}"  # noqa
         env = Environment(
             loader=PackageLoader('solarforecastarbiter.reports', 'templates'),
             autoescape=select_autoescape(['html', 'xml']),
@@ -40,12 +40,12 @@ metric_format = """<table style="width:100%;">
 </table>
 """
 
+
 def test_metric_table(report_with_raw, macro_test_template):
     metric_table_template = macro_test_template('metric_table(report_metrics,category,metric_ordering)')  # noqa
     metrics = report_with_raw.raw_report.metrics
     category = 'total'
     for i in range(3):
-
         expected_metric = (metrics[i],)
         rendered_metric_table = metric_table_template.render(
             report_metrics=expected_metric,


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [ ] Closes #xxxx .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked 

To  be merged following #305, I updated docstrings in the reports module and added parameters for all non-private objects found in datamodel. There are some spotty linking issues in the sphinx rendering I hope to figure out.
