### PR TITLE
metrics: add event forecast metrics

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -474,6 +474,21 @@ Functions to compute forecast probabilistic performance metrics:
     metrics.probabilistic.sharpness
     metrics.probabilistic.continuous_ranked_probability_score
 
+Event
+-----
+
+Functions to compute deterministic event forecast performance metrics:
+
+.. autosummary::
+    :toctree: generated/
+
+    metrics.event.probability_of_detection
+    metrics.event.false_alarm_ratio
+    metrics.event.probability_of_false_detection
+    metrics.event.critical_success_index
+    metrics.event.event_bias
+    metrics.event.event_accuracy
+
 Value
 -----
 

--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -11,6 +11,14 @@ API Changes
 * :py:func:`solarforecastarbiter.reports.figures.output_svg` now takes a
   :py:class:`selenium.webdriver.remote.webdriver.WebDriver` as an optional
   argument (:pull:`345`)
+* Add metrics for deterministic event forecasts
+  :py:mod:`solarforecastarbiter.metrics.event.probability_of_detection`,
+  :py:mod:`solarforecastarbiter.metrics.event.false_alarm_ratio`,
+  :py:mod:`solarforecastarbiter.metrics.event.probability_of_false_detection`,
+  :py:mod:`solarforecastarbiter.metrics.event.critical_success_index`,
+  :py:mod:`solarforecastarbiter.metrics.event.event_bias`, and
+  :py:mod:`solarforecastarbiter.metrics.event.event_accuracy`. (:issue:`347`) (:pull:`348`)
+
 
 Enhancements
 ~~~~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -12,12 +12,12 @@ API Changes
   :py:class:`selenium.webdriver.remote.webdriver.WebDriver` as an optional
   argument (:pull:`345`)
 * Add metrics for deterministic event forecasts
-  :py:mod:`solarforecastarbiter.metrics.event.probability_of_detection`,
-  :py:mod:`solarforecastarbiter.metrics.event.false_alarm_ratio`,
-  :py:mod:`solarforecastarbiter.metrics.event.probability_of_false_detection`,
-  :py:mod:`solarforecastarbiter.metrics.event.critical_success_index`,
-  :py:mod:`solarforecastarbiter.metrics.event.event_bias`, and
-  :py:mod:`solarforecastarbiter.metrics.event.event_accuracy`. (:issue:`347`) (:pull:`348`)
+  :py:func:`solarforecastarbiter.metrics.event.probability_of_detection`,
+  :py:func:`solarforecastarbiter.metrics.event.false_alarm_ratio`,
+  :py:func:`solarforecastarbiter.metrics.event.probability_of_false_detection`,
+  :py:func:`solarforecastarbiter.metrics.event.critical_success_index`,
+  :py:func:`solarforecastarbiter.metrics.event.event_bias`, and
+  :py:func:`solarforecastarbiter.metrics.event.event_accuracy`. (:issue:`347`) (:pull:`348`)
 
 
 Enhancements

--- a/solarforecastarbiter/metrics/event.py
+++ b/solarforecastarbiter/metrics/event.py
@@ -1,0 +1,33 @@
+"""Event forecast error metrics."""
+
+import numpy as np
+
+
+def probability_of_detection(obs, fx):
+    """Probability of Detection (POD)."""
+    pass
+
+
+def false_alarm_ratio(obs, fx):
+    """False Alarm Ratio (FAR)."""
+    pass
+
+
+def probability_of_false_detection(obs, fx):
+    """Probability of False Detection (POFD)."""
+    pass
+
+
+def critical_success_index(obs, fx):
+    """Critical Success Index (CSI)."""
+    pass
+
+
+def event_bias(obs, fx):
+    """Event Bias (EBIAS)."""
+    pass
+
+
+def event_accuracy(obs, fx):
+    """Event Accuracy (EA)."""
+    pass

--- a/solarforecastarbiter/metrics/event.py
+++ b/solarforecastarbiter/metrics/event.py
@@ -209,3 +209,22 @@ def event_accuracy(obs, fx):
     n = len(obs)
     tp, fp, tn, fn = _event2count(obs, fx)
     return (tp + tn) / n
+
+
+# Add new metrics to this map to map shorthand to function
+_MAP = {
+    'pod': (probability_of_detection, 'POD'),
+    'far': (false_alarm_ratio, 'FAR'),
+    'pofd': (probability_of_false_detection, 'POFD'),
+    'csi': (critical_success_index, 'CSI'),
+    'ebias': (event_bias, 'EBIAS'),
+    'ea': (event_accuracy, 'EA')
+}
+
+__all__ = [m[0].__name__ for m in _MAP.values()]
+
+# Functions that require a reference forecast
+_REQ_REF_FX = []
+
+# Functions that require normalized factor
+_REQ_NORM = []

--- a/solarforecastarbiter/metrics/event.py
+++ b/solarforecastarbiter/metrics/event.py
@@ -35,7 +35,8 @@ def _event2count(obs, fx):
     Raises
     ------
     RuntimeError
-        If there is no forecast or observation timeseries data.
+        If there is no forecast or observation timeseries data, or the forecast
+        and observation timeseries data do not have the same length.
 
     """
 

--- a/solarforecastarbiter/metrics/event.py
+++ b/solarforecastarbiter/metrics/event.py
@@ -39,10 +39,8 @@ def _event2count(obs, fx):
 
     """
 
-    if isinstance(obs, (list, tuple)):
-        obs = np.array(obs)
-    if isinstance(fx, (list, tuple)):
-        fx = np.array(fx)
+    obs = np.asarray(obs)
+    fx = np.asarray(fx)
 
     if len(obs) == 0:
         raise RuntimeError("No Observation timeseries data.")
@@ -136,7 +134,7 @@ def probability_of_false_detection(obs, fx):
 def critical_success_index(obs, fx):
     """Critical Success Index (CSI).
 
-    .. math:: \\text{CSI} = \\text{TP} / (\\text{TP} + \\text{FN} + \\text{FN})
+    .. math:: \\text{CSI} = \\text{TP} / (\\text{TP} + \\text{FP} + \\text{FN})
 
     Parameters
     ----------

--- a/solarforecastarbiter/metrics/event.py
+++ b/solarforecastarbiter/metrics/event.py
@@ -19,25 +19,29 @@ def _event2count(obs, fx):
     obs : (n,) array-like
         Observed event values (True=event, False=no event).
     fx : (n,) array-like
-        Forecasted event values.
+        Forecasted event values (True=event, False=no event).
 
     Returns
     -------
     tp : int
-        True positive.
+        Number of true positives.
     fp : int
-        False positive.
+        Number of false positives.
     tn : int
-        True positive.
+        Number of true negatives.
     fn : int
-        False negative.
+        Number of false negatives.
     """
 
-    tp = np.sum((fx == True) & (obs == True))    # True Positive (TP)
-    fp = np.sum((fx == True) & (obs == False))   # False Positive (FP)
-    tn = np.sum((fx == False) & (obs == False))  # True Negative (TN)
-    fn = np.sum((fx == False) & (obs == True))   # False Negative (FN)
+    if isinstance(obs, (list, tuple)):
+        obs = np.array(obs)
+    if isinstance(fx, (list, tuple)):
+        fx = np.array(fx)
 
+    tp = np.sum(np.logical_and(fx, obs))
+    fp = np.sum(np.logical_and(fx, ~obs))
+    tn = np.sum(np.logical_and(~fx, ~obs))
+    fn = np.sum(np.logical_and(~fx, obs))
     return tp, fp, tn, fn
 
 
@@ -51,7 +55,7 @@ def probability_of_detection(obs, fx):
     obs : (n,) array-like
         Observed event values (True=event, False=no event).
     fx : (n,) array-like
-        Forecasted event values.
+        Forecasted event values (True=event, False=no event).
 
     Returns
     -------
@@ -61,7 +65,10 @@ def probability_of_detection(obs, fx):
     """
 
     tp, fp, tn, fn = _event2count(obs, fx)
-    return tp / (tp + fn)
+    if (tp + fn) == 0:
+        return 0.0
+    else:
+        return tp / (tp + fn)
 
 
 def false_alarm_ratio(obs, fx):
@@ -74,7 +81,7 @@ def false_alarm_ratio(obs, fx):
     obs : (n,) array-like
         Observed event values (True=event, False=no event).
     fx : (n,) array-like
-        Forecasted event values.
+        Forecasted event values (True=event, False=no event).
 
     Returns
     -------
@@ -83,7 +90,10 @@ def false_alarm_ratio(obs, fx):
 
     """
     tp, fp, tn, fn = _event2count(obs, fx)
-    return fp / (tp + fp)
+    if (tp + fp) == 0:
+        return 0.0
+    else:
+        return fp / (tp + fp)
 
 
 def probability_of_false_detection(obs, fx):
@@ -96,7 +106,7 @@ def probability_of_false_detection(obs, fx):
     obs : (n,) array-like
         Observed event values (True=event, False=no event).
     fx : (n,) array-like
-        Forecasted event values.
+        Forecasted event values (True=event, False=no event).
 
     Returns
     -------
@@ -106,7 +116,10 @@ def probability_of_false_detection(obs, fx):
     """
 
     tp, fp, tn, fn = _event2count(obs, fx)
-    return fp / (fp + tn)
+    if (fp + tn) == 0:
+        return 0.0
+    else:
+        return fp / (fp + tn)
 
 
 def critical_success_index(obs, fx):
@@ -119,7 +132,7 @@ def critical_success_index(obs, fx):
     obs : (n,) array-like
         Observed event values (True=event, False=no event).
     fx : (n,) array-like
-        Forecasted event values.
+        Forecasted event values (True=event, False=no event).
 
     Returns
     -------
@@ -129,20 +142,23 @@ def critical_success_index(obs, fx):
     """
 
     tp, fp, tn, fn = _event2count(obs, fx)
-    return tp / (tp + fp + fn)
+    if (tp + fp + fn) == 0:
+        return 0.0
+    else:
+        return tp / (tp + fp + fn)
 
 
 def event_bias(obs, fx):
     """Event Bias (EBIAS).
 
-    .. math:: \\text{EBIAS} = (\\text{TP} + \\text{FP}) / (\\text{TP} + \\text{FN})
+    .. math:: \\text{EBIAS} = (\\text{TP} + \\text{FP}) / (\\text{TP} + \\text{FN})  # NOQA
 
     Parameters
     ----------
     obs : (n,) array-like
         Observed event values (True=event, False=no event).
     fx : (n,) array-like
-        Forecasted event values.
+        Forecasted event values (True=event, False=no event).
 
     Returns
     -------
@@ -152,7 +168,10 @@ def event_bias(obs, fx):
     """
 
     tp, fp, tn, fn = _event2count(obs, fx)
-    return (tp + fp) / (tp + fn)
+    if (tp + fn) == 0:
+        return 0.0
+    else:
+        return (tp + fp) / (tp + fn)
 
 
 def event_accuracy(obs, fx):
@@ -167,7 +186,7 @@ def event_accuracy(obs, fx):
     obs : (n,) array-like
         Observed event values (True=event, False=no event).
     fx : (n,) array-like
-        Forecasted event values.
+        Forecasted event values (True=event, False=no event).
 
     Returns
     -------
@@ -178,4 +197,7 @@ def event_accuracy(obs, fx):
 
     n = len(obs)
     tp, fp, tn, fn = _event2count(obs, fx)
-    return (tp + tn) / n
+    if n == 0:
+        raise ValueError("No samples.")
+    else:
+        return (tp + tn) / n

--- a/solarforecastarbiter/metrics/event.py
+++ b/solarforecastarbiter/metrics/event.py
@@ -3,31 +3,179 @@
 import numpy as np
 
 
+def _event2count(obs, fx):
+    """Convert events (True/False) into counts.
+
+    Given forecasts and observations of events (True=event occurred,
+    False=event did not occur), the pairs of forecasts and observations can be
+    placed into four categories:
+    - True Positive (TP): forecast = event, observed = event
+    - False Positive (FP): forecast = event, observed = no event
+    - True Negative (TN): forecast = no event, observed = no event
+    - False Negative (FN): forecast = no event, observed = event
+
+    Parameters
+    ----------
+    obs : (n,) array-like
+        Observed event values (True=event, False=no event).
+    fx : (n,) array-like
+        Forecasted event values.
+
+    Returns
+    -------
+    tp : int
+        True positive.
+    fp : int
+        False positive.
+    tn : int
+        True positive.
+    fn : int
+        False negative.
+    """
+
+    tp = np.sum((fx == True) & (obs == True))    # True Positive (TP)
+    fp = np.sum((fx == True) & (obs == False))   # False Positive (FP)
+    tn = np.sum((fx == False) & (obs == False))  # True Negative (TN)
+    fn = np.sum((fx == False) & (obs == True))   # False Negative (FN)
+
+    return tp, fp, tn, fn
+
+
 def probability_of_detection(obs, fx):
-    """Probability of Detection (POD)."""
-    pass
+    """Probability of Detection (POD).
+
+    .. math:: \\text{POD} = \\text{TP} / (\\text{TP} + \\text{FN})
+
+    Parameters
+    ----------
+    obs : (n,) array-like
+        Observed event values (True=event, False=no event).
+    fx : (n,) array-like
+        Forecasted event values.
+
+    Returns
+    -------
+    pod : float
+        The POD of the forecast.
+
+    """
+
+    tp, fp, tn, fn = _event2count(obs, fx)
+    return tp / (tp + fn)
 
 
 def false_alarm_ratio(obs, fx):
-    """False Alarm Ratio (FAR)."""
-    pass
+    """False Alarm Ratio (FAR).
+
+    .. math:: \\text{FAR} = \\text{FP} / (\\text{TP} + \\text{FP})
+
+    Parameters
+    ----------
+    obs : (n,) array-like
+        Observed event values (True=event, False=no event).
+    fx : (n,) array-like
+        Forecasted event values.
+
+    Returns
+    -------
+    far : float
+        The FAR of the forecast.
+
+    """
+    tp, fp, tn, fn = _event2count(obs, fx)
+    return fp / (tp + fp)
 
 
 def probability_of_false_detection(obs, fx):
-    """Probability of False Detection (POFD)."""
-    pass
+    """Probability of False Detection (POFD).
+
+    .. math:: \\text{POFD} = \\text{FP} / (\\text{FP} + \\text{TN})
+
+    Parameters
+    ----------
+    obs : (n,) array-like
+        Observed event values (True=event, False=no event).
+    fx : (n,) array-like
+        Forecasted event values.
+
+    Returns
+    -------
+    pofd : float
+        The POFD of the forecast.
+
+    """
+
+    tp, fp, tn, fn = _event2count(obs, fx)
+    return fp / (fp + tn)
 
 
 def critical_success_index(obs, fx):
-    """Critical Success Index (CSI)."""
-    pass
+    """Critical Success Index (CSI).
+
+    .. math:: \\text{CSI} = \\text{TP} / (\\text{TP} + \\text{FN} + \\text{FN})
+
+    Parameters
+    ----------
+    obs : (n,) array-like
+        Observed event values (True=event, False=no event).
+    fx : (n,) array-like
+        Forecasted event values.
+
+    Returns
+    -------
+    csi : float
+        The CSI of the forecast.
+
+    """
+
+    tp, fp, tn, fn = _event2count(obs, fx)
+    return tp / (tp + fp + fn)
 
 
 def event_bias(obs, fx):
-    """Event Bias (EBIAS)."""
-    pass
+    """Event Bias (EBIAS).
+
+    .. math:: \\text{EBIAS} = (\\text{TP} + \\text{FP}) / (\\text{TP} + \\text{FN})
+
+    Parameters
+    ----------
+    obs : (n,) array-like
+        Observed event values (True=event, False=no event).
+    fx : (n,) array-like
+        Forecasted event values.
+
+    Returns
+    -------
+    ebias : float
+        The EBIAS of the forecast.
+
+    """
+
+    tp, fp, tn, fn = _event2count(obs, fx)
+    return (tp + fp) / (tp + fn)
 
 
 def event_accuracy(obs, fx):
-    """Event Accuracy (EA)."""
-    pass
+    """Event Accuracy (EA).
+
+    .. math:: \\text{EA} = (\\text{TP} + \\text{TN}) / n
+
+    where n is the number of samples.
+
+    Parameters
+    ----------
+    obs : (n,) array-like
+        Observed event values (True=event, False=no event).
+    fx : (n,) array-like
+        Forecasted event values.
+
+    Returns
+    -------
+    ea : float
+        The EA of the forecast.
+
+    """
+
+    n = len(obs)
+    tp, fp, tn, fn = _event2count(obs, fx)
+    return (tp + tn) / n

--- a/solarforecastarbiter/metrics/event.py
+++ b/solarforecastarbiter/metrics/event.py
@@ -49,10 +49,10 @@ def _event2count(obs, fx):
     elif len(fx) == 0:
         raise RuntimeError("No Forecast timeseries data.")
 
-    tp = np.sum(np.logical_and(fx, obs))
-    fp = np.sum(np.logical_and(fx, ~obs))
-    tn = np.sum(np.logical_and(~fx, ~obs))
-    fn = np.sum(np.logical_and(~fx, obs))
+    tp = np.count_nonzero(np.logical_and(fx, obs))
+    fp = np.count_nonzero(np.logical_and(fx, ~obs))
+    tn = np.count_nonzero(np.logical_and(~fx, ~obs))
+    fn = np.count_nonzero(np.logical_and(~fx, obs))
     return tp, fp, tn, fn
 
 

--- a/solarforecastarbiter/metrics/event.py
+++ b/solarforecastarbiter/metrics/event.py
@@ -31,12 +31,23 @@ def _event2count(obs, fx):
         Number of true negatives.
     fn : int
         Number of false negatives.
+
+    Raises
+    ------
+    RuntimeError
+        If there is no forecast or observation timeseries data.
+
     """
 
     if isinstance(obs, (list, tuple)):
         obs = np.array(obs)
     if isinstance(fx, (list, tuple)):
         fx = np.array(fx)
+
+    if len(obs) == 0:
+        raise RuntimeError("No Observation timeseries data.")
+    elif len(fx) == 0:
+        raise RuntimeError("No Forecast timeseries data.")
 
     tp = np.sum(np.logical_and(fx, obs))
     fp = np.sum(np.logical_and(fx, ~obs))
@@ -197,7 +208,4 @@ def event_accuracy(obs, fx):
 
     n = len(obs)
     tp, fp, tn, fn = _event2count(obs, fx)
-    if n == 0:
-        raise ValueError("No samples.")
-    else:
-        return (tp + tn) / n
+    return (tp + tn) / n

--- a/solarforecastarbiter/metrics/event.py
+++ b/solarforecastarbiter/metrics/event.py
@@ -126,6 +126,12 @@ def probability_of_false_detection(obs, fx):
     pofd : float
         The POFD of the forecast.
 
+    Raises
+    ------
+    RuntimeError
+        If there is no forecast or observation timeseries data, or the forecast
+        and observation timeseries data do not have the same length.
+
     """
 
     tp, fp, tn, fn = _event2count(obs, fx)
@@ -152,6 +158,12 @@ def critical_success_index(obs, fx):
     csi : float
         The CSI of the forecast.
 
+    Raises
+    ------
+    RuntimeError
+        If there is no forecast or observation timeseries data, or the forecast
+        and observation timeseries data do not have the same length.
+
     """
 
     tp, fp, tn, fn = _event2count(obs, fx)
@@ -177,6 +189,12 @@ def event_bias(obs, fx):
     -------
     ebias : float
         The EBIAS of the forecast.
+
+    Raises
+    ------
+    RuntimeError
+        If there is no forecast or observation timeseries data, or the forecast
+        and observation timeseries data do not have the same length.
 
     """
 
@@ -205,6 +223,12 @@ def event_accuracy(obs, fx):
     -------
     ea : float
         The EA of the forecast.
+
+    Raises
+    ------
+    RuntimeError
+        If there is no forecast or observation timeseries data, or the forecast
+        and observation timeseries data do not have the same length.
 
     """
 

--- a/solarforecastarbiter/metrics/event.py
+++ b/solarforecastarbiter/metrics/event.py
@@ -75,6 +75,12 @@ def probability_of_detection(obs, fx):
     pod : float
         The POD of the forecast.
 
+    Raises
+    ------
+    RuntimeError
+        If there is no forecast or observation timeseries data, or the forecast
+        and observation timeseries data do not have the same length.
+
     """
 
     tp, fp, tn, fn = _event2count(obs, fx)
@@ -100,6 +106,12 @@ def false_alarm_ratio(obs, fx):
     -------
     far : float
         The FAR of the forecast.
+
+    Raises
+    ------
+    RuntimeError
+        If there is no forecast or observation timeseries data, or the forecast
+        and observation timeseries data do not have the same length.
 
     """
     tp, fp, tn, fn = _event2count(obs, fx)

--- a/solarforecastarbiter/metrics/event.py
+++ b/solarforecastarbiter/metrics/event.py
@@ -46,6 +46,9 @@ def _event2count(obs, fx):
         raise RuntimeError("No Observation timeseries data.")
     elif len(fx) == 0:
         raise RuntimeError("No Forecast timeseries data.")
+    elif len(obs) != len(fx):
+        raise RuntimeError("Forecast and Observation timeseries data do not "
+                           "have the same length.")
 
     tp = np.count_nonzero(np.logical_and(fx, obs))
     fp = np.count_nonzero(np.logical_and(fx, ~obs))

--- a/solarforecastarbiter/metrics/tests/test_event.py
+++ b/solarforecastarbiter/metrics/tests/test_event.py
@@ -16,11 +16,17 @@ from solarforecastarbiter.metrics import event
     ([True, True], [True, True], (2, 0, 0, 0)),
     ([False, False], [False, False], (0, 0, 2, 0)),
     ([True, True], [False, False], (0, 0, 0, 2)),
+
+    # bad data
+    pytest.param([True], [], 0,
+                 marks=pytest.mark.xfail(raises=RuntimeError, strict=True)),
+    pytest.param([], [True], 0,
+                 marks=pytest.mark.xfail(raises=RuntimeError, strict=True)),
 ])
 def test__event2count(obs, fx, result):
     tp, fp, tn, fn = event._event2count(obs, fx)
-    assert (tp + fp + tn + fn) == len(obs)
     assert (tp, fp, tn, fn) == result
+    assert (tp + fp + tn + fn) == len(obs)
 
 
 @pytest.mark.parametrize("obs,fx,result", [
@@ -55,6 +61,7 @@ def test_probability_of_false_detection(obs, fx, result):
 @pytest.mark.parametrize("obs,fx,result", [
     ([True], [False], 0.0),
     ([True], [True], 1.0),
+    ([False], [False], 0.0),
     ([True, False], [True, True], 0.5),
     ([True, False, True], [True, True, False], 1 / 3),
 ])
@@ -64,6 +71,7 @@ def test_critical_success_index(obs, fx, result):
 
 @pytest.mark.parametrize("obs,fx,result", [
     ([True], [False], 0.0),
+    ([False], [False], 0.0),
     ([True, True], [True, False], 0.5),
     ([True, False], [True, True], 2.0),
 ])

--- a/solarforecastarbiter/metrics/tests/test_event.py
+++ b/solarforecastarbiter/metrics/tests/test_event.py
@@ -1,27 +1,82 @@
 import pytest
-import numpy as np
 from solarforecastarbiter.metrics import event
 
 
-def test_probability_of_detection():
-    pass
+@pytest.mark.parametrize("obs,fx,result", [
+    # one event
+    ([True], [False], (0, 0, 0, 1)),
+    ([False], [True], (0, 1, 0, 0)),
+    ([True], [True], (1, 0, 0, 0)),
+    ([False], [False], (0, 0, 1, 0)),
+
+    # two events
+    ([True, False], [True, False], (1, 0, 1, 0)),
+    ([True, True], [True, False], (1, 0, 0, 1)),
+    ([False, False], [True, False], (0, 1, 1, 0)),
+    ([True, True], [True, True], (2, 0, 0, 0)),
+    ([False, False], [False, False], (0, 0, 2, 0)),
+    ([True, True], [False, False], (0, 0, 0, 2)),
+])
+def test__event2count(obs, fx, result):
+    tp, fp, tn, fn = event._event2count(obs, fx)
+    assert (tp + fp + tn + fn) == len(obs)
+    assert (tp, fp, tn, fn) == result
 
 
-def test_false_alarm_ratio():
-    pass
+@pytest.mark.parametrize("obs,fx,result", [
+    ([True], [False], 0.0),
+    ([False], [True], 0.0),
+    ([True, True], [True, True], 1.0),
+    ([True, True], [True, False], 0.5),
+])
+def test_probability_of_detection(obs, fx, result):
+    assert event.probability_of_detection(obs, fx) == result
 
 
-def test_probability_of_false_detection():
-    pass
+@pytest.mark.parametrize("obs,fx,result", [
+    ([True], [False], 0.0),
+    ([False], [True], 1.0),
+    ([True, True], [True, False], 0.0),
+    ([False, True], [True, True], 0.5),
+])
+def test_false_alarm_ratio(obs, fx, result):
+    assert event.false_alarm_ratio(obs, fx) == result
 
 
-def test_critical_success_index():
-    pass
+@pytest.mark.parametrize("obs,fx,result", [
+    ([True], [False], 0.0),
+    ([False], [True], 1.0),
+    ([False, False], [True, False], 0.5),
+])
+def test_probability_of_false_detection(obs, fx, result):
+    assert event.probability_of_false_detection(obs, fx) == result
 
 
-def test_event_bias():
-    pass
+@pytest.mark.parametrize("obs,fx,result", [
+    ([True], [False], 0.0),
+    ([True], [True], 1.0),
+    ([True, False], [True, True], 0.5),
+    ([True, False, True], [True, True, False], 1 / 3),
+])
+def test_critical_success_index(obs, fx, result):
+    assert event.critical_success_index(obs, fx) == result
 
 
-def test_event_accuracy():
-    pass
+@pytest.mark.parametrize("obs,fx,result", [
+    ([True], [False], 0.0),
+    ([True, True], [True, False], 0.5),
+    ([True, False], [True, True], 2.0),
+])
+def test_event_bias(obs, fx, result):
+    assert event.event_bias(obs, fx) == result
+
+
+@pytest.mark.parametrize("obs,fx,result", [
+    ([True], [False], 0.0),
+    ([False], [True], 0.0),
+    ([True, True], [True, True], 1.0),
+    ([True, False], [True, False], 1.0),
+    ([True, False], [True, True], 0.5),
+])
+def test_event_accuracy(obs, fx, result):
+    assert event.event_accuracy(obs, fx) == result

--- a/solarforecastarbiter/metrics/tests/test_event.py
+++ b/solarforecastarbiter/metrics/tests/test_event.py
@@ -1,0 +1,27 @@
+import pytest
+import numpy as np
+from solarforecastarbiter.metrics import event
+
+
+def test_probability_of_detection():
+    pass
+
+
+def test_false_alarm_ratio():
+    pass
+
+
+def test_probability_of_false_detection():
+    pass
+
+
+def test_critical_success_index():
+    pass
+
+
+def test_event_bias():
+    pass
+
+
+def test_event_accuracy():
+    pass

--- a/solarforecastarbiter/metrics/tests/test_event.py
+++ b/solarforecastarbiter/metrics/tests/test_event.py
@@ -22,6 +22,8 @@ from solarforecastarbiter.metrics import event
                  marks=pytest.mark.xfail(raises=RuntimeError, strict=True)),
     pytest.param([], [True], 0,
                  marks=pytest.mark.xfail(raises=RuntimeError, strict=True)),
+    pytest.param([True], [True, True], 0,
+                 marks=pytest.mark.xfail(raises=RuntimeError, strict=True))
 ])
 def test__event2count(obs, fx, result):
     tp, fp, tn, fn = event._event2count(obs, fx)


### PR DESCRIPTION
  - [x] Closes #347 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This PR adds the standalone functions for computing the deterministic event forecast metrics.