### PR TITLE
retrieve units from processed_forecasts_observations instead of objec…

### DIFF
--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -707,7 +707,8 @@ def timeseries_plots(report):
         A div element to insert into an html template.
     """
     value_cds, meta_cds = construct_timeseries_cds(report)
-    units = report.report_parameters.object_pairs[0].forecast.units
+    pfxobs = report.raw_report.processed_forecasts_observations
+    units = pfxobs[0].original.forecast.units
     tfig = timeseries(value_cds, meta_cds, report.report_parameters.start,
                       report.report_parameters.end, units,
                       report.raw_report.timezone)


### PR DESCRIPTION
…t_pairs

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->


  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Minor update to `reports.figures.py` to avoid the need to load metadata into object_pairs when creating plots on the dashboard.