### PR TITLE
revert to using PhantomJS but kill cleanly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,10 +23,11 @@ jobs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
 
-  - script: |
-      sudo apt update
-      sudo apt install chromium-chromedriver
-    displayName: 'Install chromedriver'
+  - task: Npm@1
+    inputs:
+      command: 'custom'
+      customCommand: 'install phantomjs-prebuilt'
+    displayName: 'Install phantomjs'
 
   - script: python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt
     displayName: 'Install dependencies'

--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -14,8 +14,8 @@ API Changes
 
 Enhancements
 ~~~~~~~~~~~~
-* Try using the Chrome web driver instead of phantomjs for SVG geneartion
-  for better cleanup (:issue:`344`) (:pull:`345`)
+* Clean up any PhantomJS drivers created to render SVGs (:issue:`344`)
+  (:pull:`349`)
 
 Bug fixes
 ~~~~~~~~~


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #344  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Chrome is really difficult to install and run in a docker container without giving up sandboxing, so go back to phantomjs for now but try and ensure processes get cleaned up. FIrefox is an easier option, but it is much slower. Bokeh 2.0 may have changes to the javascript that make Firefox faster to render and break phantomjs, so punt until then.