### PR TITLE
move metric table out of metric-plot-wrapper, so it isn't clobbered b…

### DIFF
--- a/solarforecastarbiter/reports/templates/body.html
+++ b/solarforecastarbiter/reports/templates/body.html
@@ -26,11 +26,13 @@
     <li><a href="#data-validation">Data Validation</a></li>
   </ul>
   <li><a href="#metrics">Metrics</a></li>
+  {% if include_metrics_toc | default(True) %}
   <ul>
     {% for category in report.report_parameters.categories %}
       <li><a href="#{{ category }}-analysis">{{ human_categories[category].title() }} Analysis</a></li>
     {% endfor %}
   </ul>
+  {% endif %}
   <li><a href="#versions">Versions</a></li>
 </ul>
 {% endblock %}
@@ -120,22 +122,21 @@ generate a new report after the data provider submits new data.
 {% block metrics %}
 <h2 id="metrics">Metrics</h2>
 <p>
-  Metrics are displayed in the tables and figures below.
+  A table of metrics over the entire study period and figures for the selected
+  categories are shown below.
   Metrics may be downloaded in CSV format by clicking
   <a href="javascript:download_metrics_as_csv('{{ report_name }}')">here</a>.
 </p>
 
+{{ macros.metric_table_fx_vert(report.raw_report.metrics, "total", report.report_parameters.metrics) }}
+
+<div id="metric-plot-wrapper">
 {% for category in report.report_parameters.categories %}
 <h3 id="{{ category }}-analysis">{{ human_categories[category].title() }} Analysis</h3>
   {% if category_blurbs is defined %}
 <p>{{ category_blurbs[category] }}</p>
   {% endif %}
-  {% if category == "total" %}
-    {{ macros.metric_table_fx_vert(report.raw_report.metrics, "total", report.report_parameters.metrics) }}
-  {% endif %}
 <br>
-
-<div id="metric-plot-wrapper">
   {% for metric in report.report_parameters.metrics %}
     {% for rep_fig in report.raw_report.plots.figures %}
       {% if rep_fig.category == category and rep_fig.metric == metric %}

--- a/solarforecastarbiter/reports/templates/body.html
+++ b/solarforecastarbiter/reports/templates/body.html
@@ -124,7 +124,7 @@ generate a new report after the data provider submits new data.
   Metrics may be downloaded in CSV format by clicking
   <a href="javascript:download_metrics_as_csv('{{ report_name }}')">here</a>.
 </p>
-<div id="metric-plot-wrapper">
+
 {% for category in report.report_parameters.categories %}
 <h3 id="{{ category }}-analysis">{{ human_categories[category].title() }} Analysis</h3>
   {% if category_blurbs is defined %}
@@ -134,6 +134,8 @@ generate a new report after the data provider submits new data.
     {{ macros.metric_table_fx_vert(report.raw_report.metrics, "total", report.report_parameters.metrics) }}
   {% endif %}
 <br>
+
+<div id="metric-plot-wrapper">
   {% for metric in report.report_parameters.metrics %}
     {% for rep_fig in report.raw_report.plots.figures %}
       {% if rep_fig.category == category and rep_fig.metric == metric %}


### PR DESCRIPTION
…y js

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [ ] Closes #xxxx .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
The `#metric-plot-wrapper` div was introduced as a target for the dashboard's javascript sorting code. This moves the metric table outside of that div, so it isn't overwritten when viewed on the dashboard.
