### PR TITLE
discrete xaxes labels closes #363

### DIFF
--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -37,7 +37,7 @@ PLOT_LAYOUT_DEFAULTS = {
 
 def configure_axes(fig, x_axis_kwargs, y_axis_kwargs):
     """Applies plotly axes configuration to display zero line and grid, and the
-    configuration passed in x_axes_kwargs and y_axes kargs.
+    configuration passed in x_axis_kwargs and y_axis kwargs.
     Parameters
     ----------
     fig: plotly.graph_objects.Figure

--- a/solarforecastarbiter/reports/templates/body.html
+++ b/solarforecastarbiter/reports/templates/body.html
@@ -145,7 +145,7 @@ generate a new report after the data provider submits new data.
   {% for metric in report.report_parameters.metrics %}
     {% for rep_fig in report.raw_report.plots.figures %}
       {% if rep_fig.category == category and rep_fig.metric == metric %}
-      {% set plot_id = category+'_'+metric+'_'+rep_fig.name | replace(" ", "_") %}
+      {% set plot_id = (category+'_'+metric+'_'+rep_fig.name) | replace('^', '-') | replace(' ', '_') %}
     <div class="metric-block" id="{{ plot_id }}" data-category="{{ rep_fig.category }}" data-metric="{{ rep_fig.metric }}" data-forecast="{{ rep_fig.name }}">
         <script>plot=JSON.parse('{{ rep_fig.spec | safe }}');
                 Object.assign(plot,{config: {responsive: true}});


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #363 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Updates axes configuration function to accept a dict of kwargs for plotly's `Figure.update_xaxes` and `Figure.update_yaxes` function. This was to remedy the display of non-discrete values on the axes for years, but in finding the solution I also discovered that a tick delta could be supplied for the date axes and we could avoid displaying the noon ticks between days.