### PR TITLE
metrics: test timezone behavior

### DIFF
--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -171,6 +171,52 @@ def test_resample_and_align_interval_label(site_metadata, label_obs, label_fx,
     assert obs_out.index.freq == freq
 
 
+@pytest.mark.parametrize("interval_label", ["beginning", "instant", "ending"])
+@pytest.mark.parametrize("tz,local_tz,local_ts", [
+    ("UTC", "UTC", ["20190702T0000", "20190702T0100"]),
+    ("UTC", "US/Pacific", ["20190701T1700", "20190701T1800"]),
+    ("US/Pacific", "UTC", ["20190702T0700", "20190702T0800"]),
+    ("US/Central", "US/Pacific", ["20190701T2200", "20190701T2300"]),
+    ("US/Pacific", "US/Eastern", ["20190702T0300", "20190702T0400"]),
+])
+def test_resample_and_align_timezone(site_metadata, interval_label, tz,
+                                     local_tz, local_ts):
+
+    expected_dt = pd.DatetimeIndex(local_ts, tz=local_tz)
+
+    # Create the fx/obs pair
+    ts = pd.DatetimeIndex(["20190702T0000", "20190702T0100"], tz=tz)
+    fx_series = pd.Series([1.0, 4.0], index=ts, name="value")
+    obs_series = pd.Series([1.1, 2.7], index=ts, name="value")
+    observation = datamodel.Observation(
+        site=site_metadata, name='dummy obs', variable='ghi',
+        interval_value_type='instantaneous', uncertainty=1,
+        interval_length=pd.Timedelta(obs_series.index.freq),
+        interval_label=interval_label,
+    )
+    forecast = datamodel.Forecast(
+        site=site_metadata, name='dummy fx', variable='ghi',
+        interval_value_type='instantaneous',
+        interval_length=pd.Timedelta(fx_series.index.freq),
+        interval_label=interval_label,
+        issue_time_of_day=dt.time(hour=5),
+        lead_time_to_start=pd.Timedelta('1h'),
+        run_length=pd.Timedelta('12h')
+    )
+    fx_obs = datamodel.ForecastObservation(forecast=forecast,
+                                           observation=observation)
+
+    forecast_values, observation_values = preprocessing.resample_and_align(
+        fx_obs, fx_series, obs_series, local_tz)
+
+    pd.testing.assert_index_equal(forecast_values.index,
+                                  observation_values.index,
+                                  check_categorical=False)
+    pd.testing.assert_index_equal(observation_values.index,
+                                  expected_dt,
+                                  check_categorical=False)
+
+
 @pytest.mark.parametrize('obs,somecounts', [
     (pd.DataFrame(index=pd.DatetimeIndex([], name='timestamp'),
                   columns=['value', 'quality_flag']),


### PR DESCRIPTION
  - [x] Closes #298 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This PR adds tests for `metrics.preprocessing` and `metrics.calculator` functions to ensure that report timezones are respected when computing and reporting metric results (e.g. RMSE per hour of the day should use the timezone from the report, not the site). Based on review of the code (as noted in #298), the `metrics` functions appear to already properly convert the fx/obs pairs to the local timezone from the report. However, there were no tests that explicitly confirmed this behavior. Hence this PR.