### PR TITLE
template failed reports and report dicts

### DIFF
--- a/docs/source/whatsnew/1.0.0b4.rst
+++ b/docs/source/whatsnew/1.0.0b4.rst
@@ -25,6 +25,7 @@ timeseries and metadata.
 * Add the :py:class:`solarforecastarbiter.datamodel.ReportParameters` class, add the ``report_parameters`` parameters to :py:class:`solarforecastarbiter.datamodel.Report`, and moved most parameters
 * Remove the ``ReportMetadata`` class and moved some parameters to :py:class:`solarforecastarbiter.datamodel.RawReport`
 * Remove :py:func:`solarforecastarbiter.reports.main.create_metadata`
+* :py:func:`solarforecastarbiter.reports.main.get_versions` now returns a tuple of (package, version) tuples
 
 Enhancements
 ~~~~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0b4.rst
+++ b/docs/source/whatsnew/1.0.0b4.rst
@@ -37,6 +37,7 @@ Enhancements
 * Add missing tests for :py:mod:`solarforecastarbiter.reports.figures`
 * Add data validation summary table in the html report (:issue:`299`) (:pull:`320`)
 * Track data preprocessing results add section and summary table in the html report (:issue:`299`) (:pull:`320`)
+* Generate error page templates for failed reports.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0b4.rst
+++ b/docs/source/whatsnew/1.0.0b4.rst
@@ -25,7 +25,7 @@ timeseries and metadata.
 * Add the :py:class:`solarforecastarbiter.datamodel.ReportParameters` class, add the ``report_parameters`` parameters to :py:class:`solarforecastarbiter.datamodel.Report`, and moved most parameters
 * Remove the ``ReportMetadata`` class and moved some parameters to :py:class:`solarforecastarbiter.datamodel.RawReport`
 * Remove :py:func:`solarforecastarbiter.reports.main.create_metadata`
-* :py:func:`solarforecastarbiter.reports.main.get_versions` now returns a tuple of (package, version) tuples
+* :py:func:`solarforecastarbiter.reports.main.get_versions` now returns a tuple of (package, version) tuples (:pull:`325`)
 
 Enhancements
 ~~~~~~~~~~~~
@@ -37,7 +37,7 @@ Enhancements
 * Add missing tests for :py:mod:`solarforecastarbiter.reports.figures`
 * Add data validation summary table in the html report (:issue:`299`) (:pull:`320`)
 * Track data preprocessing results add section and summary table in the html report (:issue:`299`) (:pull:`320`)
-* Generate error page templates for failed reports.
+* Generate error page templates for failed reports. (:pull:`325`)
 
 Bug fixes
 ~~~~~~~~~

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1433,8 +1433,31 @@ def raw_report(report_objects, report_metrics, preprocessing_result_types):
 @pytest.fixture
 def report_with_raw(report_dict, raw_report):
     report_dict['raw_report'] = raw_report(True)
+    report_dict['status'] = 'complete'
     report = datamodel.Report.from_dict(report_dict)
     return report
+
+
+@pytest.fixture()
+def failed_report(report_dict):
+    report_dict['raw_report'] = datamodel.RawReport(
+        generated_at=pd.Timestamp.utcnow(), timezone='UTC',
+        versions=(), plots=None, metrics=(),
+        processed_forecasts_observations=(),
+        messages=(datamodel.ReportMessage(message='Report Failed',
+                                          step='make',
+                                          level='CRITICAL',
+                                          function='fn'))
+    )
+    report_dict['status'] = 'failed'
+    return datamodel.Report.from_dict(report_dict)
+
+
+@pytest.fixture()
+def pending_report(report_dict):
+    report_dict['status'] = 'pending'
+    report_dict['raw_report'] = None
+    return datamodel.Report.from_dict(report_dict)
 
 
 @pytest.fixture()

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1421,7 +1421,7 @@ def raw_report(report_objects, report_metrics, preprocessing_result_types):
         )
         raw = datamodel.RawReport(
             generated_at=report.report_parameters.end,
-            versions={},
+            versions=(),
             timezone=obs.site.timezone,
             plots=figs,
             metrics=report_metrics(report),
@@ -1741,7 +1741,7 @@ def report_metadata_dict():
         'end': '2019-01-02T00:00Z',
         'now': '2019-01-03T00:00Z',
         'timezone': 'America/Pheonix',
-        'versions': {}
+        'versions': (),
     }
 
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1303,8 +1303,8 @@ class RawReport(BaseModel):
     """  # NOQA
     generated_at: pd.Timestamp
     timezone: str
-    versions: dict
     plots: RawReportPlots
+    versions: Tuple[Tuple[str, str], ...]
     metrics: Tuple[MetricResult, ...]
     processed_forecasts_observations: Tuple[ProcessedForecastObservation, ...]
     messages: Tuple[ReportMessage, ...] = ()

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1303,8 +1303,8 @@ class RawReport(BaseModel):
     """  # NOQA
     generated_at: pd.Timestamp
     timezone: str
-    plots: RawReportPlots
     versions: Tuple[Tuple[str, str], ...]
+    plots: RawReportPlots
     metrics: Tuple[MetricResult, ...]
     processed_forecasts_observations: Tuple[ProcessedForecastObservation, ...]
     messages: Tuple[ReportMessage, ...] = ()

--- a/solarforecastarbiter/reports/main.py
+++ b/solarforecastarbiter/reports/main.py
@@ -113,16 +113,16 @@ def get_versions():
         'bottleneck',
         'jinja2',
     ]
-    versions = {}
+    versions = []
     for p in packages:
         try:
             v = pkg_resources.get_distribution(p).version
         except pkg_resources.DistributionNotFound:
             v = 'None'
-        versions[p] = v
-    versions['python'] = platform.python_version()
-    versions['platform'] = platform.platform()
-    return versions
+        versions.append((p, str(v)))
+    versions.append(('python', str(platform.python_version())))
+    versions.append(('platform', platform.platform()))
+    return tuple(versions)
 
 
 def infer_timezone(report_parameters):
@@ -280,8 +280,8 @@ def capture_report_failure(report_id, session):
                     function=str(f)
                 )
                 raw = datamodel.RawReport(
-                    pd.Timestamp.now(tz='UTC'), 'UTC', {}, {},
-                    [], [], (msg,))
+                    pd.Timestamp.now(tz='UTC'), 'UTC', (), {},
+                    (), (), (msg,))
                 session.post_raw_report(report_id, raw, 'failed')
                 raise
             else:

--- a/solarforecastarbiter/reports/main.py
+++ b/solarforecastarbiter/reports/main.py
@@ -280,7 +280,7 @@ def capture_report_failure(report_id, session):
                     function=str(f)
                 )
                 raw = datamodel.RawReport(
-                    pd.Timestamp.now(tz='UTC'), 'UTC', (), {},
+                    pd.Timestamp.now(tz='UTC'), 'UTC', (), None,
                     (), (), (msg,))
                 session.post_raw_report(report_id, raw, 'failed')
                 raise

--- a/solarforecastarbiter/reports/templates/base.html
+++ b/solarforecastarbiter/reports/templates/base.html
@@ -8,7 +8,7 @@
       <div class="container">
         <div class="row">
           <div class="content col-md-9 col-sm-12">
-            {% include "body.html" %}
+            {% block body %}{% endblock %}
           </div>
         </div>
       </div>

--- a/solarforecastarbiter/reports/templates/body.html
+++ b/solarforecastarbiter/reports/templates/body.html
@@ -1,6 +1,8 @@
+{% extends base_template %}
 {% import "macros.j2" as macros with context %}
 {% set report_name = report.report_parameters.name %}
 
+{% block body %}
 {% block report_title %}
 <h1 id="report-title">{{ report_name }}</h1>
 {% endblock %}
@@ -149,4 +151,5 @@ generate a new report after the data provider submits new data.
 {% block versions %}
 <h2 id="versions">Versions</h2>
 {% include "versions.html" %}
+{% endblock %}
 {% endblock %}

--- a/solarforecastarbiter/reports/templates/empty_base.html
+++ b/solarforecastarbiter/reports/templates/empty_base.html
@@ -1,0 +1,1 @@
+{% block body %}{% endblock %}

--- a/solarforecastarbiter/reports/templates/failure.html
+++ b/solarforecastarbiter/reports/templates/failure.html
@@ -1,0 +1,21 @@
+{% extends base_template %}
+{% block body %}
+{% block report_title %}
+<h1 id="report-title">{{ report.report_parameters.name }}</h1>
+{% endblock %}
+<ul>
+  <li>Start: {{ report.report_parameters.start }}</li>
+  <li>End: {{ report.report_parameters.end }}</li>
+  <li>Generated at: {{ report.raw_report.generated_at }}</li>
+</ul>
+{% block errors %}
+<div class="alert alert-danger">
+<h2>Report generation failed</h2>
+{% if report.raw_report.messages| length > 0 %}
+  {% for mesg in report.raw_report.messages %}
+  <h5>{{ mesg.message }}</h5>
+  {% endfor %}
+{% endif %}
+</div>
+{% endblock %}
+{% endblock %}

--- a/solarforecastarbiter/reports/templates/pending.html
+++ b/solarforecastarbiter/reports/templates/pending.html
@@ -1,0 +1,12 @@
+{% extends base_template %}
+{% block body %}
+{% block report_title %}
+<h1 id="report-title">{{ report.report_parameters.name }}</h1>
+{% endblock %}
+<p>Report generation is pending.</p>
+<ul>
+  <li>Start: {{ report.report_parameters.start }}</li>
+  <li>End: {{ report.report_parameters.end }}</li>
+  <li>Generated at: {{ report.raw_report.generated_at }}</li>
+</ul>
+{% endblock %}

--- a/solarforecastarbiter/reports/templates/pending.html
+++ b/solarforecastarbiter/reports/templates/pending.html
@@ -3,10 +3,8 @@
 {% block report_title %}
 <h1 id="report-title">{{ report.report_parameters.name }}</h1>
 {% endblock %}
-<p>Report generation is pending.</p>
-<ul>
-  <li>Start: {{ report.report_parameters.start }}</li>
-  <li>End: {{ report.report_parameters.end }}</li>
-  <li>Generated at: {{ report.raw_report.generated_at }}</li>
-</ul>
+<div class="alert alert-info">
+  Report generation is pending. We will try and fetch the report again in 30 seconds, or you can try reloading this page.
+</div>
+<script>setInterval(function () {  window.location.reload(); }, 30000);</script>
 {% endblock %}

--- a/solarforecastarbiter/reports/templates/versions.html
+++ b/solarforecastarbiter/reports/templates/versions.html
@@ -7,10 +7,10 @@
     </tr>
   </thead>
   <tbody>
-{% for pkg, ver in report.raw_report.versions.items() | sort(attribute='0') %}
+{% for pkg_ver in report.raw_report.versions %}
   <tr>
-    <td style="text-align: left;">{{ pkg }}</td>
-    <td style="text-align: left;">{{ ver }}</td>
+    <td style="text-align: left;">{{ pkg_ver[0] }}</td>
+    <td style="text-align: left;">{{ pkg_ver[1] }}</td>
   </tr>
 {% endfor %}
   </tbody>

--- a/solarforecastarbiter/reports/tests/test_reports_main.py
+++ b/solarforecastarbiter/reports/tests/test_reports_main.py
@@ -212,6 +212,20 @@ def test_capture_report_failure(mocker):
     assert api_post.call_args_list[1][0][0] == '/reports/report_id/status/failed'  # NOQA
 
 
+def test_capture_report_failure_is_valid_datamodel(mocker):
+    api_post = mocker.patch('solarforecastarbiter.io.api.APISession.post')
+
+    def fail():
+        raise TypeError()
+
+    session = api.APISession('nope')
+    failwrap = main.capture_report_failure('report_id', session)
+    with pytest.raises(TypeError):
+        failwrap(fail)()
+    raw = datamodel.RawReport.from_dict(api_post.call_args_list[0][1]['json'])
+    assert 'CRITICAL' == raw.messages[0].level
+
+
 def test_capture_report_failure_msg(mocker):
     api_post = mocker.patch('solarforecastarbiter.io.api.APISession.post')
 

--- a/solarforecastarbiter/reports/tests/test_reports_main.py
+++ b/solarforecastarbiter/reports/tests/test_reports_main.py
@@ -79,7 +79,7 @@ def test_get_data_for_report(mock_data, report_objects):
 
 def test_get_version():
     vers = main.get_versions()
-    assert set(vers.keys()) > {'solarforecastarbiter', 'python'}
+    assert {v[0] for v in vers} > {'solarforecastarbiter', 'python'}
 
 
 def test_infer_timezone(report_objects):

--- a/solarforecastarbiter/reports/tests/test_template.py
+++ b/solarforecastarbiter/reports/tests/test_template.py
@@ -31,13 +31,15 @@ def with_series(request):
 
 @pytest.fixture
 def expected_kwargs(report_with_raw, dash_url):
-    def fn(with_series):
+    def fn(with_series, with_report=True):
         kwargs = {}
         kwargs['human_categories'] = datamodel.ALLOWED_CATEGORIES
         kwargs['human_metrics'] = datamodel.ALLOWED_METRICS
         kwargs['category_blurbs'] = datamodel.CATEGORY_BLURBS
-        kwargs['report'] = report_with_raw
+        if with_report:
+            kwargs['report'] = report_with_raw
         kwargs['dash_url'] = dash_url
+
         version = report_with_raw.raw_report.plots.bokeh_version
         kwargs['bokeh_version'] = version
         if with_series:
@@ -58,6 +60,22 @@ def test__get_render_kwargs_no_series(
     assert kwargs == expected_kwargs(with_series)
 
 
+def test__get_render_kwargs_pending(
+        mocked_timeseries_plots, pending_report, dash_url,
+        expected_kwargs, mocker):
+    mocker.patch('solarforecastarbiter.reports.template.bokeh_version',
+                 new='newest')
+    kwargs = template._get_render_kwargs(
+        pending_report,
+        dash_url,
+        False
+    )
+    exp = expected_kwargs(False)
+    exp['bokeh_version'] = 'newest'
+    exp['report'] = pending_report
+    assert kwargs == exp
+
+
 def test__get_render_kwargs_with_series_exception(
         report_with_raw, dash_url, mocked_timeseries_plots_exception):
     kwargs = template._get_render_kwargs(
@@ -72,24 +90,47 @@ def test__get_render_kwargs_with_series_exception(
     assert kwargs['timeseries_script'] == ''
 
 
+@pytest.fixture(params=[0, 1])
+def asdict(request):
+    return request.param
+
+
+@pytest.fixture(params=[0, 1, 2])
+def good_or_bad_report(request, report_with_raw, failed_report,
+                       pending_report, asdict):
+    if request.param == 0:
+        out = report_with_raw
+    elif request.param == 1:
+        out = failed_report
+    elif request.param == 2:
+        out = pending_report
+    if asdict:
+        out = out.to_dict()
+    return out
+
+
+@pytest.mark.parametrize('with_body', [True, False])
 def test_get_template_and_kwargs(
-        report_with_raw, dash_url, with_series, expected_kwargs,
-        mocked_timeseries_plots):
+        good_or_bad_report, dash_url, with_series, expected_kwargs,
+        mocked_timeseries_plots, with_body):
     html_template, kwargs = template.get_template_and_kwargs(
-        report_with_raw,
+        good_or_bad_report,
         dash_url,
         with_series,
-        True
+        with_body
     )
+    base = kwargs.pop('base_template')
+    kwargs.pop('report')
+    assert type(base) == jinja2.environment.Template
     assert type(html_template) == jinja2.environment.Template
-    assert kwargs == expected_kwargs(with_series)
+    assert kwargs == expected_kwargs(with_series, False)
 
 
 def test_render_html_body_only(report_with_raw, dash_url, with_series,
                                mocked_timeseries_plots):
     rendered = template.render_html(
         report_with_raw, dash_url, with_series, True)
-    assert rendered[1:23] == '<h1 id="report-title">'
+    assert rendered[:22] == '<h1 id="report-title">'
 
 
 def test_render_html_full_html(report_with_raw, dash_url, with_series,

--- a/solarforecastarbiter/reports/tests/test_template.py
+++ b/solarforecastarbiter/reports/tests/test_template.py
@@ -126,6 +126,15 @@ def test_get_template_and_kwargs(
     assert kwargs == expected_kwargs(with_series, False)
 
 
+def test_get_template_and_kwargs_bad_status(
+        report_with_raw, dash_url, mocked_timeseries_plots):
+    inp = report_with_raw.to_dict()
+    inp['status'] = 'notokay'
+    with pytest.raises(ValueError):
+        template.get_template_and_kwargs(
+            inp, dash_url, False, True)
+
+
 def test_render_html_body_only(report_with_raw, dash_url, with_series,
                                mocked_timeseries_plots):
     rendered = template.render_html(


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [ ] Closes #xxxx .
  - [ ] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
