### PR TITLE
Added probabilistic forecast support to metrics calculator

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -352,6 +352,7 @@ Probabilistic Forecasts
    io.api.APISession.get_probabilistic_forecast
    io.api.APISession.list_probabilistic_forecasts
    io.api.APISession.create_probabilistic_forecast
+   io.api.APISession.get_probabilistic_forecast_values
    io.api.APISession.get_probabilistic_forecast_constant_value
    io.api.APISession.get_probabilistic_forecast_constant_value_values
    io.api.APISession.post_probabilistic_forecast_constant_value_values
@@ -420,6 +421,7 @@ Entry points for calculating metrics for
 
    metrics.calculator.calculate_metrics
    metrics.calculator.calculate_deterministic_metrics
+   metrics.calculator.calculate_probabilistic_metrics
 
 Preprocessing
 -------------

--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -18,6 +18,11 @@ API Changes
   :py:func:`solarforecastarbiter.metrics.event.critical_success_index`,
   :py:func:`solarforecastarbiter.metrics.event.event_bias`, and
   :py:func:`solarforecastarbiter.metrics.event.event_accuracy`. (:issue:`347`) (:pull:`348`)
+* Added support for probabilistic forecasts with
+  :py:func:`solarforecastarbiter.metrics.calculator.calculate_metrics` modifications and
+  :py:func:`solarforecastarbiter.metrics.calculator.calculate_probabilistic_metrics` addition. (:issue:`315`) (:issue:`266`) (:pull:`367`)
+* Added api function to get all values of a :py:class:`solarforecastarbiter.datamodel.ProbabilisticForecast` with addition of
+  :py:func:`solarforecastarbiter.io.api.get_probabilistic_forecast_values`. (:pull:`367`)
 
 
 Enhancements
@@ -32,6 +37,8 @@ Bug fixes
   (:issue:`341`) (:pull:`342`)
 * Fix CLI report generation when status not set in report metadata
   (:pull:`345`)
+* Fix bug with APISession list functions when only a single value is available.
+  (:pull:`367`)
 
 
 Contributors

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1217,6 +1217,7 @@ def single_prob_forecast_aggregate(aggregate, single_site,
     )
     return datamodel.ForecastAggregate(forecast_agg, aggregate)
 
+
 @pytest.fixture()
 def report_objects(aggregate):
     tz = 'America/Phoenix'

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1034,12 +1034,28 @@ def single_forecast_observation(single_forecast, single_observation):
 
 
 @pytest.fixture()
+def single_prob_forecast_observation(prob_forecasts, single_observation):
+    return datamodel.ForecastObservation(prob_forecasts, single_observation)
+
+
+@pytest.fixture()
 def many_forecast_observation(many_forecasts, many_observations):
     many_ghi_forecasts = [fx for fx in many_forecasts
                           if fx.variable == 'ghi']
     many_ghi_observations = [obs for obs in many_observations
                              if obs.variable == 'ghi']
     cart_prod = itertools.product(many_ghi_forecasts, many_ghi_observations)
+    return [datamodel.ForecastObservation(*c) for c in cart_prod]
+
+
+@pytest.fixture()
+def many_prob_forecasts_observation(many_prob_forecasts, many_observations):
+    many_ghi_prob_forecasts = [pfx for pfx in many_prob_forecasts
+                               if pfx.variable == 'ghi' and pfx.axis == 'x']
+    many_ghi_observations = [obs for obs in many_observations
+                             if obs.variable == 'ghi']
+    car_prod = itertools.product(many_ghi_prob_forecasts,
+                                 many_ghi_observations)
     return [datamodel.ForecastObservation(*c) for c in cart_prod]
 
 

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1198,6 +1198,26 @@ def single_forecast_aggregate(aggregate, single_site):
 
 
 @pytest.fixture()
+def single_prob_forecast_aggregate(aggregate, single_site,
+                                   agg_prob_forecast_constant_value):
+    forecast_agg = datamodel.ProbabilisticForecast(
+        name="GHI Aggregate FX 60",
+        issue_time_of_day=dt.time(0, 0),
+        lead_time_to_start=pd.Timedelta("0 days 00:00:00"),
+        interval_length=pd.Timedelta("0 days 01:00:00"),
+        run_length=pd.Timedelta("1 days 00:00:00"),
+        interval_label="beginning",
+        interval_value_type="interval_mean",
+        variable="ghi",
+        site=single_site,
+        axis='x',
+        constant_values=[agg_prob_forecast_constant_value],
+        forecast_id="49220780-76ae-4b11-bef1-7a75bdc784e3",
+        extra_parameters='',
+    )
+    return datamodel.ForecastAggregate(forecast_agg, aggregate)
+
+@pytest.fixture()
 def report_objects(aggregate):
     tz = 'America/Phoenix'
     start = pd.Timestamp('20190401 0000', tz=tz)

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -145,6 +145,128 @@ def forecast_values():
                                          name='timestamp')).tz_convert('UTC')
 
 
+@pytest.fixture()
+def prob_forecast_values_text_list():
+    return [b"""
+{
+  "_links": {
+    "metadata": ""
+  },
+  "forecast_id": "CV25",
+  "values": [
+    {
+      "timestamp": "2019-01-01T06:00:00-0700",
+      "value": 0.0
+    },
+    {
+      "timestamp": "2019-01-01T07:00:00-0700",
+      "value": 1.0
+    },
+    {
+      "timestamp": "2019-01-01T08:00:00-0700",
+      "value": 2.0
+    },
+    {
+      "timestamp": "2019-01-01T09:00:00-0700",
+      "value": 3.0
+    },
+    {
+      "timestamp": "2019-01-01T10:00:00-0700",
+      "value": 4.0
+    },
+    {
+      "timestamp": "2019-01-01T11:00:00-0700",
+      "value": 5.0
+    }
+  ]
+}
+"""
+,
+b"""
+{
+"_links": {
+"metadata": ""
+},
+  "forecast_id": "CV50",
+  "values": [
+    {
+    "timestamp": "2019-01-01T06:00:00-0700",
+    "value": 1.0
+    },
+    {
+    "timestamp": "2019-01-01T07:00:00-0700",
+    "value": 2.0
+    },
+    {
+    "timestamp": "2019-01-01T08:00:00-0700",
+    "value": 3.0
+    },
+    {
+    "timestamp": "2019-01-01T09:00:00-0700",
+    "value": 4.0
+    },
+    {
+    "timestamp": "2019-01-01T10:00:00-0700",
+    "value": 5.0
+    },
+    {
+    "timestamp": "2019-01-01T11:00:00-0700",
+    "value": 6.0
+    }
+  ]
+}
+"""
+,
+b"""
+{
+"_links": {
+"metadata": ""
+},
+  "forecast_id": "CV75",
+  "values": [
+    {
+      "timestamp": "2019-01-01T06:00:00-0700",
+      "value": 2.0
+    },
+    {
+      "timestamp": "2019-01-01T07:00:00-0700",
+      "value": 3.0
+    },
+    {
+      "timestamp": "2019-01-01T08:00:00-0700",
+      "value": 4.0
+    },
+    {
+      "timestamp": "2019-01-01T09:00:00-0700",
+      "value": 5.0
+    },
+    {
+      "timestamp": "2019-01-01T10:00:00-0700",
+      "value": 6.0
+    },
+    {
+      "timestamp": "2019-01-01T11:00:00-0700",
+      "value": 7.0
+    }
+  ]
+}
+"""
+]
+
+
+@pytest.fixture()
+def prob_forecast_values():
+    return pd.DataFrame(
+        {'25': [0.0, 1, 2, 3, 4, 5],
+         '50': [1.0, 2, 3, 4, 5, 6],
+         '75': [2.0, 3, 4, 5, 6, 7]},
+         index=pd.date_range(start='20190101T0600',
+                             end='20190101T1100',
+                             freq='1h',
+                             tz='America/Denver',
+                             name='timestamp')).tz_convert('UTC')
+
+
 @pytest.fixture(scope='module')
 def site_metadata():
     """
@@ -1054,7 +1176,7 @@ def many_prob_forecasts_observation(many_prob_forecasts, many_observations):
                                if pfx.variable == 'ghi' and pfx.axis == 'x']
     many_ghi_observations = [obs for obs in many_observations
                              if obs.variable == 'ghi']
-    car_prod = itertools.product(many_ghi_prob_forecasts,
+    cart_prod = itertools.product(many_ghi_prob_forecasts,
                                  many_ghi_observations)
     return [datamodel.ForecastObservation(*c) for c in cart_prod]
 

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -180,12 +180,11 @@ def prob_forecast_values_text_list():
     }
   ]
 }
-"""
-,
+""",  # NOQA
 b"""
 {
-"_links": {
-"metadata": ""
+  "_links": {
+    "metadata": ""
 },
   "forecast_id": "CV50",
   "values": [
@@ -215,12 +214,11 @@ b"""
     }
   ]
 }
-"""
-,
+""",  # NOQA
 b"""
 {
-"_links": {
-"metadata": ""
+  "_links": {
+    "metadata": ""
 },
   "forecast_id": "CV75",
   "values": [
@@ -260,11 +258,11 @@ def prob_forecast_values():
         {'25': [0.0, 1, 2, 3, 4, 5],
          '50': [1.0, 2, 3, 4, 5, 6],
          '75': [2.0, 3, 4, 5, 6, 7]},
-         index=pd.date_range(start='20190101T0600',
-                             end='20190101T1100',
-                             freq='1h',
-                             tz='America/Denver',
-                             name='timestamp')).tz_convert('UTC')
+        index=pd.date_range(start='20190101T0600',
+                            end='20190101T1100',
+                            freq='1h',
+                            tz='America/Denver',
+                            name='timestamp')).tz_convert('UTC')
 
 
 @pytest.fixture(scope='module')
@@ -1177,7 +1175,7 @@ def many_prob_forecasts_observation(many_prob_forecasts, many_observations):
     many_ghi_observations = [obs for obs in many_observations
                              if obs.variable == 'ghi']
     cart_prod = itertools.product(many_ghi_prob_forecasts,
-                                 many_ghi_observations)
+                                  many_ghi_observations)
     return [datamodel.ForecastObservation(*c) for c in cart_prod]
 
 

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -5,7 +5,6 @@ import json
 import logging
 import requests
 from urllib3 import Retry
-import pandas as pd
 
 
 import pandas as pd

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -5,6 +5,7 @@ import json
 import logging
 import requests
 from urllib3 import Retry
+import pandas as pd
 
 
 from solarforecastarbiter import datamodel
@@ -196,6 +197,8 @@ class APISession(requests.Session):
         """
         req = self.get('/observations/')
         obs_dicts = req.json()
+        if isinstance(obs_dicts, dict):
+            obs_dicts = [obs_dicts]
         if len(obs_dicts) == 0:
             return []
         sites = {site.site_id: site for site in self.list_sites()}
@@ -268,6 +271,8 @@ class APISession(requests.Session):
         """
         req = self.get('/forecasts/single/')
         fx_dicts = req.json()
+        if isinstance(fx_dicts, dict):
+            fx_dicts = [fx_dicts]
         if len(fx_dicts) == 0:
             return []
         sites = {site.site_id: site for site in self.list_sites()}
@@ -337,6 +342,8 @@ class APISession(requests.Session):
         """
         req = self.get('/forecasts/cdf/')
         fx_dicts = req.json()
+        if isinstance(fx_dicts, dict):
+            fx_dicts = [fx_dicts]
         if len(fx_dicts) == 0:
             return []
         sites = {site.site_id: site for site in self.list_sites()}
@@ -539,6 +546,8 @@ class APISession(requests.Session):
         ----------
         forecast_id : string
             UUID of the forecast object
+        constant_value : string
+            The variable value or percentile.
         start : timelike object
             Start of the interval to retrieve values for
         end : timelike object
@@ -563,6 +572,45 @@ class APISession(requests.Session):
         out = json_payload_to_forecast_series(req.json())
         return adjust_timeseries_for_interval_label(
             out, interval_label, start, end)
+
+    @ensure_timestamps('start', 'end')
+    def get_probabilistic_forecast_values(
+        self, forecast_id, start, end, interval_label=None):
+        """
+        Get all probabilistic forecast values for each from start to end for
+        forecast_id
+
+        Parameters
+        ----------
+        forecast_id : string
+            UUID of the forecast object
+        start : timelike object
+            Start of the interval to retrieve values for
+        end : timelike object
+            End of the interval
+        interval_label : str or None
+            If beginning, ending, adjust the data to return only data that is
+            valid between start and end. If None or instant, return any data
+            between start and end inclusive of the endpoints.
+
+        Returns
+        -------
+        pandas.DataFrame
+           With the forecast values in each column with column names as the
+           constant value and a datetime index
+
+        Raises
+        ------
+        ValueError
+            If start or end cannot be converted into a Pandas Timestamp
+        """
+        df_dict = {}
+        prob_fx = self.get_probabilistic_forecast(forecast_id)
+        for cv in prob_fx.constant_values:
+            df_dict[cv.constant_value] = self.get_probabilistic_forecast_constant_value_values( #NOQA
+                forecast_id=cv.forecast_id, start=start, end=end,
+                interval_label=interval_label)
+        return pd.DataFrame(df_dict)
 
     def post_observation_values(self, observation_id, observation_df,
                                 params=None):
@@ -697,6 +745,8 @@ class APISession(requests.Session):
         """
         req = self.get('/reports')
         rep_dicts = req.json()
+        if isinstance(rep_dicts, dict):
+            rep_dicts = [rep_dicts]
         if len(rep_dicts) == 0:
             return []
         out = []
@@ -874,6 +924,8 @@ class APISession(requests.Session):
         """
         req = self.get('/aggregates/')
         agg_dicts = req.json()
+        if isinstance(agg_dicts, dict):
+            agg_dicts = [agg_dicts]
         if len(agg_dicts) == 0:
             return []
         observations = {obs.observation_id: obs
@@ -991,6 +1043,9 @@ class APISession(requests.Session):
         # order avoids possible issues with inheritance
         if isinstance(obj, datamodel.ProbabilisticForecastConstantValue):
             f = self.get_probabilistic_forecast_constant_value_values
+            obj_id = obj.forecast_id
+        elif isinstance(obj, datamodel.ProbabilisticForecast):
+            f = self.get_probabilistic_forecast_values
             obj_id = obj.forecast_id
         elif isinstance(obj, datamodel.Forecast):
             f = self.get_forecast_values

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -575,7 +575,7 @@ class APISession(requests.Session):
 
     @ensure_timestamps('start', 'end')
     def get_probabilistic_forecast_values(
-        self, forecast_id, start, end, interval_label=None):
+            self, forecast_id, start, end, interval_label=None):
         """
         Get all probabilistic forecast values for each from start to end for
         forecast_id
@@ -607,7 +607,7 @@ class APISession(requests.Session):
         df_dict = {}
         prob_fx = self.get_probabilistic_forecast(forecast_id)
         for cv in prob_fx.constant_values:
-            df_dict[cv.constant_value] = self.get_probabilistic_forecast_constant_value_values( #NOQA
+            df_dict[cv.constant_value] = self.get_probabilistic_forecast_constant_value_values(  # NOQA
                 forecast_id=cv.forecast_id, start=start, end=end,
                 interval_label=interval_label)
         return pd.DataFrame(df_dict)

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -302,11 +302,9 @@ def test_apisession_list_prob_forecasts(requests_mock, many_prob_forecasts,
     assert fx_list == many_prob_forecasts
 
 
-def test_apisession_list_prob_forecast_single(requests_mock, prob_forecasts,
-                                              prob_forecast_text,
-                                              mock_list_sites, mock_get_site,
-                                              prob_forecast_constant_value_text,
-                                              mock_get_agg):
+def test_apisession_list_prob_forecast_single(
+        requests_mock, prob_forecasts, prob_forecast_text, mock_list_sites,
+        mock_get_site, prob_forecast_constant_value_text, mock_get_agg):
     session = api.APISession('')
     matcher = re.compile(f'{session.base_url}/forecasts/cdf/single/.*')
     requests_mock.register_uri(

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -1,8 +1,10 @@
 import json
+from random import randint
 import re
 import copy
 
 
+import numpy as np
 import pandas as pd
 import pandas.testing as pdt
 import pytest
@@ -569,3 +571,640 @@ def test_apisession_get_prob_forecast_values(
             'GET', f'/forecasts/cdf/single/{id}/values', content=cvv)
     out = session.get_probabilistic_forecast_values('', *fx_start_end)
     pdt.assert_frame_equal(out, prob_forecast_values)
+
+@pytest.mark.parametrize('label,theslice', [
+    (None, slice(0, 10)),
+    ('beginning', slice(0, -1)),
+    ('ending', slice(1, 10))
+])
+def test_apisession_get_forecast_values_interval_label(
+        requests_mock, forecast_values, forecast_values_text, label, theslice,
+        fx_start_end):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/forecasts/single/.*/values')
+    requests_mock.register_uri('GET', matcher, content=forecast_values_text)
+    out = session.get_forecast_values(
+        'fxid', fx_start_end[0], fx_start_end[1], label)
+    pdt.assert_series_equal(out, forecast_values.iloc[theslice])
+
+
+def test_apisession_get_forecast_values_empty(requests_mock, empty_df):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/forecasts/single/.*/values')
+    requests_mock.register_uri('GET', matcher, content=b'{"values":[]}')
+    out = session.get_forecast_values(
+        'fxid', pd.Timestamp('2019-01-01T06:00:00-0700'),
+        pd.Timestamp('2019-01-01T11:00:00-0700'))
+    pdt.assert_series_equal(out, empty_df['value'])
+
+
+def test_apisession_post_observation_values(requests_mock, observation_values):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/observations/.*/values')
+    mocked = requests_mock.register_uri('POST', matcher)
+    session.post_observation_values('obsid', observation_values)
+    # observation_values_text has a different timestamp format
+    assert mocked.request_history[0].text == '{"values":[{"timestamp":"2019-01-01T19:00:00Z","value":0.0,"quality_flag":0},{"timestamp":"2019-01-01T19:05:00Z","value":1.0,"quality_flag":0},{"timestamp":"2019-01-01T19:10:00Z","value":1.5,"quality_flag":0},{"timestamp":"2019-01-01T19:15:00Z","value":9.9,"quality_flag":1},{"timestamp":"2019-01-01T19:20:00Z","value":2.0,"quality_flag":0},{"timestamp":"2019-01-01T19:25:00Z","value":-999.0,"quality_flag":3}]}'  # NOQA
+
+
+def test_apisession_post_forecast_values(requests_mock, forecast_values):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/forecasts/single/.*/values')
+    mocked = requests_mock.register_uri('POST', matcher)
+    session.post_forecast_values('fxid', forecast_values)
+    assert mocked.request_history[0].text == '{"values":[{"timestamp":"2019-01-01T13:00:00Z","value":0.0},{"timestamp":"2019-01-01T14:00:00Z","value":1.0},{"timestamp":"2019-01-01T15:00:00Z","value":2.0},{"timestamp":"2019-01-01T16:00:00Z","value":3.0},{"timestamp":"2019-01-01T17:00:00Z","value":4.0},{"timestamp":"2019-01-01T18:00:00Z","value":5.0}]}'  # NOQA
+
+
+def test_apisession_post_prob_forecast_constant_value_values(
+        requests_mock, forecast_values):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/forecasts/cdf/single/.*/values')
+    mocked = requests_mock.register_uri('POST', matcher)
+    session.post_probabilistic_forecast_constant_value_values(
+        'fxid', forecast_values)
+    assert mocked.request_history[0].text == '{"values":[{"timestamp":"2019-01-01T13:00:00Z","value":0.0},{"timestamp":"2019-01-01T14:00:00Z","value":1.0},{"timestamp":"2019-01-01T15:00:00Z","value":2.0},{"timestamp":"2019-01-01T16:00:00Z","value":3.0},{"timestamp":"2019-01-01T17:00:00Z","value":4.0},{"timestamp":"2019-01-01T18:00:00Z","value":5.0}]}'  # NOQA
+
+
+@pytest.mark.parametrize('match, meth', [
+    ('observations', 'get_observation_values'),
+    ('forecasts/single', 'get_forecast_values'),
+    ('forecasts/cdf/single',
+     'get_probabilistic_forecast_constant_value_values'),
+    ('aggregates', 'get_aggregate_values'),
+])
+def test_apisession_get_values(
+        requests_mock, mocker, single_observation, single_forecast,
+        prob_forecast_constant_value, aggregate, match, meth, fx_start_end):
+    objs = {
+        'observations': single_observation,
+        'forecasts/single': single_forecast,
+        'forecasts/cdf/single': prob_forecast_constant_value,
+        'aggregates': aggregate
+    }
+    obj = objs[match]
+    session = api.APISession('')
+    matcher = re.compile(
+        f'{session.base_url}/{match}/.*/values')
+    requests_mock.register_uri('GET', matcher, content=b'{"values":[]}')
+    status = mocker.patch(
+        f'solarforecastarbiter.io.api.APISession.{meth}')
+    session.get_values(obj, *fx_start_end)
+    assert status.called
+
+
+@pytest.fixture()
+def mock_request_fxobs(report_objects, mocker):
+    _, obs, fx0, fx1, agg, fxagg = report_objects
+    mocker.patch('solarforecastarbiter.io.api.APISession.get_observation',
+                 return_value=obs)
+    mocker.patch('solarforecastarbiter.io.api.APISession.get_aggregate',
+                 return_value=agg)
+
+    def returnone(fxid):
+        if fxid == "da2bc386-8712-11e9-a1c7-0a580a8200ae":
+            return fx0
+        elif fxid == "49220780-76ae-4b11-bef1-7a75bdc784e3":
+            return fxagg
+        else:
+            return fx1
+    mocker.patch('solarforecastarbiter.io.api.APISession.get_forecast',
+                 side_effect=returnone)
+
+
+def test_apisession_get_report(requests_mock, report_text, report_objects,
+                               mock_request_fxobs):
+    session = api.APISession('')
+    requests_mock.register_uri('GET', f'{session.base_url}/reports/',
+                               content=report_text)
+    out = session.get_report('')
+    expected = report_objects[0]
+    assert out == expected
+
+
+def test_apisession_get_report_with_raw(
+        requests_mock, report_text, report_objects, mock_request_fxobs,
+        raw_report, mocker):
+    raw = raw_report(False)
+    raw_dict = raw.to_dict()
+    report = json.loads(report_text)
+    report['raw_report'] = raw_dict
+    report_text = json.dumps(report).encode()
+    mocker.patch(
+        'solarforecastarbiter.io.api.APISession.get_raw_report_processed_data',
+        return_value=())
+    session = api.APISession('')
+    requests_mock.register_uri('GET', f'{session.base_url}/reports/',
+                               content=report_text)
+    out = session.get_report('')
+    expected = report_objects[0].replace(
+        raw_report=raw.replace(processed_forecasts_observations=()))
+    assert out == expected
+
+
+def test_apisession_list_reports(requests_mock, report_text, report_objects,
+                                 mock_request_fxobs):
+    session = api.APISession('')
+    requests_mock.register_uri('GET', f'{session.base_url}/reports',
+                               content=b'['+report_text+b']')
+    out = session.list_reports()
+    expected = [report_objects[0]]
+    assert out == expected
+
+
+def test_apisession_list_reports_empty(requests_mock):
+    session = api.APISession('')
+    requests_mock.register_uri('GET', f'{session.base_url}/reports',
+                               content=b'[]')
+    out = session.list_reports()
+    assert out == []
+
+
+def test_apisession_create_report(requests_mock, report_objects, mocker):
+    session = api.APISession('')
+    report = report_objects[0]
+    mocked = requests_mock.register_uri('POST', f'{session.base_url}/reports/')
+    mocker.patch('solarforecastarbiter.io.api.APISession.get_report',
+                 return_value=report)
+    expected = {
+        "report_parameters": {
+            "name": "NREL MIDC OASIS GHI Forecast Analysis",
+            "start": "2019-04-01T00:00:00-07:00",
+            "end": "2019-04-04T23:59:00-07:00",
+            "filters": [
+                {'quality_flags': [
+                    "USER FLAGGED",
+                    "NIGHTTIME",
+                    "LIMITS EXCEEDED",
+                    "STALE VALUES",
+                    "INTERPOLATED VALUES",
+                    "INCONSISTENT IRRADIANCE COMPONENTS",
+                ]},
+                {'time_of_day_range': ['12:00', '14:00']}],
+            "metrics": ["mae", "rmse", "mbe"],
+            "categories": ["total", "date", "hour"],
+            "object_pairs": [
+                {"forecast": "da2bc386-8712-11e9-a1c7-0a580a8200ae",
+                 "observation": "9f657636-7e49-11e9-b77f-0a580a8003e9"},
+                {"forecast": "68a1c22c-87b5-11e9-bf88-0a580a8200ae",
+                 "observation": "9f657636-7e49-11e9-b77f-0a580a8003e9"},
+                {"forecast": "49220780-76ae-4b11-bef1-7a75bdc784e3",
+                 "aggregate": "458ffc27-df0b-11e9-b622-62adb5fd6af0"}
+            ]
+        }}
+    session.create_report(report)
+    posted = mocked.last_request.json()
+    assert posted == expected
+
+
+def test_apisession_post_raw_report_processed_data(
+        requests_mock, raw_report, report_objects):
+    _, obs, fx0, fx1, agg, fxagg = report_objects
+    session = api.APISession('')
+    ids = [fx0.forecast_id, obs.observation_id, fx1.forecast_id,
+           obs.observation_id, fxagg.forecast_id, agg.aggregate_id]
+    mocked = requests_mock.register_uri(
+        'POST', re.compile(f'{session.base_url}/reports/.*/values'),
+        [{'text': id_} for id_ in ids])
+    inp = raw_report(True)
+    out = session.post_raw_report_processed_data('report_id', inp)
+    exp = raw_report(False)
+    assert out == exp.processed_forecasts_observations
+    history = mocked.request_history
+    for i, id_ in enumerate(ids):
+        assert id_ == history[i].json()['object_id']
+
+
+def test_apisession_get_raw_report_processed_data(
+        requests_mock, raw_report, report_objects):
+    _, obs, fx0, fx1, agg, fxagg = report_objects
+    session = api.APISession('')
+    ser = pd.Series(name='value', index=pd.DatetimeIndex(
+        [], tz='UTC', name='timestamp'), dtype=float)
+    val = utils.serialize_timeseries(ser)
+    requests_mock.register_uri(
+        'GET', re.compile(f'{session.base_url}/reports/.*/values'),
+        json=[{'id': id_, 'processed_values': val} for id_ in
+              (fx0.forecast_id, fx1.forecast_id, obs.observation_id,
+               agg.aggregate_id, fxagg.forecast_id)])
+    inp = raw_report(False)
+    out = session.get_raw_report_processed_data('', inp)
+    for fxo in out:
+        pdt.assert_series_equal(fxo.forecast_values, ser)
+        pdt.assert_series_equal(fxo.observation_values, ser)
+
+
+def test_apisession_post_raw_report(requests_mock, raw_report, mocker,
+                                    report_objects):
+    raw = raw_report(True)
+    _, obs, fx0, fx1, agg, fxagg = report_objects
+    session = api.APISession('')
+    ids = [fx0.forecast_id, obs.observation_id, fx1.forecast_id,
+           obs.observation_id, agg.aggregate_id, fxagg.forecast_id]
+    requests_mock.register_uri(
+        'POST', re.compile(f'{session.base_url}/reports/.*/values'),
+        [{'text': id_} for id_ in ids])
+    mocked = requests_mock.register_uri(
+        'POST', re.compile(f'{session.base_url}/reports/.*/raw'))
+    status = mocker.patch(
+        'solarforecastarbiter.io.api.APISession.update_report_status')
+    session.post_raw_report('', raw)
+    assert isinstance(mocked.last_request.json(), dict)
+    assert status.called
+
+
+def test_apisession_update_report_status(requests_mock):
+    session = api.APISession('')
+    mocked = requests_mock.register_uri(
+        'POST', re.compile(f'{session.base_url}/reports/REPORT_ID/status/'))
+    session.update_report_status('REPORT_ID', 'complete')
+    assert mocked.last_request.url.split('/')[-1] == 'complete'
+
+
+@pytest.fixture()
+def mockobs(many_observations, mocker):
+    def _getobs(cls, observation_id):
+        for obs in many_observations:
+            if observation_id == obs.observation_id:
+                return obs
+
+    mocker.patch(
+        'solarforecastarbiter.io.api.APISession.get_observation',
+        new=_getobs)
+    mocker.patch(
+        'solarforecastarbiter.io.api.APISession.list_observations',
+        return_value=many_observations)
+
+
+def test_apisession_get_aggregate(requests_mock, aggregate_text, aggregate,
+                                  mockobs):
+    session = api.APISession('')
+    requests_mock.register_uri(
+        'GET', re.compile(f'{session.base_url}/aggregates/.*/metadata'),
+        content=aggregate_text)
+    agg = session.get_aggregate('')
+    assert agg == aggregate
+
+
+def test_apisession_list_aggregates(requests_mock, aggregate_text, aggregate,
+                                    mockobs):
+    session = api.APISession('')
+    requests_mock.register_uri(
+        'GET', re.compile(f'{session.base_url}/aggregates/'),
+        content=b'[' + aggregate_text + b']')
+    aggs = session.list_aggregates()
+    assert aggs[0] == aggregate
+
+
+def test_apisession_list_aggregates_empty(requests_mock):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/aggregates/.*')
+    requests_mock.register_uri('GET', matcher, content=b"[]")
+    obs_list = session.list_aggregates()
+    assert obs_list == []
+
+
+def test_apisession_create_aggregate(requests_mock, aggregate, aggregate_text,
+                                     mockobs):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/aggregates/.*')
+
+    def callback(request, context):
+        if request.url.endswith('aggregates/'):
+            ad = json.loads(aggregate_text)
+            for key in ('provider', 'aggregate_id', 'created_at',
+                        'modified_at', 'observations', 'interval_value_type'):
+                del ad[key]
+            assert ad == request.json()
+            return aggregate.aggregate_id
+        else:
+            rj = request.json()
+            assert 'observations' in rj
+            assert 'observation_id' in rj['observations'][0]
+            assert (
+                'effective_from' in rj['observations'][0]
+                or 'effective_until' in rj['observations'][0])
+
+    requests_mock.register_uri('POST', matcher, text=callback)
+    requests_mock.register_uri('GET', matcher, content=aggregate_text)
+    aggregate_dict = aggregate.to_dict()
+    del aggregate_dict['aggregate_id']
+    del aggregate_dict['interval_value_type']
+    ss = datamodel.Aggregate.from_dict(aggregate_dict)
+    new_aggregate = session.create_aggregate(ss)
+    assert new_aggregate == aggregate
+
+
+def test_apisession_get_user_info(requests_mock):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/users/current')
+    requests_mock.register_uri('GET', matcher, content=b'{"test": "key"}')
+    out = session.get_user_info()
+    assert out['test'] == 'key'
+
+
+@pytest.fixture(scope='session')
+def auth_token():
+    try:
+        token_req = requests.post(
+            'https://solarforecastarbiter.auth0.com/oauth/token',
+            headers={'content-type': 'application/json'},
+            data=('{"grant_type": "password", '
+                  '"username": "testing@solarforecastarbiter.org",'
+                  '"password": "Thepassword123!", '
+                  '"audience": "https://api.solarforecastarbiter.org", '
+                  '"client_id": "c16EJo48lbTCQEhqSztGGlmxxxmZ4zX7"}'))
+    except Exception:
+        return pytest.skip('Cannot retrieve valid Auth0 token')
+    else:
+        token = token_req.json()['access_token']
+        return token
+
+
+@pytest.fixture(scope='session')
+def real_session(auth_token):
+    session = api.APISession(
+        auth_token, base_url='https://dev-api.solarforecastarbiter.org')
+    try:
+        session.get('')
+    except Exception:
+        return pytest.skip('Cannot connect to dev api')
+    else:
+        return session
+
+
+def test_real_apisession_get_site(real_session):
+    site = real_session.get_site('123e4567-e89b-12d3-a456-426655440001')
+    assert isinstance(site, datamodel.Site)
+
+
+def test_real_apisession_list_sites(real_session):
+    sites = real_session.list_sites()
+    assert isinstance(sites, list)
+    assert isinstance(sites[0], datamodel.Site)
+
+
+def test_real_apisession_create_site(site_text, real_session):
+    sited = json.loads(site_text)
+    sited['name'] = f'Test create site {randint(0, 100)}'
+    site = datamodel.SolarPowerPlant.from_dict(sited)
+    new_site = real_session.create_site(site)
+    real_session.delete(f'/sites/{new_site.site_id}')
+    assert new_site.name == site.name
+    assert new_site.modeling_parameters == site.modeling_parameters
+
+
+def test_real_apisession_get_observation(real_session):
+    obs = real_session.get_observation('123e4567-e89b-12d3-a456-426655440000')
+    assert isinstance(obs, datamodel.Observation)
+
+
+def test_real_apisession_list_observations(real_session):
+    obs = real_session.list_observations()
+    assert isinstance(obs, list)
+    assert isinstance(obs[0], datamodel.Observation)
+
+
+def test_real_apisession_create_observation(single_observation_text,
+                                            single_observation,
+                                            real_session):
+    observationd = json.loads(single_observation_text)
+    observationd['name'] = f'Test create observation {randint(0, 100)}'
+    observationd['site'] = single_observation.site
+    observation = datamodel.Observation.from_dict(observationd)
+    new_observation = real_session.create_observation(observation)
+    real_session.delete(f'/observations/{new_observation.observation_id}')
+    for attr in ('name', 'site', 'variable', 'interval_label',
+                 'interval_length', 'extra_parameters', 'uncertainty'):
+        assert getattr(new_observation, attr) == getattr(observation, attr)
+
+
+def test_real_apisession_get_forecast(real_session):
+    fx = real_session.get_forecast('f8dd49fa-23e2-48a0-862b-ba0af6dec276')
+    assert isinstance(fx, datamodel.Forecast)
+
+
+def test_real_apisession_list_forecasts(real_session):
+    fxs = real_session.list_forecasts()
+    assert isinstance(fxs, list)
+    assert isinstance(fxs[0], datamodel.Forecast)
+
+
+def test_real_apisession_create_forecast(single_forecast_text, single_forecast,
+                                         real_session):
+    forecastd = json.loads(single_forecast_text)
+    forecastd['name'] = f'Test create forecast {randint(0, 100)}'
+    forecastd['site'] = single_forecast.site
+    forecast = datamodel.Forecast.from_dict(forecastd)
+    new_forecast = real_session.create_forecast(forecast)
+    real_session.delete(f'/forecasts/single/{new_forecast.forecast_id}')
+    for attr in ('name', 'site', 'variable', 'interval_label',
+                 'interval_length', 'lead_time_to_start', 'run_length',
+                 'extra_parameters'):
+        assert getattr(new_forecast, attr) == getattr(forecast, attr)
+
+
+def test_real_apisession_create_forecast_invalid(
+        single_forecast_text, single_forecast, real_session):
+    forecastd = json.loads(single_forecast_text)
+    forecastd['name'] = f'Test create forecast {randint(0, 100)}'
+    forecastd['site'] = single_forecast.site
+    forecastd['interval_label'] = 'mean'
+    forecast = datamodel.Forecast.from_dict(forecastd)
+    with pytest.raises(requests.exceptions.HTTPError) as e:
+        real_session.create_forecast(forecast)
+    assert 'Must be one of' in str(e.value)
+
+
+def test_real_apisession_get_prob_forecast(real_session):
+    fx = real_session.get_probabilistic_forecast(
+        'ef51e87c-50b9-11e9-8647-d663bd873d93')
+    assert isinstance(fx, datamodel.ProbabilisticForecast)
+
+
+def test_real_apisession_list_prob_forecasts(real_session):
+    fxs = real_session.list_probabilistic_forecasts()
+    assert isinstance(fxs, list)
+    assert isinstance(fxs[0], datamodel.ProbabilisticForecast)
+
+
+def test_real_apisession_create_prob_forecast(
+        prob_forecast_text, prob_forecasts, prob_forecast_constant_value,
+        real_session):
+    forecastd = json.loads(prob_forecast_text)
+    forecastd['name'] = f'Test create forecast {randint(0, 100)}'
+    forecastd['site'] = prob_forecasts.site
+    fx_prob_cv_d = prob_forecast_constant_value.to_dict()
+    fx_prob_cv_d['name'] = forecastd['name']
+    del fx_prob_cv_d['forecast_id']
+    forecastd['constant_values'] = (
+        datamodel.ProbabilisticForecastConstantValue.from_dict(fx_prob_cv_d), )
+    forecast = datamodel.ProbabilisticForecast.from_dict(forecastd)
+    new_forecast = real_session.create_probabilistic_forecast(forecast)
+    real_session.delete(f'/forecasts/cdf/{new_forecast.forecast_id}')
+    test_attrs = ('name', 'site', 'variable', 'interval_label',
+                  'interval_length', 'lead_time_to_start', 'run_length',
+                  'extra_parameters')
+    for attr in test_attrs:
+        assert getattr(new_forecast, attr) == getattr(forecast, attr)
+    for new_cv, cv in zip(new_forecast.constant_values,
+                          forecast.constant_values):
+        for attr in test_attrs:
+            assert getattr(new_cv, attr) == getattr(cv, attr)
+
+
+def test_real_apisession_get_prob_forecast_constant_value(real_session):
+    fx = real_session.get_probabilistic_forecast_constant_value(
+        '633f9b2a-50bb-11e9-8647-d663bd873d93')
+    assert isinstance(fx, datamodel.ProbabilisticForecastConstantValue)
+
+
+def test_real_apisession_get_observation_values(real_session):
+    start = pd.Timestamp('2019-04-15T00:00:00Z')
+    end = pd.Timestamp('2019-04-15T12:00:00Z')
+    obs = real_session.get_observation_values(
+        '123e4567-e89b-12d3-a456-426655440000',
+        start, end)
+    assert isinstance(obs, pd.DataFrame)
+    assert set(obs.columns) == set(['value', 'quality_flag'])
+    assert len(obs.index) > 0
+    pdt.assert_frame_equal(obs.loc[start:end], obs)
+
+
+def test_real_apisession_get_observation_values_tz(real_session):
+    # use different tzs to confirm that it works
+    start = pd.Timestamp('2019-04-14T22:00:00-0200')
+    end = pd.Timestamp('2019-04-15T05:00:00-0700')
+    obs = real_session.get_observation_values(
+        '123e4567-e89b-12d3-a456-426655440000',
+        start, end)
+    assert isinstance(obs, pd.DataFrame)
+    assert set(obs.columns) == set(['value', 'quality_flag'])
+    assert len(obs.index) > 0
+    end = end.tz_convert(start.tzinfo)
+    pdt.assert_frame_equal(obs.loc[start:end], obs)
+
+
+def test_real_apisession_get_forecast_values(real_session):
+    start = pd.Timestamp('2019-04-15T00:00:00Z')
+    end = pd.Timestamp('2019-04-15T12:00:00Z')
+    fx = real_session.get_forecast_values(
+        'f8dd49fa-23e2-48a0-862b-ba0af6dec276',
+        start, end)
+    assert isinstance(fx, pd.Series)
+    assert len(fx) > 0
+    pdt.assert_series_equal(fx.loc[start:end], fx)
+
+
+def test_real_apisession_get_forecast_values_tz(real_session):
+    # use different tzs to confirm that it works
+    start = pd.Timestamp('2019-04-14T20:00:00-0400')
+    end = pd.Timestamp('2019-04-15T13:00:00+0100')
+    fx = real_session.get_forecast_values(
+        'f8dd49fa-23e2-48a0-862b-ba0af6dec276',
+        start, end)
+    assert isinstance(fx, pd.Series)
+    assert len(fx) > 0
+    end = end.tz_convert(start.tzinfo)
+    pdt.assert_series_equal(fx.loc[start:end], fx)
+
+
+def test_real_apisession_get_prob_forecast_values_tz(real_session):
+    # use different tzs to confirm that it works
+    start = pd.Timestamp('2019-04-14T20:00:00-0400')
+    end = pd.Timestamp('2019-04-15T13:00:00+0100')
+    fx = real_session.get_probabilistic_forecast_constant_value_values(
+        '633f9b2a-50bb-11e9-8647-d663bd873d93',
+        start, end)
+    assert isinstance(fx, pd.Series)
+    assert len(fx) > 0
+    end = end.tz_convert(start.tzinfo)
+    pdt.assert_series_equal(fx.loc[start:end], fx)
+
+
+def test_real_apisession_post_observation_values(real_session):
+    test_df = pd.DataFrame(
+        {'value': [np.random.random()], 'quality_flag': [0]},
+        index=pd.DatetimeIndex([pd.Timestamp('2019-04-14T00:00:00Z')],
+                               name='timestamp'))
+    real_session.post_observation_values(
+        '123e4567-e89b-12d3-a456-426655440000', test_df)
+    obs = real_session.get_observation_values(
+        '123e4567-e89b-12d3-a456-426655440000',
+        pd.Timestamp('2019-04-14T00:00:00Z'),
+        pd.Timestamp('2019-04-14T00:01:00Z'))
+    # quality flag may be altered by validation routine
+    pdt.assert_series_equal(obs['value'], test_df['value'])
+
+
+def test_real_apisession_post_forecast_values(real_session):
+    test_ser = pd.Series(
+        [np.random.random()], name='value',
+        index=pd.DatetimeIndex([pd.Timestamp('2019-04-14T00:00:00Z')],
+                               name='timestamp'))
+    real_session.post_forecast_values(
+        'f8dd49fa-23e2-48a0-862b-ba0af6dec276', test_ser)
+    fx = real_session.get_forecast_values(
+        'f8dd49fa-23e2-48a0-862b-ba0af6dec276',
+        pd.Timestamp('2019-04-14T00:00:00Z'),
+        pd.Timestamp('2019-04-14T00:01:00Z'))
+    pdt.assert_series_equal(fx, test_ser)
+
+
+def test_real_apisession_post_prob_forecast_constant_val_values(real_session):
+    test_ser = pd.Series(
+        [np.random.random()], name='value',
+        index=pd.DatetimeIndex([pd.Timestamp('2019-04-14T00:00:00Z')],
+                               name='timestamp'))
+    real_session.post_probabilistic_forecast_constant_value_values(
+        '633f9b2a-50bb-11e9-8647-d663bd873d93', test_ser)
+    fx = real_session.get_probabilistic_forecast_constant_value_values(
+        '633f9b2a-50bb-11e9-8647-d663bd873d93',
+        pd.Timestamp('2019-04-14T00:00:00Z'),
+        pd.Timestamp('2019-04-14T00:01:00Z'))
+    pdt.assert_series_equal(fx, test_ser)
+
+
+def test_real_apisession_get_aggregate(real_session):
+    agg = real_session.get_aggregate('458ffc27-df0b-11e9-b622-62adb5fd6af0')
+    assert isinstance(agg, datamodel.Aggregate)
+
+
+def test_real_apisession_list_aggregates(real_session):
+    aggs = real_session.list_aggregates()
+    assert isinstance(aggs, list)
+    assert isinstance(aggs[0], datamodel.Aggregate)
+    assert '458ffc27-df0b-11e9-b622-62adb5fd6af0' in {
+        a.aggregate_id for a in aggs}
+
+
+def test_real_apisession_create_aggregate(real_session, aggregate):
+    new_agg = real_session.create_aggregate(aggregate)
+    real_session.delete(f'/aggregates/{new_agg.aggregate_id}')
+    for attr in ('name', 'description', 'variable', 'aggregate_type',
+                 'interval_length', 'interval_label', 'timezone'):
+        assert getattr(new_agg, attr) == getattr(aggregate, attr)
+    for i, obs in enumerate(new_agg.observations):
+        assert (
+            aggregate.observations[i].observation.observation_id ==
+            obs.observation.observation_id)
+        for attr in ('effective_from', 'effective_until',
+                     'observation_deleted_at'):
+            assert getattr(aggregate.observations[i], attr) == (
+                getattr(obs, attr))
+
+
+def test_real_apisession_get_aggregate_values(real_session):
+    start = pd.Timestamp('2019-04-15T00:00:00Z')
+    end = pd.Timestamp('2019-04-15T12:00:00Z')
+    agg = real_session.get_aggregate_values(
+        '458ffc27-df0b-11e9-b622-62adb5fd6af0',
+        start, end)
+    assert isinstance(agg, pd.DataFrame)
+    assert set(agg.columns) == set(['value', 'quality_flag'])
+    assert len(agg.index) > 0
+    pdt.assert_frame_equal(agg.loc[start:end], agg)
+
+
+def test_real_apisession_get_user_info(real_session):
+    user_info = real_session.get_user_info()
+    assert user_info['organization'] == 'Organization 1'

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -1,9 +1,8 @@
 import json
-from random import randint
 import re
+import copy
 
 
-import numpy as np
 import pandas as pd
 import pandas.testing as pdt
 import pytest
@@ -172,6 +171,16 @@ def test_apisession_list_observations(requests_mock, many_observations,
     assert obs_list == many_observations
 
 
+def test_apisession_list_observation_single(requests_mock, single_observation,
+                                            single_observation_text,
+                                            mock_list_sites):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/observations/.*')
+    requests_mock.register_uri('GET', matcher, content=single_observation_text)
+    obs_list = session.list_observations()
+    assert obs_list == [single_observation]
+
+
 def test_apisession_list_observations_empty(requests_mock):
     session = api.APISession('')
     matcher = re.compile(f'{session.base_url}/observations/.*')
@@ -212,6 +221,16 @@ def test_apisession_list_forecasts(requests_mock, many_forecasts,
     requests_mock.register_uri('GET', matcher, content=many_forecasts_text)
     fx_list = session.list_forecasts()
     assert fx_list == many_forecasts
+
+
+def test_apisession_list_forecast_single(requests_mock, single_forecast,
+                                         single_forecast_text, mock_get_site,
+                                         mock_get_agg):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/forecasts/.*')
+    requests_mock.register_uri('GET', matcher, content=single_forecast_text)
+    fx_list = session.list_forecasts()
+    assert fx_list == [single_forecast]
 
 
 def test_apisession_create_forecast(requests_mock, single_forecast,
@@ -281,6 +300,22 @@ def test_apisession_list_prob_forecasts(requests_mock, many_prob_forecasts,
         'GET', matcher, content=many_prob_forecasts_text)
     fx_list = session.list_probabilistic_forecasts()
     assert fx_list == many_prob_forecasts
+
+
+def test_apisession_list_prob_forecast_single(requests_mock, prob_forecasts,
+                                              prob_forecast_text,
+                                              mock_list_sites, mock_get_site,
+                                              prob_forecast_constant_value_text,
+                                              mock_get_agg):
+    session = api.APISession('')
+    matcher = re.compile(f'{session.base_url}/forecasts/cdf/single/.*')
+    requests_mock.register_uri(
+        'GET', matcher, content=prob_forecast_constant_value_text)
+    matcher = re.compile(session.base_url + r'/forecasts/cdf/$')
+    requests_mock.register_uri(
+        'GET', matcher, content=prob_forecast_text)
+    fx_list = session.list_probabilistic_forecasts()
+    assert fx_list == [prob_forecasts]
 
 
 def test_apisession_list_prob_forecasts_empty(requests_mock):
@@ -502,639 +537,37 @@ def test_apisession_get_prob_forecast_constant_value_values(
     pdt.assert_series_equal(out, forecast_values)
 
 
-@pytest.mark.parametrize('label,theslice', [
-    (None, slice(0, 10)),
-    ('beginning', slice(0, -1)),
-    ('ending', slice(1, 10))
-])
-def test_apisession_get_forecast_values_interval_label(
-        requests_mock, forecast_values, forecast_values_text, label, theslice,
-        fx_start_end):
+def test_apisession_get_prob_forecast_values(
+        requests_mock, mock_get_site,
+        prob_forecast_values, prob_forecast_values_text_list,
+        prob_forecast_text, prob_forecast_constant_value_text, fx_start_end):
     session = api.APISession('')
-    matcher = re.compile(f'{session.base_url}/forecasts/single/.*/values')
-    requests_mock.register_uri('GET', matcher, content=forecast_values_text)
-    out = session.get_forecast_values(
-        'fxid', fx_start_end[0], fx_start_end[1], label)
-    pdt.assert_series_equal(out, forecast_values.iloc[theslice])
 
+    # modify ProbabilisticForecast json text
+    probfx_json = json.loads(prob_forecast_text)
+    probfx_json['forecast_id'] = 'FXID'
+    probfx_json['axis'] = 'y'
+    cvs_json = json.loads(prob_forecast_constant_value_text)
+    cvs = []
+    for col in prob_forecast_values:
+        new_cv = copy.deepcopy(cvs_json)
+        new_cv['constant_value'] = col
+        new_cv['forecast_id'] = 'CV' + col
+        new_cv['axis'] = 'y'
+        cvs.append(new_cv)
+    probfx_json['constant_values'] = cvs
 
-def test_apisession_get_forecast_values_empty(requests_mock, empty_df):
-    session = api.APISession('')
-    matcher = re.compile(f'{session.base_url}/forecasts/single/.*/values')
-    requests_mock.register_uri('GET', matcher, content=b'{"values":[]}')
-    out = session.get_forecast_values(
-        'fxid', pd.Timestamp('2019-01-01T06:00:00-0700'),
-        pd.Timestamp('2019-01-01T11:00:00-0700'))
-    pdt.assert_series_equal(out, empty_df['value'])
-
-
-def test_apisession_post_observation_values(requests_mock, observation_values):
-    session = api.APISession('')
-    matcher = re.compile(f'{session.base_url}/observations/.*/values')
-    mocked = requests_mock.register_uri('POST', matcher)
-    session.post_observation_values('obsid', observation_values)
-    # observation_values_text has a different timestamp format
-    assert mocked.request_history[0].text == '{"values":[{"timestamp":"2019-01-01T19:00:00Z","value":0.0,"quality_flag":0},{"timestamp":"2019-01-01T19:05:00Z","value":1.0,"quality_flag":0},{"timestamp":"2019-01-01T19:10:00Z","value":1.5,"quality_flag":0},{"timestamp":"2019-01-01T19:15:00Z","value":9.9,"quality_flag":1},{"timestamp":"2019-01-01T19:20:00Z","value":2.0,"quality_flag":0},{"timestamp":"2019-01-01T19:25:00Z","value":-999.0,"quality_flag":3}]}'  # NOQA
-
-
-def test_apisession_post_forecast_values(requests_mock, forecast_values):
-    session = api.APISession('')
-    matcher = re.compile(f'{session.base_url}/forecasts/single/.*/values')
-    mocked = requests_mock.register_uri('POST', matcher)
-    session.post_forecast_values('fxid', forecast_values)
-    assert mocked.request_history[0].text == '{"values":[{"timestamp":"2019-01-01T13:00:00Z","value":0.0},{"timestamp":"2019-01-01T14:00:00Z","value":1.0},{"timestamp":"2019-01-01T15:00:00Z","value":2.0},{"timestamp":"2019-01-01T16:00:00Z","value":3.0},{"timestamp":"2019-01-01T17:00:00Z","value":4.0},{"timestamp":"2019-01-01T18:00:00Z","value":5.0}]}'  # NOQA
-
-
-def test_apisession_post_prob_forecast_constant_value_values(
-        requests_mock, forecast_values):
-    session = api.APISession('')
-    matcher = re.compile(f'{session.base_url}/forecasts/cdf/single/.*/values')
-    mocked = requests_mock.register_uri('POST', matcher)
-    session.post_probabilistic_forecast_constant_value_values(
-        'fxid', forecast_values)
-    assert mocked.request_history[0].text == '{"values":[{"timestamp":"2019-01-01T13:00:00Z","value":0.0},{"timestamp":"2019-01-01T14:00:00Z","value":1.0},{"timestamp":"2019-01-01T15:00:00Z","value":2.0},{"timestamp":"2019-01-01T16:00:00Z","value":3.0},{"timestamp":"2019-01-01T17:00:00Z","value":4.0},{"timestamp":"2019-01-01T18:00:00Z","value":5.0}]}'  # NOQA
-
-
-@pytest.mark.parametrize('match, meth', [
-    ('observations', 'get_observation_values'),
-    ('forecasts/single', 'get_forecast_values'),
-    ('forecasts/cdf/single',
-     'get_probabilistic_forecast_constant_value_values'),
-    ('aggregates', 'get_aggregate_values'),
-])
-def test_apisession_get_values(
-        requests_mock, mocker, single_observation, single_forecast,
-        prob_forecast_constant_value, aggregate, match, meth, fx_start_end):
-    objs = {
-        'observations': single_observation,
-        'forecasts/single': single_forecast,
-        'forecasts/cdf/single': prob_forecast_constant_value,
-        'aggregates': aggregate
-    }
-    obj = objs[match]
-    session = api.APISession('')
-    matcher = re.compile(
-        f'{session.base_url}/{match}/.*/values')
-    requests_mock.register_uri('GET', matcher, content=b'{"values":[]}')
-    status = mocker.patch(
-        f'solarforecastarbiter.io.api.APISession.{meth}')
-    session.get_values(obj, *fx_start_end)
-    assert status.called
-
-
-@pytest.fixture()
-def mock_request_fxobs(report_objects, mocker):
-    _, obs, fx0, fx1, agg, fxagg = report_objects
-    mocker.patch('solarforecastarbiter.io.api.APISession.get_observation',
-                 return_value=obs)
-    mocker.patch('solarforecastarbiter.io.api.APISession.get_aggregate',
-                 return_value=agg)
-
-    def returnone(fxid):
-        if fxid == "da2bc386-8712-11e9-a1c7-0a580a8200ae":
-            return fx0
-        elif fxid == "49220780-76ae-4b11-bef1-7a75bdc784e3":
-            return fxagg
-        else:
-            return fx1
-    mocker.patch('solarforecastarbiter.io.api.APISession.get_forecast',
-                 side_effect=returnone)
-
-
-def test_apisession_get_report(requests_mock, report_text, report_objects,
-                               mock_request_fxobs):
-    session = api.APISession('')
-    requests_mock.register_uri('GET', f'{session.base_url}/reports/',
-                               content=report_text)
-    out = session.get_report('')
-    expected = report_objects[0]
-    assert out == expected
-
-
-def test_apisession_get_report_with_raw(
-        requests_mock, report_text, report_objects, mock_request_fxobs,
-        raw_report, mocker):
-    raw = raw_report(False)
-    raw_dict = raw.to_dict()
-    report = json.loads(report_text)
-    report['raw_report'] = raw_dict
-    report_text = json.dumps(report).encode()
-    mocker.patch(
-        'solarforecastarbiter.io.api.APISession.get_raw_report_processed_data',
-        return_value=())
-    session = api.APISession('')
-    requests_mock.register_uri('GET', f'{session.base_url}/reports/',
-                               content=report_text)
-    out = session.get_report('')
-    expected = report_objects[0].replace(
-        raw_report=raw.replace(processed_forecasts_observations=()))
-    assert out == expected
-
-
-def test_apisession_list_reports(requests_mock, report_text, report_objects,
-                                 mock_request_fxobs):
-    session = api.APISession('')
-    requests_mock.register_uri('GET', f'{session.base_url}/reports',
-                               content=b'['+report_text+b']')
-    out = session.list_reports()
-    expected = [report_objects[0]]
-    assert out == expected
-
-
-def test_apisession_list_reports_empty(requests_mock):
-    session = api.APISession('')
-    requests_mock.register_uri('GET', f'{session.base_url}/reports',
-                               content=b'[]')
-    out = session.list_reports()
-    assert out == []
-
-
-def test_apisession_create_report(requests_mock, report_objects, mocker):
-    session = api.APISession('')
-    report = report_objects[0]
-    mocked = requests_mock.register_uri('POST', f'{session.base_url}/reports/')
-    mocker.patch('solarforecastarbiter.io.api.APISession.get_report',
-                 return_value=report)
-    expected = {
-        "report_parameters": {
-            "name": "NREL MIDC OASIS GHI Forecast Analysis",
-            "start": "2019-04-01T00:00:00-07:00",
-            "end": "2019-04-04T23:59:00-07:00",
-            "filters": [
-                {'quality_flags': [
-                    "USER FLAGGED",
-                    "NIGHTTIME",
-                    "LIMITS EXCEEDED",
-                    "STALE VALUES",
-                    "INTERPOLATED VALUES",
-                    "INCONSISTENT IRRADIANCE COMPONENTS",
-                ]},
-                {'time_of_day_range': ['12:00', '14:00']}],
-            "metrics": ["mae", "rmse", "mbe"],
-            "categories": ["total", "date", "hour"],
-            "object_pairs": [
-                {"forecast": "da2bc386-8712-11e9-a1c7-0a580a8200ae",
-                 "observation": "9f657636-7e49-11e9-b77f-0a580a8003e9"},
-                {"forecast": "68a1c22c-87b5-11e9-bf88-0a580a8200ae",
-                 "observation": "9f657636-7e49-11e9-b77f-0a580a8003e9"},
-                {"forecast": "49220780-76ae-4b11-bef1-7a75bdc784e3",
-                 "aggregate": "458ffc27-df0b-11e9-b622-62adb5fd6af0"}
-            ]
-        }}
-    session.create_report(report)
-    posted = mocked.last_request.json()
-    assert posted == expected
-
-
-def test_apisession_post_raw_report_processed_data(
-        requests_mock, raw_report, report_objects):
-    _, obs, fx0, fx1, agg, fxagg = report_objects
-    session = api.APISession('')
-    ids = [fx0.forecast_id, obs.observation_id, fx1.forecast_id,
-           obs.observation_id, fxagg.forecast_id, agg.aggregate_id]
-    mocked = requests_mock.register_uri(
-        'POST', re.compile(f'{session.base_url}/reports/.*/values'),
-        [{'text': id_} for id_ in ids])
-    inp = raw_report(True)
-    out = session.post_raw_report_processed_data('report_id', inp)
-    exp = raw_report(False)
-    assert out == exp.processed_forecasts_observations
-    history = mocked.request_history
-    for i, id_ in enumerate(ids):
-        assert id_ == history[i].json()['object_id']
-
-
-def test_apisession_get_raw_report_processed_data(
-        requests_mock, raw_report, report_objects):
-    _, obs, fx0, fx1, agg, fxagg = report_objects
-    session = api.APISession('')
-    ser = pd.Series(name='value', index=pd.DatetimeIndex(
-        [], tz='UTC', name='timestamp'), dtype=float)
-    val = utils.serialize_timeseries(ser)
+    matcher = re.compile(session.base_url + r'/forecasts/cdf/[\w-]*$')
     requests_mock.register_uri(
-        'GET', re.compile(f'{session.base_url}/reports/.*/values'),
-        json=[{'id': id_, 'processed_values': val} for id_ in
-              (fx0.forecast_id, fx1.forecast_id, obs.observation_id,
-               agg.aggregate_id, fxagg.forecast_id)])
-    inp = raw_report(False)
-    out = session.get_raw_report_processed_data('', inp)
-    for fxo in out:
-        pdt.assert_series_equal(fxo.forecast_values, ser)
-        pdt.assert_series_equal(fxo.observation_values, ser)
-
-
-def test_apisession_post_raw_report(requests_mock, raw_report, mocker,
-                                    report_objects):
-    raw = raw_report(True)
-    _, obs, fx0, fx1, agg, fxagg = report_objects
-    session = api.APISession('')
-    ids = [fx0.forecast_id, obs.observation_id, fx1.forecast_id,
-           obs.observation_id, agg.aggregate_id, fxagg.forecast_id]
-    requests_mock.register_uri(
-        'POST', re.compile(f'{session.base_url}/reports/.*/values'),
-        [{'text': id_} for id_ in ids])
-    mocked = requests_mock.register_uri(
-        'POST', re.compile(f'{session.base_url}/reports/.*/raw'))
-    status = mocker.patch(
-        'solarforecastarbiter.io.api.APISession.update_report_status')
-    session.post_raw_report('', raw)
-    assert isinstance(mocked.last_request.json(), dict)
-    assert status.called
-
-
-def test_apisession_update_report_status(requests_mock):
-    session = api.APISession('')
-    mocked = requests_mock.register_uri(
-        'POST', re.compile(f'{session.base_url}/reports/REPORT_ID/status/'))
-    session.update_report_status('REPORT_ID', 'complete')
-    assert mocked.last_request.url.split('/')[-1] == 'complete'
-
-
-@pytest.fixture()
-def mockobs(many_observations, mocker):
-    def _getobs(cls, observation_id):
-        for obs in many_observations:
-            if observation_id == obs.observation_id:
-                return obs
-
-    mocker.patch(
-        'solarforecastarbiter.io.api.APISession.get_observation',
-        new=_getobs)
-    mocker.patch(
-        'solarforecastarbiter.io.api.APISession.list_observations',
-        return_value=many_observations)
-
-
-def test_apisession_get_aggregate(requests_mock, aggregate_text, aggregate,
-                                  mockobs):
-    session = api.APISession('')
-    requests_mock.register_uri(
-        'GET', re.compile(f'{session.base_url}/aggregates/.*/metadata'),
-        content=aggregate_text)
-    agg = session.get_aggregate('')
-    assert agg == aggregate
-
-
-def test_apisession_list_aggregates(requests_mock, aggregate_text, aggregate,
-                                    mockobs):
-    session = api.APISession('')
-    requests_mock.register_uri(
-        'GET', re.compile(f'{session.base_url}/aggregates/'),
-        content=b'[' + aggregate_text + b']')
-    aggs = session.list_aggregates()
-    assert aggs[0] == aggregate
-
-
-def test_apisession_list_aggregates_empty(requests_mock):
-    session = api.APISession('')
-    matcher = re.compile(f'{session.base_url}/aggregates/.*')
-    requests_mock.register_uri('GET', matcher, content=b"[]")
-    obs_list = session.list_aggregates()
-    assert obs_list == []
-
-
-def test_apisession_create_aggregate(requests_mock, aggregate, aggregate_text,
-                                     mockobs):
-    session = api.APISession('')
-    matcher = re.compile(f'{session.base_url}/aggregates/.*')
-
-    def callback(request, context):
-        if request.url.endswith('aggregates/'):
-            ad = json.loads(aggregate_text)
-            for key in ('provider', 'aggregate_id', 'created_at',
-                        'modified_at', 'observations', 'interval_value_type'):
-                del ad[key]
-            assert ad == request.json()
-            return aggregate.aggregate_id
-        else:
-            rj = request.json()
-            assert 'observations' in rj
-            assert 'observation_id' in rj['observations'][0]
-            assert (
-                'effective_from' in rj['observations'][0]
-                or 'effective_until' in rj['observations'][0])
-
-    requests_mock.register_uri('POST', matcher, text=callback)
-    requests_mock.register_uri('GET', matcher, content=aggregate_text)
-    aggregate_dict = aggregate.to_dict()
-    del aggregate_dict['aggregate_id']
-    del aggregate_dict['interval_value_type']
-    ss = datamodel.Aggregate.from_dict(aggregate_dict)
-    new_aggregate = session.create_aggregate(ss)
-    assert new_aggregate == aggregate
-
-
-def test_apisession_get_user_info(requests_mock):
-    session = api.APISession('')
-    matcher = re.compile(f'{session.base_url}/users/current')
-    requests_mock.register_uri('GET', matcher, content=b'{"test": "key"}')
-    out = session.get_user_info()
-    assert out['test'] == 'key'
-
-
-@pytest.fixture(scope='session')
-def auth_token():
-    try:
-        token_req = requests.post(
-            'https://solarforecastarbiter.auth0.com/oauth/token',
-            headers={'content-type': 'application/json'},
-            data=('{"grant_type": "password", '
-                  '"username": "testing@solarforecastarbiter.org",'
-                  '"password": "Thepassword123!", '
-                  '"audience": "https://api.solarforecastarbiter.org", '
-                  '"client_id": "c16EJo48lbTCQEhqSztGGlmxxxmZ4zX7"}'))
-    except Exception:
-        return pytest.skip('Cannot retrieve valid Auth0 token')
-    else:
-        token = token_req.json()['access_token']
-        return token
-
-
-@pytest.fixture(scope='session')
-def real_session(auth_token):
-    session = api.APISession(
-        auth_token, base_url='https://dev-api.solarforecastarbiter.org')
-    try:
-        session.get('')
-    except Exception:
-        return pytest.skip('Cannot connect to dev api')
-    else:
-        return session
-
-
-def test_real_apisession_get_site(real_session):
-    site = real_session.get_site('123e4567-e89b-12d3-a456-426655440001')
-    assert isinstance(site, datamodel.Site)
-
-
-def test_real_apisession_list_sites(real_session):
-    sites = real_session.list_sites()
-    assert isinstance(sites, list)
-    assert isinstance(sites[0], datamodel.Site)
-
-
-def test_real_apisession_create_site(site_text, real_session):
-    sited = json.loads(site_text)
-    sited['name'] = f'Test create site {randint(0, 100)}'
-    site = datamodel.SolarPowerPlant.from_dict(sited)
-    new_site = real_session.create_site(site)
-    real_session.delete(f'/sites/{new_site.site_id}')
-    assert new_site.name == site.name
-    assert new_site.modeling_parameters == site.modeling_parameters
-
-
-def test_real_apisession_get_observation(real_session):
-    obs = real_session.get_observation('123e4567-e89b-12d3-a456-426655440000')
-    assert isinstance(obs, datamodel.Observation)
-
-
-def test_real_apisession_list_observations(real_session):
-    obs = real_session.list_observations()
-    assert isinstance(obs, list)
-    assert isinstance(obs[0], datamodel.Observation)
-
-
-def test_real_apisession_create_observation(single_observation_text,
-                                            single_observation,
-                                            real_session):
-    observationd = json.loads(single_observation_text)
-    observationd['name'] = f'Test create observation {randint(0, 100)}'
-    observationd['site'] = single_observation.site
-    observation = datamodel.Observation.from_dict(observationd)
-    new_observation = real_session.create_observation(observation)
-    real_session.delete(f'/observations/{new_observation.observation_id}')
-    for attr in ('name', 'site', 'variable', 'interval_label',
-                 'interval_length', 'extra_parameters', 'uncertainty'):
-        assert getattr(new_observation, attr) == getattr(observation, attr)
-
-
-def test_real_apisession_get_forecast(real_session):
-    fx = real_session.get_forecast('f8dd49fa-23e2-48a0-862b-ba0af6dec276')
-    assert isinstance(fx, datamodel.Forecast)
-
-
-def test_real_apisession_list_forecasts(real_session):
-    fxs = real_session.list_forecasts()
-    assert isinstance(fxs, list)
-    assert isinstance(fxs[0], datamodel.Forecast)
-
-
-def test_real_apisession_create_forecast(single_forecast_text, single_forecast,
-                                         real_session):
-    forecastd = json.loads(single_forecast_text)
-    forecastd['name'] = f'Test create forecast {randint(0, 100)}'
-    forecastd['site'] = single_forecast.site
-    forecast = datamodel.Forecast.from_dict(forecastd)
-    new_forecast = real_session.create_forecast(forecast)
-    real_session.delete(f'/forecasts/single/{new_forecast.forecast_id}')
-    for attr in ('name', 'site', 'variable', 'interval_label',
-                 'interval_length', 'lead_time_to_start', 'run_length',
-                 'extra_parameters'):
-        assert getattr(new_forecast, attr) == getattr(forecast, attr)
-
-
-def test_real_apisession_create_forecast_invalid(
-        single_forecast_text, single_forecast, real_session):
-    forecastd = json.loads(single_forecast_text)
-    forecastd['name'] = f'Test create forecast {randint(0, 100)}'
-    forecastd['site'] = single_forecast.site
-    forecastd['interval_label'] = 'mean'
-    forecast = datamodel.Forecast.from_dict(forecastd)
-    with pytest.raises(requests.exceptions.HTTPError) as e:
-        real_session.create_forecast(forecast)
-    assert 'Must be one of' in str(e.value)
-
-
-def test_real_apisession_get_prob_forecast(real_session):
-    fx = real_session.get_probabilistic_forecast(
-        'ef51e87c-50b9-11e9-8647-d663bd873d93')
-    assert isinstance(fx, datamodel.ProbabilisticForecast)
-
-
-def test_real_apisession_list_prob_forecasts(real_session):
-    fxs = real_session.list_probabilistic_forecasts()
-    assert isinstance(fxs, list)
-    assert isinstance(fxs[0], datamodel.ProbabilisticForecast)
-
-
-def test_real_apisession_create_prob_forecast(
-        prob_forecast_text, prob_forecasts, prob_forecast_constant_value,
-        real_session):
-    forecastd = json.loads(prob_forecast_text)
-    forecastd['name'] = f'Test create forecast {randint(0, 100)}'
-    forecastd['site'] = prob_forecasts.site
-    fx_prob_cv_d = prob_forecast_constant_value.to_dict()
-    fx_prob_cv_d['name'] = forecastd['name']
-    del fx_prob_cv_d['forecast_id']
-    forecastd['constant_values'] = (
-        datamodel.ProbabilisticForecastConstantValue.from_dict(fx_prob_cv_d), )
-    forecast = datamodel.ProbabilisticForecast.from_dict(forecastd)
-    new_forecast = real_session.create_probabilistic_forecast(forecast)
-    real_session.delete(f'/forecasts/cdf/{new_forecast.forecast_id}')
-    test_attrs = ('name', 'site', 'variable', 'interval_label',
-                  'interval_length', 'lead_time_to_start', 'run_length',
-                  'extra_parameters')
-    for attr in test_attrs:
-        assert getattr(new_forecast, attr) == getattr(forecast, attr)
-    for new_cv, cv in zip(new_forecast.constant_values,
-                          forecast.constant_values):
-        for attr in test_attrs:
-            assert getattr(new_cv, attr) == getattr(cv, attr)
-
-
-def test_real_apisession_get_prob_forecast_constant_value(real_session):
-    fx = real_session.get_probabilistic_forecast_constant_value(
-        '633f9b2a-50bb-11e9-8647-d663bd873d93')
-    assert isinstance(fx, datamodel.ProbabilisticForecastConstantValue)
-
-
-def test_real_apisession_get_observation_values(real_session):
-    start = pd.Timestamp('2019-04-15T00:00:00Z')
-    end = pd.Timestamp('2019-04-15T12:00:00Z')
-    obs = real_session.get_observation_values(
-        '123e4567-e89b-12d3-a456-426655440000',
-        start, end)
-    assert isinstance(obs, pd.DataFrame)
-    assert set(obs.columns) == set(['value', 'quality_flag'])
-    assert len(obs.index) > 0
-    pdt.assert_frame_equal(obs.loc[start:end], obs)
-
-
-def test_real_apisession_get_observation_values_tz(real_session):
-    # use different tzs to confirm that it works
-    start = pd.Timestamp('2019-04-14T22:00:00-0200')
-    end = pd.Timestamp('2019-04-15T05:00:00-0700')
-    obs = real_session.get_observation_values(
-        '123e4567-e89b-12d3-a456-426655440000',
-        start, end)
-    assert isinstance(obs, pd.DataFrame)
-    assert set(obs.columns) == set(['value', 'quality_flag'])
-    assert len(obs.index) > 0
-    end = end.tz_convert(start.tzinfo)
-    pdt.assert_frame_equal(obs.loc[start:end], obs)
-
-
-def test_real_apisession_get_forecast_values(real_session):
-    start = pd.Timestamp('2019-04-15T00:00:00Z')
-    end = pd.Timestamp('2019-04-15T12:00:00Z')
-    fx = real_session.get_forecast_values(
-        'f8dd49fa-23e2-48a0-862b-ba0af6dec276',
-        start, end)
-    assert isinstance(fx, pd.Series)
-    assert len(fx) > 0
-    pdt.assert_series_equal(fx.loc[start:end], fx)
-
-
-def test_real_apisession_get_forecast_values_tz(real_session):
-    # use different tzs to confirm that it works
-    start = pd.Timestamp('2019-04-14T20:00:00-0400')
-    end = pd.Timestamp('2019-04-15T13:00:00+0100')
-    fx = real_session.get_forecast_values(
-        'f8dd49fa-23e2-48a0-862b-ba0af6dec276',
-        start, end)
-    assert isinstance(fx, pd.Series)
-    assert len(fx) > 0
-    end = end.tz_convert(start.tzinfo)
-    pdt.assert_series_equal(fx.loc[start:end], fx)
-
-
-def test_real_apisession_get_prob_forecast_values_tz(real_session):
-    # use different tzs to confirm that it works
-    start = pd.Timestamp('2019-04-14T20:00:00-0400')
-    end = pd.Timestamp('2019-04-15T13:00:00+0100')
-    fx = real_session.get_probabilistic_forecast_constant_value_values(
-        '633f9b2a-50bb-11e9-8647-d663bd873d93',
-        start, end)
-    assert isinstance(fx, pd.Series)
-    assert len(fx) > 0
-    end = end.tz_convert(start.tzinfo)
-    pdt.assert_series_equal(fx.loc[start:end], fx)
-
-
-def test_real_apisession_post_observation_values(real_session):
-    test_df = pd.DataFrame(
-        {'value': [np.random.random()], 'quality_flag': [0]},
-        index=pd.DatetimeIndex([pd.Timestamp('2019-04-14T00:00:00Z')],
-                               name='timestamp'))
-    real_session.post_observation_values(
-        '123e4567-e89b-12d3-a456-426655440000', test_df)
-    obs = real_session.get_observation_values(
-        '123e4567-e89b-12d3-a456-426655440000',
-        pd.Timestamp('2019-04-14T00:00:00Z'),
-        pd.Timestamp('2019-04-14T00:01:00Z'))
-    # quality flag may be altered by validation routine
-    pdt.assert_series_equal(obs['value'], test_df['value'])
-
-
-def test_real_apisession_post_forecast_values(real_session):
-    test_ser = pd.Series(
-        [np.random.random()], name='value',
-        index=pd.DatetimeIndex([pd.Timestamp('2019-04-14T00:00:00Z')],
-                               name='timestamp'))
-    real_session.post_forecast_values(
-        'f8dd49fa-23e2-48a0-862b-ba0af6dec276', test_ser)
-    fx = real_session.get_forecast_values(
-        'f8dd49fa-23e2-48a0-862b-ba0af6dec276',
-        pd.Timestamp('2019-04-14T00:00:00Z'),
-        pd.Timestamp('2019-04-14T00:01:00Z'))
-    pdt.assert_series_equal(fx, test_ser)
-
-
-def test_real_apisession_post_prob_forecast_constant_val_values(real_session):
-    test_ser = pd.Series(
-        [np.random.random()], name='value',
-        index=pd.DatetimeIndex([pd.Timestamp('2019-04-14T00:00:00Z')],
-                               name='timestamp'))
-    real_session.post_probabilistic_forecast_constant_value_values(
-        '633f9b2a-50bb-11e9-8647-d663bd873d93', test_ser)
-    fx = real_session.get_probabilistic_forecast_constant_value_values(
-        '633f9b2a-50bb-11e9-8647-d663bd873d93',
-        pd.Timestamp('2019-04-14T00:00:00Z'),
-        pd.Timestamp('2019-04-14T00:01:00Z'))
-    pdt.assert_series_equal(fx, test_ser)
-
-
-def test_real_apisession_get_aggregate(real_session):
-    agg = real_session.get_aggregate('458ffc27-df0b-11e9-b622-62adb5fd6af0')
-    assert isinstance(agg, datamodel.Aggregate)
-
-
-def test_real_apisession_list_aggregates(real_session):
-    aggs = real_session.list_aggregates()
-    assert isinstance(aggs, list)
-    assert isinstance(aggs[0], datamodel.Aggregate)
-    assert '458ffc27-df0b-11e9-b622-62adb5fd6af0' in {
-        a.aggregate_id for a in aggs}
-
-
-def test_real_apisession_create_aggregate(real_session, aggregate):
-    new_agg = real_session.create_aggregate(aggregate)
-    real_session.delete(f'/aggregates/{new_agg.aggregate_id}')
-    for attr in ('name', 'description', 'variable', 'aggregate_type',
-                 'interval_length', 'interval_label', 'timezone'):
-        assert getattr(new_agg, attr) == getattr(aggregate, attr)
-    for i, obs in enumerate(new_agg.observations):
-        assert (
-            aggregate.observations[i].observation.observation_id ==
-            obs.observation.observation_id)
-        for attr in ('effective_from', 'effective_until',
-                     'observation_deleted_at'):
-            assert getattr(aggregate.observations[i], attr) == (
-                getattr(obs, attr))
-
-
-def test_real_apisession_get_aggregate_values(real_session):
-    start = pd.Timestamp('2019-04-15T00:00:00Z')
-    end = pd.Timestamp('2019-04-15T12:00:00Z')
-    agg = real_session.get_aggregate_values(
-        '458ffc27-df0b-11e9-b622-62adb5fd6af0',
-        start, end)
-    assert isinstance(agg, pd.DataFrame)
-    assert set(agg.columns) == set(['value', 'quality_flag'])
-    assert len(agg.index) > 0
-    pdt.assert_frame_equal(agg.loc[start:end], agg)
-
-
-def test_real_apisession_get_user_info(real_session):
-    user_info = real_session.get_user_info()
-    assert user_info['organization'] == 'Organization 1'
+        'GET', matcher, content=json.dumps(probfx_json).encode('utf-8'))
+    for cv in cvs:
+        id = cv['forecast_id']
+        cv = json.dumps(copy.deepcopy(cv))
+        requests_mock.register_uri(
+            'GET', f'/forecasts/cdf/single/{id}', content=cv.encode('utf-8'))
+    for cvv in prob_forecast_values_text_list:
+        id = json.loads(cvv)['forecast_id']
+        requests_mock.register_uri(
+            'GET', f'/forecasts/cdf/single/{id}/values', content=cvv)
+    out = session.get_probabilistic_forecast_values('', *fx_start_end)
+    pdt.assert_frame_equal(out, prob_forecast_values)

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -122,19 +122,8 @@ def _apply_probabilistic_metric_func(metric, fx, fx_prob, obs, **kwargs):
     if metric in probabilistic._REQ_REF_FX:
         return metric_func(obs, fx, fx_prob,
                            kwargs['ref_fx'], kwargs['ref_fx_prob'])
-    elif metric in probabilistic._REQ_2DFX:
-        all_pairs = kwargs['all_pairs']
-        fx_2d = []
-        fx_prob_2d = []
-        i = 0
-        for pair in all_pairs:
-            cv = pair.original.forecast.constant_values[i]
-            i_fx, i_fx_prob = _extract_prob_forecast_value_and_prob(pair, cv)
-            fx_2d.append(i_fx)
-            fx_prob_2d.append(i_fx_prob)
-        return metric_func(obs, fx_2d, fx_prob_2d)
     else:
-        return metric_func(obs, fx)
+        return metric_func(obs, fx.to_numpy(), fx_prob.to_numpy())
 
 
 def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
@@ -364,8 +353,6 @@ def calculate_probabilistic_metrics(processed_fx_obs, categories, metrics,
             # Group by category
             for cat, group in df.groupby(index_category):
 
-                import ipdb; ipdb.set_trace()
-
                 # Calculate
                 res = _apply_probabilistic_metric_func(
                     metric_, group.forecast, group.observation,
@@ -388,7 +375,8 @@ def calculate_probabilistic_metrics(processed_fx_obs, categories, metrics,
 
 
 def _transform_prob_forecast_value_and_prob(proc_fx_obs):
-    """Helper function that returns the series of physical values and
+    """
+    Helper function that returns ordered list of series of physical values and
     probabilities for a datamodel.ProcessedForecastObservation
 
     Parameters

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -286,7 +286,7 @@ def calculate_probabilistic_metrics(processed_fx_obs, categories, metrics,
         ref_fx_fx_prob = _transform_prob_forecast_value_and_prob(ref_fx_obs)
         out['reference_forecast_id'] = ref_fx_obs.original.forecast.forecast_id
         if (not ref_fx_fx_prob or
-            any([rfx[0].empty or rfx[1].empty for rfx in ref_fx_fx_prob])):
+                any([rfx[0].empty or rfx[1].empty for rfx in ref_fx_fx_prob])):
             raise RuntimeError("Missing reference probabilistic forecast "
                                "timeseries data.")
         elif ref_fx_obs.interval_label != processed_fx_obs.interval_label:
@@ -300,7 +300,8 @@ def calculate_probabilistic_metrics(processed_fx_obs, categories, metrics,
         ref_fx_fx_prob = [(None, None)]*len(fx_fx_prob)
 
     # No data or metrics
-    if not fx_fx_prob or any([fx[0].empty or fx[1].empty for fx in fx_fx_prob]):
+    if (not fx_fx_prob or
+            any([fx[0].empty or fx[1].empty for fx in fx_fx_prob])):
         raise RuntimeError("Missing probabilistic forecast timeseries data.")
     elif obs.empty:
         raise RuntimeError("No observation timeseries data.")

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -56,8 +56,6 @@ def calculate_metrics(processed_pairs, categories, metrics,
     * Support event metrics and forecasts
     """
     calc_metrics = []
-    all_pairs = None
-    const_value = None
     current_fx_id = -1
 
     for proc_fxobs in processed_pairs:
@@ -326,7 +324,8 @@ def calculate_probabilistic_metrics(processed_fx_obs, categories, metrics,
                         'reference_probability': ref_fx_prob}, axis=1)
 
         # Force `groupby` to be consistent with `interval_label`, i.e., if
-        # `interval_label == ending`, then the last interval should be in the bin
+        # `interval_label == ending`, then the last interval should be in the
+        # bin
         if processed_fx_obs.interval_label == "ending":
             df.index -= pd.Timedelta("1ns")
 
@@ -346,7 +345,7 @@ def calculate_probabilistic_metrics(processed_fx_obs, categories, metrics,
                     try:
                         ref_fx_vals = group.reference
                         ref_fx_prob_vals = group.reference_probability
-                    except:
+                    except AttributeError:
                         ref_fx_vals = None
                         ref_fx_prob_vals = None
 

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -17,7 +17,7 @@ import pandas as pd
 
 
 from solarforecastarbiter import datamodel
-from solarforecastarbiter.metrics import deterministic
+from solarforecastarbiter.metrics import deterministic, probabilistic
 
 
 logger = logging.getLogger(__name__)
@@ -57,40 +57,82 @@ def calculate_metrics(processed_pairs, categories, metrics,
     * Support event metrics and forecasts
     """
     calc_metrics = []
+    all_pairs = None
+    const_value = None
+    current_fx_id = -1
 
     for proc_fxobs in processed_pairs:
+        if proc_fxobs.original.forecast.forecast_id != current_fx_id:
+            fx_iter = 0
+            current_fx_id = proc_fxobs.original.forecast.forecast_id
 
-        # TODO: support ProbabilisticForecast
+        # determine type of metrics to calculate
         if isinstance(proc_fxobs.original.forecast,
                       datamodel.ProbabilisticForecast):
-            method_ = calculate_probabilistic_metrics
+            const_value = proc_fxobs.original.forecast.constant_value[fx_iter]
+            if any(x in probabilistic._REQ_2DFX for x in metrics):
+                all_pairs = processed_pairs
+            try:
+                metrics_ = calculate_probabilistic_metrics(
+                    proc_fxobs,
+                    categories,
+                    metrics,
+                    ref_fx_obs=ref_pair,
+                    all_proc_fx_obs=all_pairs,
+                    constant_value=const_value)
+            except RuntimeError as e:
+                logger.error('Failed to calculate probabilistic metrics'
+                             'for %s: %s',
+                             proc_fxobs.name, e)
         else:
-            method_ = calculate_deterministic_metrics
-        try:
-            metrics_ = method_(
-                proc_fxobs,
-                categories,
-                metrics,
-                ref_fx_obs=ref_pair,
-                normalizer=normalizer
-            )
-        except RuntimeError as e:
-            logger.error('Failed to calculate metrics for %s: %s',
-                         proc_fxobs.name, e)
-        else:
-            calc_metrics.append(metrics_)
+            try:
+                metrics_ = calculate_deterministic_metrics(
+                    proc_fxobs,
+                    categories,
+                    metrics,
+                    ref_fx_obs=ref_pair,
+                    normalizer=normalizer)
+            except RuntimeError as e:
+                logger.error('Failed to calculate deterministic metrics'
+                             'for %s: %s',
+                             proc_fxobs.name, e)
+        calc_metrics.append(metrics_)
+
+        fx_iter += 1
 
     return calc_metrics
 
 
 def _apply_deterministic_metric_func(metric, fx, obs, **kwargs):
     """Helper function to deal with variable number of arguments possible for
-    metric functions. """
+    deterministic metric functions."""
     metric_func = deterministic._MAP[metric][0]
     if metric in deterministic._REQ_REF_FX:
         return metric_func(obs, fx, kwargs['ref_fx'])
     elif metric in deterministic._REQ_NORM:
         return metric_func(obs, fx, kwargs['normalizer'])
+    else:
+        return metric_func(obs, fx)
+
+
+def _apply_probabilistic_metric_func(metric, fx, fx_prob, obs, **kwargs):
+    """Helper function to deal with variable number of arguments possible for
+    probabilistic metric functions."""
+    metric_func = probabilistic._MAP[metric][0]
+    if metric in probabilistic._REQ_REF_FX:
+        return metric_func(obs, fx, fx_prob,
+                           kwargs['ref_fx'], kwargs['ref_fx_prob'])
+    elif metric in probabilistic._REQ_2DFX:
+        all_pairs = kwargs['all_pairs']
+        fx_2d = []
+        fx_prob_2d = []
+        i = 0
+        for pair in all_pairs:
+            cv = pair.original.forecast.constant_values[i]
+            i_fx, i_fx_prob = _extract_prob_forecast_value_and_prob(pair, cv)
+            fx_2d.append(i_fx)
+            fx_prob_2d.append(i_fx_prob)
+        return metric_func(obs, fx_2d, fx_prob_2d)
     else:
         return metric_func(obs, fx)
 
@@ -126,6 +168,8 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
     RuntimeError
         If there is no forecast, observation timeseries data or no metrics
         are specified.
+    ValueError
+        If original and reference forecast `interval_label`s do not match.
 
     """
     out = {
@@ -209,7 +253,8 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
 
 
 def calculate_probabilistic_metrics(processed_fx_obs, categories, metrics,
-                                    ref_fx_obs=None, normalizer=1.0):
+                                    constant_value, ref_fx_obs=None,
+                                    all_pairs=None,):
     """
     Calculate probabilistic metrics for the processed data using the provided
     categories and metric types.
@@ -221,13 +266,15 @@ def calculate_probabilistic_metrics(processed_fx_obs, categories, metrics,
         List of categories to compute metrics over.
     metrics : list of str
         List of metrics to be computed.
-    ref_fx_obs :
-        solarforecastarbiter.datamodel.ProcessedForecastObservation
+    constant_value : float
+        Constant value associated with this ProcessedForecastObservation
+    ref_fx_obs : datamodel.ProcessedForecastObservation
         Reference forecast to be used when calculating skill metrics. Default
         is None and no skill metrics will be calculated.
-    normalizer : float
-        Normalized factor (should be in the same units as data). Default is
-        1.0 and only needed for normalized metrics.
+    all_pairs : list of datamodel.ProcessedForecastObservation
+        All ProcessedForecastObservation associated with the original
+        ProbabilisticForecast. Default is None and Continuous Ranked
+        Probability Score (CPRS) will not be computed.
 
     Returns
     -------
@@ -239,6 +286,9 @@ def calculate_probabilistic_metrics(processed_fx_obs, categories, metrics,
     RuntimeError
         If there is no forecast, observation timeseries data or no metrics
         are specified.
+    ValueError
+        If original and reference forecast `interval_label` or `axis` values
+        do not match.
 
     """
     out = {
@@ -251,5 +301,114 @@ def calculate_probabilistic_metrics(processed_fx_obs, categories, metrics,
     except AttributeError:
         out['aggregate_id'] = processed_fx_obs.original.aggregate.aggregate_id
 
-    fx = processed_fx_obs.forecast_values
+    import ipdb; ipdb.set_trace()
+
+    # Determine forecast physical and probabiltity values by axis
+    fx, fx_prob = _extract_prob_forecast_value_and_prob(
+        processed_fx_obs, constant_value)
     obs = processed_fx_obs.observation_values
+
+    # Check reference forecast is from processed pair, if needed
+    ref_fx = None
+    ref_fx_prob = None
+    if any(m in probabilistic._REQ_REF_FX for m in metrics):
+        if not ref_fx_obs:
+            raise RuntimeError("No reference forecast provided but it is "
+                               "required for desired metrics")
+
+        # ref_fx, ref_fx_prob = _extract_prob_forecast_value_and_prob(
+        #     ref_fx_obs, constant_value=)
+        out['reference_forecast_id'] = ref_fx_obs.original.forecast.forecast_id
+        if ref_fx.empty:
+            raise RuntimeError("No reference forecast timeseries data")
+        elif ref_fx_obs.interval_label != processed_fx_obs.interval_label:
+            raise ValueError("Mismatched `interval_label` between "
+                             "observation and reference forecast.")
+        elif (ref_fx_obs.original.forecast.axis !=
+              processed_fx_obs.original.forecast.axis):
+            raise ValueError("Mismatched `axis` between "
+                             "observation and reference forecast.")
+
+    # No data or metrics
+    if fx.empty:
+        raise RuntimeError("No Forecast timeseries data.")
+    elif obs.empty:
+        raise RuntimeError("No Observation timeseries data.")
+    elif len(metrics) == 0:
+        raise RuntimeError("No metrics specified.")
+
+    # Dataframe for grouping
+    # TODO: how to group all these
+    df = pd.concat({'forecast': fx,
+                    'forecast_probability': fx_prob,
+                    'observation': obs,
+                    'reference': ref_fx,
+                    'reference_probability': ref_fx_prob}, axis=1)
+
+    # Force `groupby` to be consistent with `interval_label`, i.e., if
+    # `interval_label == ending`, then the last interval should be in the bin
+    if processed_fx_obs.interval_label == "ending":
+        df.index -= pd.Timedelta("1ns")
+
+    metric_vals = []
+    # Calculate metrics
+    for category in set(categories):
+        # total (special category)
+        if category == 'total':
+            index_category = lambda x: 0  # NOQA
+        else:
+            index_category = getattr(df.index, category)
+
+        # Calculate each metric
+        for metric_ in set(metrics):
+            # Group by category
+            for cat, group in df.groupby(index_category):
+
+                import ipdb; ipdb.set_trace()
+
+                # Calculate
+                res = _apply_probabilistic_metric_func(
+                    metric_, group.forecast, group.observation,
+                    ref_fx=ref_fx, ref_fx_prob=ref_fx_prob,
+                    all_pairs=all_pairs)
+
+                # Change category label of the group from numbers
+                # to e.g. January or Monday
+                if category == 'month':
+                    cat = calendar.month_abbr[cat]
+                elif category == 'weekday':
+                    cat = calendar.day_abbr[cat]
+
+                metric_vals.append(datamodel.MetricValue(
+                    category, metric_, str(cat), res))
+
+    out['values'] = tuple(metric_vals)
+    calc_metrics = datamodel.MetricResult.from_dict(out)
+    return calc_metrics
+
+
+def _transform_prob_forecast_value_and_prob(proc_fx_obs):
+    """Helper function that returns the series of physical values and
+    probabilities for a datamodel.ProcessedForecastObservation
+
+    Parameters
+    ----------
+    proc_fx_obs : datamodel.ProcessedForecastObservation
+
+    Returns
+    -------
+    fx_fx_prob : list of tuples of (n,) array_like
+        Forecast physical values.
+    """
+    fx_fx_prob = []
+    df = proc_fx_obs.forecast_values
+    assert isinstance(df, pd.DataFrame)
+    for col in proc_fx_obs.forecast_values.columns:
+        if proc_fx_obs.original.forecast.axis == 'x':
+            fx_prob = df[col]
+            fx = pd.Series([float(col)]*fx_prob.size)
+        else:  # 'y'
+            fx = df[col]
+            fx_prob = pd.Series([float(col)]*fx.size)
+        fx_fx_prob.append((fx, fx_prob))
+    return fx_fx_prob

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -70,7 +70,7 @@ def calculate_metrics(processed_pairs, categories, metrics,
                     ref_fx_obs=ref_pair))
             except RuntimeError as e:
                 logger.error('Failed to calculate probabilistic metrics'
-                             'for %s: %s',
+                             ' for %s: %s',
                              proc_fxobs.name, e)
         else:
             try:
@@ -81,7 +81,7 @@ def calculate_metrics(processed_pairs, categories, metrics,
                     ref_fx_obs=ref_pair))
             except RuntimeError as e:
                 logger.error('Failed to calculate deterministic metrics'
-                             'for %s: %s',
+                             ' for %s: %s',
                              proc_fxobs.name, e)
 
     return calc_metrics

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -285,7 +285,8 @@ def calculate_probabilistic_metrics(processed_fx_obs, categories, metrics,
 
         ref_fx_fx_prob = _transform_prob_forecast_value_and_prob(ref_fx_obs)
         out['reference_forecast_id'] = ref_fx_obs.original.forecast.forecast_id
-        if any([rfx[0].empty or rfx[1].empty for rfx in ref_fx_fx_prob]):
+        if (not ref_fx_fx_prob or
+            any([rfx[0].empty or rfx[1].empty for rfx in ref_fx_fx_prob])):
             raise RuntimeError("Missing reference probabilistic forecast "
                                "timeseries data.")
         elif ref_fx_obs.interval_label != processed_fx_obs.interval_label:
@@ -299,7 +300,7 @@ def calculate_probabilistic_metrics(processed_fx_obs, categories, metrics,
         ref_fx_fx_prob = [(None, None)]*len(fx_fx_prob)
 
     # No data or metrics
-    if any([fx[0].empty or fx[1].empty for fx in fx_fx_prob]):
+    if not fx_fx_prob or any([fx[0].empty or fx[1].empty for fx in fx_fx_prob]):
         raise RuntimeError("Missing probabilistic forecast timeseries data.")
     elif obs.empty:
         raise RuntimeError("No observation timeseries data.")

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -68,34 +68,28 @@ def calculate_metrics(processed_pairs, categories, metrics,
         # determine type of metrics to calculate
         if isinstance(proc_fxobs.original.forecast,
                       datamodel.ProbabilisticForecast):
-            const_value = proc_fxobs.original.forecast.constant_value[fx_iter]
-            if any(x in probabilistic._REQ_2DFX for x in metrics):
-                all_pairs = processed_pairs
             try:
-                metrics_ = calculate_probabilistic_metrics(
+                calc_metrics.append(calculate_probabilistic_metrics(
                     proc_fxobs,
                     categories,
                     metrics,
-                    ref_fx_obs=ref_pair,
-                    all_proc_fx_obs=all_pairs,
-                    constant_value=const_value)
+                    ref_fx_obs=ref_pair))
             except RuntimeError as e:
                 logger.error('Failed to calculate probabilistic metrics'
                              'for %s: %s',
                              proc_fxobs.name, e)
         else:
             try:
-                metrics_ = calculate_deterministic_metrics(
+                calc_metrics.append(calculate_deterministic_metrics(
                     proc_fxobs,
                     categories,
                     metrics,
                     ref_fx_obs=ref_pair,
-                    normalizer=normalizer)
+                    normalizer=normalizer))
             except RuntimeError as e:
                 logger.error('Failed to calculate deterministic metrics'
                              'for %s: %s',
                              proc_fxobs.name, e)
-        calc_metrics.append(metrics_)
 
         fx_iter += 1
 

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -464,6 +464,3 @@ _REQ_REF_FX = ['s']
 
 # Functions that require normalized factor
 _REQ_NORM = ['nmae', 'nmbe', 'nrmse']
-
-# Functions that require multiple forecasts (as 2dim)
-_REQ_2DFX = ['crps']

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -464,3 +464,6 @@ _REQ_REF_FX = ['s']
 
 # Functions that require normalized factor
 _REQ_NORM = ['nmae', 'nmbe', 'nrmse']
+
+# Functions that require multiple forecasts (as 2dim)
+_REQ_2DFX = ['crps']

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -402,7 +402,7 @@ _MAP = {
     'rel': (reliability, 'REL'),
     'res': (resolution, 'RES'),
     'unc': (uncertainty, 'UNC'),
-    'sh': (sharpness, 'SH'),
+    #'sh': (sharpness, 'SH'),  # TODO
     'crps': (continuous_ranked_probability_score, 'CRPS'),
 }
 
@@ -413,3 +413,9 @@ _REQ_REF_FX = ['bss']
 
 # Functions that require normalized factor
 _REQ_NORM = []
+
+# Functions that require multiple forecasts (as 2dim)
+_REQ_2DFX = ['crps']
+
+# TODO: Functions that require two forecasts (e.g., sharpness)
+# _REQ_FX_FX = ['sh']

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -414,8 +414,8 @@ _REQ_REF_FX = ['bss']
 # Functions that require normalized factor
 _REQ_NORM = []
 
-# Functions that require multiple forecasts (as 2dim)
-_REQ_2DFX = ['crps']
+# Functions that require full distribution forecasts (as 2dim)
+_REQ_DIST = ['crps']
 
 # TODO: Functions that require two forecasts (e.g., sharpness)
 # _REQ_FX_FX = ['sh']

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -402,7 +402,7 @@ _MAP = {
     'rel': (reliability, 'REL'),
     'res': (resolution, 'RES'),
     'unc': (uncertainty, 'UNC'),
-    #'sh': (sharpness, 'SH'),  # TODO
+    # 'sh': (sharpness, 'SH'),  # TODO
     'crps': (continuous_ranked_probability_score, 'CRPS'),
 }
 

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -15,7 +15,7 @@ DET_NO_NORM = (set(DETERMINISTIC_METRICS) - set(deterministic._REQ_NORM))
 DET_NO_REF = (set(DETERMINISTIC_METRICS) - set(deterministic._REQ_REF_FX))
 DET_NO_REF_NO_NORM = (set(DET_NO_NORM) - set(deterministic._REQ_REF_FX))
 PROBABILISTIC_METRICS = list(probabilistic._MAP.keys())
-#PROB_NO_NORM = (set(PROBABILISTIC_METRICS) - set(probabilistic._REQ_NORM))
+# PROB_NO_NORM = (set(PROBABILISTIC_METRICS) - set(probabilistic._REQ_NORM))
 PROB_NO_REF = (set(PROBABILISTIC_METRICS) - set(probabilistic._REQ_REF_FX))
 PROB_NO_2DFX = (set(PROBABILISTIC_METRICS) - set(probabilistic._REQ_2DFX))
 LIST_OF_CATEGORIES = list(datamodel.ALLOWED_CATEGORIES.keys())
@@ -31,16 +31,16 @@ def create_processed_fxobs(create_datetime_index):
             interval_label = fxobs.forecast.interval_label
 
         if (isinstance(fx_values, pd.Series) or
-            isinstance(fx_values, pd.DataFrame)):
+           isinstance(fx_values, pd.DataFrame)):
             conv_fx_values = fx_values
         else:
-            conv_fx_values = pd.Series(fx_values,
-                index=create_datetime_index(len(fx_values)))
+            conv_fx_values = pd.Series(
+                fx_values, index=create_datetime_index(len(fx_values)))
         if isinstance(obs_values, pd.Series):
             conv_obs_values = obs_values
         else:
-            conv_obs_values = pd.Series(obs_values,
-                index=create_datetime_index(len(obs_values)))
+            conv_obs_values = pd.Series(
+                obs_values, index=create_datetime_index(len(obs_values)))
 
         return datamodel.ProcessedForecastObservation(
             fxobs.forecast.name,
@@ -219,7 +219,7 @@ def test_calculate_metrics_with_probablistic(single_observation,
         prob_forecasts, prob_forecasts.axis, constant_values=const_values)
     ref_prfxobs = datamodel.ForecastObservation(conv_ref_prob_fx,
                                                 single_observation)
-    proc_ref_prfx_obs = create_processed_fxobs(prfxobs,
+    proc_ref_prfx_obs = create_processed_fxobs(ref_prfxobs,
                                                ref_fx_values,
                                                obs_values)
     result = calculator.calculate_metrics([proc_prfx_obs], LIST_OF_CATEGORIES,
@@ -234,8 +234,10 @@ def test_calculate_metrics_with_probablistic(single_observation,
 
 @pytest.mark.filterwarnings('ignore::RuntimeWarning')
 def test_calculate_metrics_with_probablistic_no_ref(single_observation,
-        prob_forecasts, create_processed_fxobs, create_datetime_index,
-        copy_prob_forecast_with_axis):
+                                                    prob_forecasts,
+                                                    create_processed_fxobs,
+                                                    create_datetime_index,
+                                                    copy_prob_forecast_with_axis):  # NOQA
     const_values = [10, 20, 30]
     conv_prob_fx = copy_prob_forecast_with_axis(
         prob_forecasts, prob_forecasts.axis, constant_values=const_values)
@@ -415,10 +417,10 @@ def test_calculate_probabilistic_metrics_no_metrics(
         )
 
 
-def test_calculate_probabilistic_metrics_no_reference(
-    single_prob_forecast_observation, create_processed_fxobs):
+def test_calculate_probabilistic_metrics_no_ref(
+        single_prob_forecast_observation, create_processed_fxobs):
     proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
-                                        pd.DataFrame(np.random.randn(3,10)),
+                                        pd.DataFrame(np.random.randn(10, 3)),
                                         pd.Series(np.random.randn(10)))
     with pytest.raises(RuntimeError):
         calculator.calculate_probabilistic_metrics(
@@ -427,26 +429,23 @@ def test_calculate_probabilistic_metrics_no_reference(
 
 
 def test_calculate_probabilistic_metrics_no_reference_data(
-    single_prob_forecast_observation, create_processed_fxobs):
+        single_prob_forecast_observation, create_processed_fxobs):
     proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
-                                        pd.DataFrame(np.random.randn(3,10)),
+                                        pd.DataFrame(np.random.randn(10, 3)),
                                         pd.Series(np.random.randn(10)))
-    proc_ref = create_processed_fxobs(single_prob_forecast_observation,
-                                      pd.DataFrame(),
-                                      pd.Series([], dtype=float))
     with pytest.raises(RuntimeError):
         calculator.calculate_probabilistic_metrics(
-            proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX
+            proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX,
         )
 
 
 def test_calculate_probabilistic_metrics_bad_reference_interval_label(
-    single_prob_forecast_observation, create_processed_fxobs):
+        single_prob_forecast_observation, create_processed_fxobs):
     proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
-                                        pd.DataFrame(np.random.randn(3,10)),
+                                        pd.DataFrame(np.random.randn(10, 3)),
                                         pd.Series(np.random.randn(10)))
     proc_ref = create_processed_fxobs(single_prob_forecast_observation,
-                                      pd.DataFrame(np.random.randn(3,10)),
+                                      pd.DataFrame(np.random.randn(10, 3)),
                                       pd.Series(np.random.randn(10)))
     proc_ref = proc_ref.replace(interval_label='ending')
     with pytest.raises(ValueError):
@@ -457,16 +456,16 @@ def test_calculate_probabilistic_metrics_bad_reference_interval_label(
 
 
 def test_calculate_probabilistic_metrics_bad_reference_axis(
-    single_prob_forecast_observation, prob_forecasts, single_observation,
-    create_processed_fxobs,
-    copy_prob_forecast_with_axis):
+        single_prob_forecast_observation, prob_forecasts, single_observation,
+        create_processed_fxobs,
+        copy_prob_forecast_with_axis):
     proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
-                                        pd.DataFrame(np.random.randn(3,10)),
+                                        pd.DataFrame(np.random.randn(10, 3)),
                                         pd.Series(np.random.randn(10)))
     conv_fx = copy_prob_forecast_with_axis(prob_forecasts, axis='y')
     ref_fxobs = datamodel.ForecastObservation(conv_fx, single_observation)
     proc_ref = create_processed_fxobs(ref_fxobs,
-                                      pd.DataFrame(np.random.randn(3,10)),
+                                      pd.DataFrame(np.random.randn(10, 3)),
                                       pd.Series(np.random.randn(10)))
     with pytest.raises(ValueError):
         calculator.calculate_probabilistic_metrics(
@@ -476,7 +475,7 @@ def test_calculate_probabilistic_metrics_bad_reference_axis(
 
 
 def test_calculate_probabilistic_metrics_missing_values(
-    single_prob_forecast_observation, create_processed_fxobs):
+        single_prob_forecast_observation, create_processed_fxobs):
     proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
                                         pd.DataFrame(),
                                         pd.Series(np.random.randn(10)))
@@ -487,9 +486,9 @@ def test_calculate_probabilistic_metrics_missing_values(
 
 
 def test_calculate_probabilistic_metrics_missing_observation(
-    single_prob_forecast_observation, create_processed_fxobs):
+        single_prob_forecast_observation, create_processed_fxobs):
     proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
-                                        pd.DataFrame(np.random.randn(3,10)),
+                                        pd.DataFrame(np.random.randn(10, 3)),
                                         pd.Series([], dtype=float))
     with pytest.raises(RuntimeError):
         calculator.calculate_probabilistic_metrics(
@@ -546,8 +545,10 @@ def test_calculate_probabilistic_metrics(categories, metrics,
         prob_forecasts, axis, prob_fx_df.columns.tolist())
     conv_ref_fx = copy_prob_forecast_with_axis(
         prob_forecasts, axis, prob_fx_df.columns.tolist())
-    prob_fxobs = datamodel.ForecastObservation(conv_prob_fx, single_observation)
-    ref_fxobs = datamodel.ForecastObservation(conv_ref_fx, single_observation)
+    prob_fxobs = datamodel.ForecastObservation(
+        conv_prob_fx, single_observation)
+    ref_fxobs = datamodel.ForecastObservation(
+        conv_ref_fx, single_observation)
     pair = create_processed_fxobs(prob_fxobs, prob_fx_df, obs)
     ref = create_processed_fxobs(ref_fxobs, ref_fx_df, obs)
 
@@ -558,8 +559,8 @@ def test_calculate_probabilistic_metrics(categories, metrics,
     assert len(results) == len(prob_fx_df.columns)
     assert all([isinstance(x, datamodel.MetricResult) for x in results])
     cvs = pair.original.forecast.constant_values
-    assert set([r.forecast_id for r in results]) == \
-           set([p.forecast_id for p in cvs])
+    assert (set([r.forecast_id for r in results]) ==
+            set([p.forecast_id for p in cvs]))
     for r in results:
         verify_metric_result(r, pair, categories, metrics)
 
@@ -634,9 +635,9 @@ def test_apply_deterministic_bad_metric_func():
 
     # Briar Skill Score with no reference
     ('bss', [1, 1, 1], [100, 100, 100], [0, 0, 0],
-            None, None, 1.),
+        None, None, 1.),
     ('bss', [1, 1, 1], [100, 100, 100], [1, 1, 1],
-            [0, 0, 0], [100, 100, 100], 1.),
+        [0, 0, 0], [100, 100, 100], 1.),
 
     ('rel', [1, 1, 1], [100, 100, 100], [1, 1, 1], None, None, 0.),
     ('res', [1, 1, 1], [100, 100, 100], [1, 1, 1], None, None, 0.),
@@ -653,17 +654,17 @@ def test_apply_probabilistic_metric_func(metric, fx, fx_prob, obs,
                                          ref_fx, ref_fx_prob, expect,
                                          create_datetime_index):
     if metric == 'crps':
-        fx_data = pd.DataFrame(fx,
-            index=create_datetime_index(len(fx)), dtype=float)
-        fx_prob_data = pd.DataFrame(fx_prob,
-            index=create_datetime_index(len(fx_prob)), dtype=float)
+        fx_data = pd.DataFrame(
+            fx, index=create_datetime_index(len(fx)), dtype=float)
+        fx_prob_data = pd.DataFrame(
+            fx_prob, index=create_datetime_index(len(fx_prob)), dtype=float)
     else:
-        fx_data = pd.Series(fx,
-            index=create_datetime_index(len(fx)), dtype=float)
-        fx_prob_data = pd.Series(fx_prob,
-            index=create_datetime_index(len(fx_prob)), dtype=float)
-    obs_series = pd.Series(obs,
-        index=create_datetime_index(len(obs)), dtype=float)
+        fx_data = pd.Series(
+            fx, index=create_datetime_index(len(fx)), dtype=float)
+        fx_prob_data = pd.Series(
+            fx_prob, index=create_datetime_index(len(fx_prob)), dtype=float)
+    obs_series = pd.Series(
+        obs, index=create_datetime_index(len(obs)), dtype=float)
 
     # Check metrics that require reference forecast kwarg
     if metric in ['bss']:
@@ -673,10 +674,10 @@ def test_apply_probabilistic_metric_func(metric, fx, fx_prob, obs,
                 calculator._apply_probabilistic_metric_func(
                     metric, fx_data, fx_prob_data, obs_series)
         else:
-            ref_fx_data = pd.Series(ref_fx,
-                index=create_datetime_index(len(ref_fx)))
-            ref_fx_prob_data = pd.Series(ref_fx_prob,
-                index=create_datetime_index(len(ref_fx_prob)))
+            ref_fx_data = pd.Series(
+                ref_fx, index=create_datetime_index(len(ref_fx)))
+            ref_fx_prob_data = pd.Series(
+                ref_fx_prob, index=create_datetime_index(len(ref_fx_prob)))
             metric_value = calculator._apply_probabilistic_metric_func(
                 metric, fx_data, fx_prob_data, obs_series,
                 ref_fx=ref_fx_data,
@@ -865,7 +866,8 @@ def test_interval_label_match(site_metadata, label_fx, label_ref,
 ])
 def test_transform_prob_forecast_value_and_prob(prob_forecasts,
                                                 single_observation,
-                                                prob_fx_df, axis, exp_fx_fx_prob,
+                                                prob_fx_df, axis,
+                                                exp_fx_fx_prob,
                                                 copy_prob_forecast_with_axis,
                                                 create_processed_fxobs):
     conv_prob_fx = copy_prob_forecast_with_axis(prob_forecasts, axis)

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -17,7 +17,8 @@ DET_NO_REF_NO_NORM = (set(DET_NO_NORM) - set(deterministic._REQ_REF_FX))
 PROBABILISTIC_METRICS = list(probabilistic._MAP.keys())
 # PROB_NO_NORM = (set(PROBABILISTIC_METRICS) - set(probabilistic._REQ_NORM))
 PROB_NO_REF = (set(PROBABILISTIC_METRICS) - set(probabilistic._REQ_REF_FX))
-PROB_NO_2DFX = (set(PROBABILISTIC_METRICS) - set(probabilistic._REQ_2DFX))
+PROB_NO_DIST = (set(PROBABILISTIC_METRICS) - set(probabilistic._REQ_DIST))
+PROB_NO_REF_NO_DIST = (set(PROB_NO_REF) - set(probabilistic._REQ_DIST))
 LIST_OF_CATEGORIES = list(datamodel.ALLOWED_CATEGORIES.keys())
 
 
@@ -141,10 +142,8 @@ def ref_fx_obs(create_processed_fxobs, many_forecast_observation):
     (LIST_OF_CATEGORIES, DET_NO_REF),
     (LIST_OF_CATEGORIES, DET_NO_REF_NO_NORM)
 ])
-def test_calculate_metrics_no_reference(
-        categories, metrics, proc_fx_obs):
-    result = calculator.calculate_metrics(proc_fx_obs,
-                                          categories, metrics)
+def test_calculate_metrics_no_reference(categories, metrics, proc_fx_obs):
+    result = calculator.calculate_metrics(proc_fx_obs, categories, metrics)
     assert isinstance(result, list)
     assert isinstance(result[0], datamodel.MetricResult)
     assert len(result) == len(proc_fx_obs)
@@ -204,13 +203,15 @@ def test_calculate_metrics_with_probablistic(single_observation,
                                            obs_values)
 
     # Without reference
-    result = calculator.calculate_metrics([proc_prfx_obs], LIST_OF_CATEGORIES,
-                                          PROB_NO_REF)
-    assert isinstance(result, list)
-    assert len(result) == 1
-    assert isinstance(result[0], list)
-    assert len(result[0]) == len(const_values)
-    assert isinstance(result[0][0], datamodel.MetricResult)
+    results = calculator.calculate_metrics([proc_prfx_obs], LIST_OF_CATEGORIES,
+                                           PROB_NO_REF)
+    assert isinstance(results, list)
+    assert len(results) == 1
+    assert isinstance(results[0], tuple)
+    single_results, dist_results = results[0]
+    assert len(single_results) == len(const_values)
+    assert all(isinstance(r, datamodel.MetricResult) for r in single_results)
+    assert isinstance(dist_results, datamodel.MetricResult)
 
     # With reference
     ref_fx_values = pd.DataFrame(np.random.randn(10, 3)+10,
@@ -222,14 +223,16 @@ def test_calculate_metrics_with_probablistic(single_observation,
     proc_ref_prfx_obs = create_processed_fxobs(ref_prfxobs,
                                                ref_fx_values,
                                                obs_values)
-    result = calculator.calculate_metrics([proc_prfx_obs], LIST_OF_CATEGORIES,
-                                          PROBABILISTIC_METRICS,
-                                          ref_pair=proc_ref_prfx_obs)
-    assert isinstance(result, list)
-    assert len(result) == 1
-    assert isinstance(result[0], list)
-    assert len(result[0]) == len(const_values)
-    assert isinstance(result[0][0], datamodel.MetricResult)
+    results = calculator.calculate_metrics([proc_prfx_obs], LIST_OF_CATEGORIES,
+                                           PROBABILISTIC_METRICS,
+                                           ref_pair=proc_ref_prfx_obs)
+    assert isinstance(results, list)
+    assert len(results) == 1
+    assert isinstance(results[0], tuple)
+    single_results, dist_results = results[0]
+    assert len(single_results) == len(const_values)
+    assert all(isinstance(r, datamodel.MetricResult) for r in single_results)
+    assert isinstance(dist_results, datamodel.MetricResult)
 
 
 @pytest.mark.filterwarnings('ignore::RuntimeWarning')
@@ -479,10 +482,8 @@ def test_calculate_probabilistic_metrics_interval_label_ending(
         pd.Series(np.random.randn(10), index=create_dt_index(10))
     )
     proc_fxobs = proc_fxobs.replace(interval_label='ending')
-    with pytest.raises(ValueError):
-        calculator.calculate_probabilistic_metrics(
-            proc_fxobs, LIST_OF_CATEGORIES, PROB_NO_REF,
-        )
+    calculator.calculate_probabilistic_metrics(proc_fxobs, LIST_OF_CATEGORIES,
+                                               PROB_NO_REF)
 
 
 def test_calculate_probabilistic_metrics_bad_reference_axis(
@@ -532,17 +533,19 @@ def test_calculate_metrics_with_probablistic_simple(prob_forecasts_data_obj,
                                                     create_dt_index):
     pair = create_processed_fxobs(
         prob_forecasts_data_obj,
-        pd.DataFrame(np.random.randn(10, 1)+10, index=create_dt_index(10)),
+        pd.DataFrame(np.random.randn(10, 3)+10, index=create_dt_index(10)),
         pd.Series(np.random.randn(10)+10, index=create_dt_index(10)))
     ref = create_processed_fxobs(
         prob_forecasts_data_obj,
-        pd.DataFrame(np.random.randn(10, 1)+10, index=create_dt_index(10)),
+        pd.DataFrame(np.random.randn(10, 3)+10, index=create_dt_index(10)),
         pd.Series(np.random.randn(10)+10, index=create_dt_index(10)))
     results = calculator.calculate_probabilistic_metrics(
         pair, LIST_OF_CATEGORIES, PROBABILISTIC_METRICS, ref_fx_obs=ref)
-    assert isinstance(results, list)
-    assert len(results) == 1
-    assert all(isinstance(r, datamodel.MetricResult) for r in results)
+    assert isinstance(results, tuple)
+    single_results, dist_results = results
+    assert len(single_results) == len(pair.original.forecast.constant_values)
+    assert all(isinstance(r, datamodel.MetricResult) for r in single_results)
+    assert isinstance(dist_results, datamodel.MetricResult)
 
 
 @pytest.mark.filterwarnings('ignore::RuntimeWarning')
@@ -601,19 +604,97 @@ def test_calculate_probabilistic_metrics(categories, metrics,
     pair = create_processed_fxobs(prob_fxobs, prob_fx_df, obs)
     ref = create_processed_fxobs(ref_fxobs, ref_fx_df, obs)
 
-    results = calculator.calculate_probabilistic_metrics(
+    single_results, dist_result = calculator.calculate_probabilistic_metrics(
         pair, categories, metrics, ref_fx_obs=ref)
 
-    # Check results
-    assert len(results) == len(prob_fx_df.columns)
-    assert all([isinstance(x, datamodel.MetricResult) for x in results])
-    cvs = pair.original.forecast.constant_values
-    assert (set([r.forecast_id for r in results]) ==
-            set([p.forecast_id for p in cvs]))
-    for r in results:
-        verify_metric_result(r, pair, categories, metrics)
+    # Check single forecast results
+    if any(x for x in PROB_NO_DIST if x in set(metrics)):
+        assert len(single_results) == len(prob_fx_df.columns)
+        assert all([isinstance(x, datamodel.MetricResult)
+                   for x in single_results])
+        cvs = pair.original.forecast.constant_values
+        assert (set([r.forecast_id for r in single_results]) ==
+                set([p.forecast_id for p in cvs]))
+        assert (set([r.observation_id for r in single_results]) ==
+                set([single_observation.observation_id]))
+        metrics_sans_dist = list(set(metrics) - set(probabilistic._REQ_DIST))
+        for r in single_results:
+            verify_metric_result(r, pair, categories, metrics_sans_dist)
+    else:
+        assert len(single_results) == 0
+
+    # Check distribution forecast results
+    if any(x for x in probabilistic._REQ_DIST if x in set(metrics)):
+        assert isinstance(dist_result, datamodel.MetricResult)
+        assert dist_result.forecast_id == prob_forecasts.forecast_id
+        assert dist_result.observation_id == single_observation.observation_id
+        metrics_dist_only = list(set(metrics) - set(PROB_NO_DIST))
+        verify_metric_result(dist_result, pair, categories, metrics_dist_only)
+    else:
+        assert dist_result is None
 
 
+@pytest.mark.filterwarnings('ignore::RuntimeWarning')
+@pytest.mark.parametrize('categories', [
+    [],
+    *list(itertools.combinations(LIST_OF_CATEGORIES, 1)),
+    LIST_OF_CATEGORIES[0:1],
+    LIST_OF_CATEGORIES[0:2],
+    LIST_OF_CATEGORIES
+])
+@pytest.mark.parametrize('interval_label', ['beginning', 'ending'])
+@pytest.mark.parametrize('df,metrics', [
+    (pd.DataFrame({
+        ('50', 'forecast'): np.random.randn(10),
+        ('50', 'probability'): np.random.randn(10),
+        ('50', 'reference_forecast'): np.random.randn(10),
+        ('50', 'reference_probability'): np.random.randn(10),
+        (None, 'observation'): np.random.randn(10)
+        }),
+     PROB_NO_DIST),
+    (pd.DataFrame({
+        ('50', 'forecast'): np.random.randn(10),
+        ('50', 'probability'): np.random.randn(10),
+        (None, 'observation'): np.random.randn(10)
+        }),
+     PROB_NO_REF_NO_DIST),
+    (pd.DataFrame({
+        ('25', 'forecast'): np.random.randn(10),
+        ('50', 'forecast'): np.random.randn(10),
+        ('75', 'forecast'): np.random.randn(10),
+        ('25', 'probability'): np.random.randn(10),
+        ('50', 'probability'): np.random.randn(10),
+        ('75', 'probability'): np.random.randn(10),
+        ('25', 'reference_forecast'): np.random.randn(10),
+        ('50', 'reference_forecast'): np.random.randn(10),
+        ('75', 'reference_forecast'): np.random.randn(10),
+        ('25', 'reference_probability'): np.random.randn(10),
+        ('50', 'reference_probability'): np.random.randn(10),
+        ('75', 'reference_probability'): np.random.randn(10),
+        (None, 'observation'): np.random.randn(10)
+        }),
+     probabilistic._REQ_DIST),
+    (pd.DataFrame({
+        ('25', 'forecast'): np.random.randn(10),
+        ('50', 'forecast'): np.random.randn(10),
+        ('75', 'forecast'): np.random.randn(10),
+        ('25', 'probability'): np.random.randn(10),
+        ('50', 'probability'): np.random.randn(10),
+        ('75', 'probability'): np.random.randn(10),
+        (None, 'observation'): np.random.randn(10)
+        }),
+     probabilistic._REQ_DIST)
+])
+def test_calculate_probabilistic_metrics_from_df(categories, df, metrics,
+                                                 interval_label,
+                                                 create_dt_index):
+    df.index = create_dt_index(len(df))
+    results = calculator._calculate_probabilistic_metrics_from_df(
+        df, categories, metrics, interval_label)
+    assert all(isinstance(r, datamodel.MetricValue) for r in results)
+
+
+@pytest.mark.filterwarnings('ignore::RuntimeWarning')
 @pytest.mark.parametrize('metric,fx,obs,ref_fx,norm,expect', [
     ('mae', [], [], None, None, np.NaN),
     ('mae', [1, 1, 1], [0, 1, -1], None, None, 1.0),
@@ -630,10 +711,8 @@ def test_calculate_probabilistic_metrics(categories, metrics,
 ])
 def test_apply_deterministic_metric_func(metric, fx, obs, ref_fx, norm, expect,
                                          create_dt_index):
-    fx_series = pd.Series(fx, index=create_dt_index(len(fx)),
-                          dtype=float)
-    obs_series = pd.Series(obs, index=create_dt_index(len(obs)),
-                           dtype=float)
+    fx_series = np.array(fx)
+    obs_series = np.array(obs)
     # Check require reference forecast kwarg
     if metric in ['s']:
         if ref_fx is None:
@@ -642,8 +721,7 @@ def test_apply_deterministic_metric_func(metric, fx, obs, ref_fx, norm, expect,
                 calculator._apply_deterministic_metric_func(
                     metric, fx_series, obs_series)
         else:
-            ref_fx_series = pd.Series(ref_fx,
-                                      index=create_dt_index(len(ref_fx)))
+            ref_fx_series = np.array(ref_fx)
             metric_value = calculator._apply_deterministic_metric_func(
                 metric, fx_series, obs_series, ref_fx=ref_fx_series)
             np.testing.assert_approx_equal(metric_value, expect)
@@ -673,8 +751,8 @@ def test_apply_deterministic_metric_func(metric, fx, obs, ref_fx, norm, expect,
 def test_apply_deterministic_bad_metric_func():
     with pytest.raises(KeyError):
         calculator._apply_deterministic_metric_func('BAD METRIC',
-                                                    pd.Series(dtype=float),
-                                                    pd.Series(dtype=float))
+                                                    np.array([]),
+                                                    np.array([]))
 
 
 @pytest.mark.filterwarnings('ignore::RuntimeWarning')
@@ -693,7 +771,7 @@ def test_apply_deterministic_bad_metric_func():
     ('unc', [1, 1, 1], [100, 100, 100], [1, 1, 1], None, None, 0.),
 
     # CRPS single forecast
-    ('crps', [1], [100], [0], None, None, 0.),
+    ('crps', [[1]], [[100]], [[0]], None, None, 0.),
     # CRPS mulitple forecasts
     ('crps', [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
              [[100, 100, 100], [100, 100, 100], [100, 100, 100]],
@@ -703,30 +781,23 @@ def test_apply_probabilistic_metric_func(metric, fx, fx_prob, obs,
                                          ref_fx, ref_fx_prob, expect,
                                          create_dt_index):
     if metric == 'crps':
-        fx_data = pd.DataFrame(
-            fx, index=create_dt_index(len(fx)), dtype=float)
-        fx_prob_data = pd.DataFrame(
-            fx_prob, index=create_dt_index(len(fx_prob)), dtype=float)
+        fx_data = np.array(fx)
+        fx_prob_data = np.array(fx_prob)
     else:
-        fx_data = pd.Series(
-            fx, index=create_dt_index(len(fx)), dtype=float)
-        fx_prob_data = pd.Series(
-            fx_prob, index=create_dt_index(len(fx_prob)), dtype=float)
-    obs_series = pd.Series(
-        obs, index=create_dt_index(len(obs)), dtype=float)
+        fx_data = np.array(fx)
+        fx_prob_data = np.array(fx_prob)
+    obs_series = np.array(obs)
 
     # Check metrics that require reference forecast kwarg
-    if metric in ['bss']:
+    if metric in probabilistic._REQ_REF_FX:
         if ref_fx is None or ref_fx_prob is None:
             with pytest.raises(KeyError):
                 # Missing positional argument
                 calculator._apply_probabilistic_metric_func(
                     metric, fx_data, fx_prob_data, obs_series)
         else:
-            ref_fx_data = pd.Series(
-                ref_fx, index=create_dt_index(len(ref_fx)))
-            ref_fx_prob_data = pd.Series(
-                ref_fx_prob, index=create_dt_index(len(ref_fx_prob)))
+            ref_fx_data = np.array(ref_fx)
+            ref_fx_prob_data = np.array(ref_fx_prob)
             metric_value = calculator._apply_probabilistic_metric_func(
                 metric, fx_data, fx_prob_data, obs_series,
                 ref_fx=ref_fx_data,
@@ -746,9 +817,9 @@ def test_apply_probabilistic_metric_func(metric, fx, fx_prob, obs,
 def test_apply_probabilistic_bad_metric_func():
     with pytest.raises(KeyError):
         calculator._apply_probabilistic_metric_func('BAD METRIC',
-                                                    pd.Series(dtype=float),
-                                                    pd.Series(dtype=float),
-                                                    pd.Series(dtype=float))
+                                                    np.array([]),
+                                                    np.array([]),
+                                                    np.array([]))
 
 
 @pytest.mark.parametrize('ts,tz,interval_label,category,result', [
@@ -909,9 +980,9 @@ def test_interval_label_match(site_metadata, label_fx, label_ref,
 @pytest.mark.parametrize('prob_fx_df,axis,exp_fx_fx_prob', [
     (pd.DataFrame({'25': [1.]*5, '50': [2.]*5, '75': [3.]*5}),
      'y',
-     [(pd.Series([1.]*5, name='25'), pd.Series([25.]*5)),
-      (pd.Series([2.]*5, name='50'), pd.Series([50.]*5)),
-      (pd.Series([3.]*5, name='75'), pd.Series([75.]*5))]),
+     [(pd.Series([1.]*5, name='25'), pd.Series([25.]*5, name='25')),
+      (pd.Series([2.]*5, name='50'), pd.Series([50.]*5, name='50')),
+      (pd.Series([3.]*5, name='75'), pd.Series([75.]*5, name='75'))]),
 ])
 def test_transform_prob_forecast_value_and_prob(prob_forecasts,
                                                 single_observation,
@@ -926,6 +997,34 @@ def test_transform_prob_forecast_value_and_prob(prob_forecasts,
     result = calculator._transform_prob_forecast_value_and_prob(proc_fxobs)
     assert len(result) == len(exp_fx_fx_prob)
     for res, exp in zip(result, exp_fx_fx_prob):
-        assert len(res) == len(res)
+        assert len(res) == len(exp)
         pd.testing.assert_series_equal(res[0], exp[0])
         pd.testing.assert_series_equal(res[1], exp[1])
+
+
+@pytest.mark.parametrize('obs,fx_fx_prob,ref_fx_fx_prob,exp_df', [
+    (pd.Series([0.]*5),
+     [(pd.Series([1.]*5, name='25'), pd.Series([25.]*5, name='25')),
+      (pd.Series([2.]*5, name='50'), pd.Series([50.]*5, name='50')),
+      (pd.Series([3.]*5, name='75'), pd.Series([75.]*5, name='75'))],
+     [(pd.Series([4.]*5, name='25'), pd.Series([25.]*5, name='25')),
+      (pd.Series([5.]*5, name='50'), pd.Series([50.]*5, name='50')),
+      (pd.Series([6.]*5, name='75'), pd.Series([75.]*5, name='75'))],
+     pd.DataFrame({
+        (None, 'observation'): pd.Series([0.]*5),
+        ('25', 'forecast'): pd.Series([1.]*5),
+        ('25', 'probability'): pd.Series([25.]*5),
+        ('25', 'reference_forecast'): pd.Series([4.]*5),
+        ('25', 'reference_probability'): pd.Series([25.]*5),
+        ('50', 'forecast'): pd.Series([2.]*5),
+        ('50', 'probability'): pd.Series([50.]*5),
+        ('50', 'reference_forecast'): pd.Series([5.]*5),
+        ('50', 'reference_probability'): pd.Series([50.]*5),
+        ('75', 'forecast'): pd.Series([3.]*5),
+        ('75', 'probability'): pd.Series([75.]*5),
+        ('75', 'reference_forecast'): pd.Series([6.]*5),
+        ('75', 'reference_probability'): pd.Series([75.]*5)}))
+])
+def test_create_prob_dataframe(obs, fx_fx_prob, ref_fx_fx_prob, exp_df):
+    result = calculator._create_prob_dataframe(obs, fx_fx_prob, ref_fx_fx_prob)
+    pd.testing.assert_frame_equal(result, exp_df)

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -428,7 +428,7 @@ def test_calculate_probabilistic_metrics_no_ref(
         )
 
 
-def test_calculate_probabilistic_metrics_no_reference_data(
+def test_calculate_probabilistic_metrics_no_reference(
         single_prob_forecast_observation, create_processed_fxobs):
     proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
                                         pd.DataFrame(np.random.randn(10, 3)),
@@ -436,6 +436,21 @@ def test_calculate_probabilistic_metrics_no_reference_data(
     with pytest.raises(RuntimeError):
         calculator.calculate_probabilistic_metrics(
             proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX,
+        )
+
+
+def test_calculate_probabilistic_metrics_no_reference_data(
+        single_prob_forecast_observation, create_processed_fxobs):
+    proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
+                                        pd.DataFrame(np.random.randn(10, 3)),
+                                        pd.Series(np.random.randn(10)))
+    proc_ref = create_processed_fxobs(single_prob_forecast_observation,
+                                      pd.DataFrame(),
+                                      pd.Series(np.random.randn(10)))
+    with pytest.raises(RuntimeError):
+        calculator.calculate_probabilistic_metrics(
+            proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX,
+            proc_ref
         )
 
 
@@ -452,6 +467,21 @@ def test_calculate_probabilistic_metrics_bad_reference_interval_label(
         calculator.calculate_probabilistic_metrics(
             proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX,
             proc_ref
+        )
+
+
+def test_calculate_probabilistic_metrics_interval_label_ending(
+        single_prob_forecast_observation, create_processed_fxobs,
+        create_datetime_index):
+    proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
+                                        pd.DataFrame(np.random.randn(10, 3),
+                                            index=create_datetime_index(10)),
+                                        pd.Series(np.random.randn(10),
+                                            index=create_datetime_index(10)))
+    proc_fxobs = proc_fxobs.replace(interval_label='ending')
+    with pytest.raises(ValueError):
+        calculator.calculate_probabilistic_metrics(
+            proc_fxobs, LIST_OF_CATEGORIES, PROB_NO_REF,
         )
 
 
@@ -481,7 +511,7 @@ def test_calculate_probabilistic_metrics_missing_values(
                                         pd.Series(np.random.randn(10)))
     with pytest.raises(RuntimeError):
         calculator.calculate_probabilistic_metrics(
-            proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX
+            proc_fxobs, LIST_OF_CATEGORIES, PROB_NO_REF
         )
 
 
@@ -492,7 +522,7 @@ def test_calculate_probabilistic_metrics_missing_observation(
                                         pd.Series([], dtype=float))
     with pytest.raises(RuntimeError):
         calculator.calculate_probabilistic_metrics(
-            proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX
+            proc_fxobs, LIST_OF_CATEGORIES, PROB_NO_REF
         )
 
 

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -359,38 +359,101 @@ def test_calculate_deterministic_metrics(categories, metrics,
     verify_metric_result(result, pair, categories, metrics)
 
 
-@pytest.mark.skip('')
-def test_calculate_probabilistic_metrics_no_metrics():
-    raise NotImplementedError
+def test_calculate_probabilistic_metrics_no_metrics(
+        single_prob_forecast_observation, create_processed_fxobs):
+    proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
+                                        pd.DataFrame(np.random.randn(3,10)),
+                                        pd.Series(np.random.randn(10)))
+    with pytest.raises(RuntimeError):
+        calculator.calculate_probabilistic_metrics(
+            proc_fxobs, LIST_OF_CATEGORIES, []
+        )
 
 
-@pytest.mark.skip('')
-def test_calculate_probabilistic_metrics_no_reference():
-    raise NotImplementedError
+def test_calculate_probabilistic_metrics_no_reference(
+    single_prob_forecast_observation, create_processed_fxobs):
+    proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
+                                        pd.DataFrame(np.random.randn(3,10)),
+                                        pd.Series(np.random.randn(10)))
+    with pytest.raises(RuntimeError):
+        calculator.calculate_probabilistic_metrics(
+            proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX
+        )
 
 
-@pytest.mark.skip('')
-def test_calculate_probabilistic_metrics_no_reference_data():
-    raise NotImplementedError
+def test_calculate_probabilistic_metrics_no_reference_data(
+    single_prob_forecast_observation, create_processed_fxobs):
+    proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
+                                        pd.DataFrame(np.random.randn(3,10)),
+                                        pd.Series(np.random.randn(10)))
+    proc_ref = create_processed_fxobs(single_prob_forecast_observation,
+                                      pd.DataFrame(),
+                                      pd.Series([], dtype=float))
+    with pytest.raises(RuntimeError):
+        calculator.calculate_probabilistic_metrics(
+            proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX
+        )
 
 
-@pytest.mark.skip('')
-def test_calculate_probabilistic_metrics_bad_reference_axis():
-    raise NotImplementedError
+def test_calculate_probabilistic_metrics_bad_reference_interval_label(
+    single_prob_forecast_observation, create_processed_fxobs):
+    proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
+                                        pd.DataFrame(np.random.randn(3,10)),
+                                        pd.Series(np.random.randn(10)))
+    proc_ref = create_processed_fxobs(single_prob_forecast_observation,
+                                      pd.DataFrame(np.random.randn(3,10)),
+                                      pd.Series(np.random.randn(10)))
+    proc_ref = proc_ref.replace(interval_label='ending')
+    with pytest.raises(ValueError):
+        calculator.calculate_probabilistic_metrics(
+            proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX,
+            proc_ref
+        )
 
 
-@pytest.mark.skip('')
-def test_calculate_probabilistic_metrics_missing_values():
-    raise NotImplementedError
+def test_calculate_probabilistic_metrics_bad_reference_axis(
+    single_prob_forecast_observation, prob_forecasts, single_observation,
+    create_processed_fxobs,
+    copy_prob_forecast_with_axis):
+    proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
+                                        pd.DataFrame(np.random.randn(3,10)),
+                                        pd.Series(np.random.randn(10)))
+    conv_fx = copy_prob_forecast_with_axis(prob_forecasts, axis='y')
+    ref_fxobs = datamodel.ForecastObservation(conv_fx, single_observation)
+    proc_ref = create_processed_fxobs(ref_fxobs,
+                                      pd.DataFrame(np.random.randn(3,10)),
+                                      pd.Series(np.random.randn(10)))
+    with pytest.raises(ValueError):
+        calculator.calculate_probabilistic_metrics(
+            proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX,
+            proc_ref
+        )
+
+
+def test_calculate_probabilistic_metrics_missing_values(
+    single_prob_forecast_observation, create_processed_fxobs):
+    proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
+                                        pd.DataFrame(),
+                                        pd.Series(np.random.randn(10)))
+    with pytest.raises(RuntimeError):
+        calculator.calculate_probabilistic_metrics(
+            proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX
+        )
+
+
+def test_calculate_probabilistic_metrics_missing_observation(
+    single_prob_forecast_observation, create_processed_fxobs):
+    proc_fxobs = create_processed_fxobs(single_prob_forecast_observation,
+                                        pd.DataFrame(np.random.randn(3,10)),
+                                        pd.Series([], dtype=float))
+    with pytest.raises(RuntimeError):
+        calculator.calculate_probabilistic_metrics(
+            proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX
+        )
 
 
 @pytest.mark.skip('')
 def test_calculate_probabilistic_metrics_reference():
-    raise NotImplementedError
-
-
-@pytest.mark.skip('')
-def test_calculate_probabilistic_metrics_all_forecasts():
     raise NotImplementedError
 
 

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -93,13 +93,13 @@ def single_forecast_data_obj(
 
 
 @pytest.fixture(params=['probfxobs', 'probfxagg'])
-def probabilistic_forecasts_data_obj(
+def prob_forecasts_data_obj(
         request, single_prob_forecast_observation,
-        aggregate_prob_forecast):
+        single_prob_forecast_aggregate):
     if request.param == 'probfxobs':
         return single_prob_forecast_observation
     else:
-        return aggregate_prob_forecast
+        return single_prob_forecast_aggregate
 
 
 @pytest.fixture()
@@ -494,6 +494,27 @@ def test_calculate_probabilistic_metrics_missing_observation(
         calculator.calculate_probabilistic_metrics(
             proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX
         )
+
+
+@pytest.mark.filterwarnings('ignore::RuntimeWarning')
+def test_calculate_metrics_with_probablistic_simple(prob_forecasts_data_obj,
+                                                    create_processed_fxobs,
+                                                    create_datetime_index):
+    pair = create_processed_fxobs(prob_forecasts_data_obj,
+                                  pd.DataFrame(np.random.randn(10, 1)+10,
+                                    index=create_datetime_index(10)),
+                                  pd.Series(np.random.randn(10)+10,
+                                    index=create_datetime_index(10)))
+    ref = create_processed_fxobs(prob_forecasts_data_obj,
+                                 pd.DataFrame(np.random.randn(10, 1)+10,
+                                    index=create_datetime_index(10)),
+                                 pd.Series(np.random.randn(10)+10,
+                                    index=create_datetime_index(10)))
+    results = calculator.calculate_probabilistic_metrics(
+        pair, LIST_OF_CATEGORIES, PROBABILISTIC_METRICS, ref_fx_obs=ref)
+    assert isinstance(results, list)
+    assert len(results) == 1
+    assert all(isinstance(r, datamodel.MetricResult) for r in results)
 
 
 @pytest.mark.filterwarnings('ignore::RuntimeWarning')


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #315 , partial #266 
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Besides adding support for probabilistic forecasts, I added a api function to get all forecast values in a pandas.DataFrame with constant_value as columns and timeseries filled in.  If things look good I'll add to the api documentation and whatsnew.

There is certainly some duplication between `metrics.calculate_probabilistic_metrics` and `metrics.calculate_deterministic_metrics` but with EventForecasts also tbd, I'm not sure now is the best time to refactor, but if you have ideas please let me know.

I'll start working on the support in the preprocessing now and report.