### PR TITLE
only split figure names twice

### DIFF
--- a/solarforecastarbiter/reports/figures.py
+++ b/solarforecastarbiter/reports/figures.py
@@ -681,7 +681,7 @@ def raw_report_plots(report, metrics):
     script, divs = components(figure_dict)
     mplots = []
     for k, v in divs.items():
-        cat, met, name = k.split('_')
+        cat, met, name = k.split('_', 2)
         fig = figure_dict[k]
         svg = output_svg(fig)
         mplots.append(datamodel.ReportFigure(


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #337  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Handles case where a name containing underscore causes split to return too many values.