### PR TITLE
Use last timestamp to adjust start time for update reference obs

### DIFF
--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -20,7 +20,13 @@ API Changes
   :py:func:`solarforecastarbiter.metrics.event.critical_success_index`,
   :py:func:`solarforecastarbiter.metrics.event.event_bias`, and
   :py:func:`solarforecastarbiter.metrics.event.event_accuracy`. (:issue:`347`) (:pull:`348`)
-
+* Add functions to get the time range of values available in the API:
+  :py:func:`solarforecastarbiter.io.api.get_observation_time_range`,
+  :py:func:`solarforecastarbiter.io.api.get_forecast_time_range`,
+  :py:func:`solarforecastarbiter.io.api.get_probabilistic_forecast_constant_value_time_range`.
+  (:pul.l:`369`)
+* Start and end are now optional parameters for the
+  `solararbiter referencedata update` CLI command (:pull:`369`)
 
 Enhancements
 ~~~~~~~~~~~~
@@ -29,6 +35,8 @@ Enhancements
   still interested in bokeh figures.(:pull:`359`)
 * Clean up any PhantomJS drivers created to render SVGs (:issue:`344`)
   (:pull:`349`)
+* Reference data updates can now procede from the last value in the API
+  to avoid any artificial data gaps (:pull:`369`) (:issue:`353`)
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -24,7 +24,7 @@ API Changes
   :py:func:`solarforecastarbiter.io.api.get_observation_time_range`,
   :py:func:`solarforecastarbiter.io.api.get_forecast_time_range`,
   :py:func:`solarforecastarbiter.io.api.get_probabilistic_forecast_constant_value_time_range`.
-  (:pul.l:`369`)
+  (:pull:`369`)
 * Start and end are now optional parameters for the
   `solararbiter referencedata update` CLI command (:pull:`369`)
 

--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -35,7 +35,7 @@ Enhancements
   still interested in bokeh figures.(:pull:`359`)
 * Clean up any PhantomJS drivers created to render SVGs (:issue:`344`)
   (:pull:`349`)
-* Reference data updates can now procede from the last value in the API
+* Reference data updates can now proceed from the last value in the API
   to avoid any artificial data gaps (:pull:`369`) (:issue:`353`)
 
 Bug fixes

--- a/solarforecastarbiter/cli.py
+++ b/solarforecastarbiter/cli.py
@@ -194,7 +194,7 @@ def referencedata_init(verbose, user, password, base_url, network, site_file):
               help='End time (ISO8601) to fetch data for. Default is now')
 @click.option('--start', type=UTCTIMESTAMP,
               help=('Start time (ISO8601) to fetch data for. Default is'
-                    ' max of Last timestamp in API and end - 7 days'))
+                    ' max of last timestamp in API and end - 7 days'))
 def referencedata_update(verbose, user, password, base_url, network, start,
                          end):
     """

--- a/solarforecastarbiter/cli.py
+++ b/solarforecastarbiter/cli.py
@@ -190,14 +190,15 @@ def referencedata_init(verbose, user, password, base_url, network, site_file):
 @referencedata.command(name='update')
 @common_options
 @network_opt
-@click.argument('start', type=UTCTIMESTAMP)
-@click.argument('end', type=UTCTIMESTAMP)
+@click.option('--end', type=UTCTIMESTAMP,
+              help='End time (ISO8601) to fetch data for. Default is now')
+@click.option('--start', type=UTCTIMESTAMP,
+              help=('Start time (ISO8601) to fetch data for. Default is'
+                    ' max of Last timestamp in API and end - 7 days'))
 def referencedata_update(verbose, user, password, base_url, network, start,
                          end):
     """
-    Updates reference data for the given period. START and END should be given
-    as ISO8601 datetime strings. If no timezone is defined, UTC will be
-    assumed.
+    Updates reference data for the given period.
     """
     set_log_level(verbose)
     token = cli_access_token(user, password)

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -584,7 +584,8 @@ class APISession(requests.Session):
         return adjust_timeseries_for_interval_label(
             out, interval_label, start, end)
 
-    def get_probabilistic_forecast_constant_value_time_range(self, forecast_id):
+    def get_probabilistic_forecast_constant_value_time_range(
+            self, forecast_id):
         """
         Get the miniumum and maximum timestamps for forecast values.
 

--- a/solarforecastarbiter/io/reference_observations/common.py
+++ b/solarforecastarbiter/io/reference_observations/common.py
@@ -213,11 +213,12 @@ def _utcnow():
     return pd.Timestamp.now(tz='UTC')
 
 
-def get_last_site_timestamp(api, site_observations, end):
-    """Get the last value timestamp from the API for a site
-    as the minimum of the last timestamp for each observation at
-    that site. A limit of end - 7 days is set to avoid excessive
-    queries to external sources.
+def get_last_site_timestamp(api, observations, end):
+    """Get the last value timestamp from the API as the minimum of the
+    last timestamp for each observation at that site. The result of
+    this function is often used to make new data queries, so a limit
+    of end - 7 days is set to avoid excessive queries to external
+    sources.
 
     Parameters
     ---------
@@ -226,14 +227,17 @@ def get_last_site_timestamp(api, site_observations, end):
     site_observations : list of solarforecastarbiter.datamodel.Observation
         A list of reference Observations for a site to search.
     end : pd.Timestamp
+        Typically, set to now.
 
     Returns
     -------
     pandas.Timestamp
+
     """
+    # update cli.py as appropriate if behaviour is changed
     out = end
     updated = False
-    for obs in site_observations:
+    for obs in observations:
         maxt = api.get_observation_time_range(obs.observation_id)[1]
         # <= so that even if maxt == end updated -> true
         # effectively ignores all NaT values unless all observations

--- a/solarforecastarbiter/io/reference_observations/common.py
+++ b/solarforecastarbiter/io/reference_observations/common.py
@@ -254,7 +254,7 @@ def update_site_observations(api, fetch_func, site, observations,
     for the period between start and end.
 
     Parameters
-    ---------
+    ----------
     api : solarforecastarbiter.io.api.APISession
         An active Reference user session.
     fetch_func : function

--- a/solarforecastarbiter/io/reference_observations/common.py
+++ b/solarforecastarbiter/io/reference_observations/common.py
@@ -209,16 +209,49 @@ def create_observation(api, site, variable, extra_params=None, **kwargs):
         return created
 
 
+def _utcnow():
+    return pd.Timestamp.now(tz='UTC')
+
+
+def get_last_site_timestamp(api, site_observations):
+    """Get the last value timestamp from the API for a site
+    as the minimum of the last timestamp for each observation at
+    that site. A limit of now - 7 days is set to avoid excessive
+    queries to external sources.
+
+    Parameters
+    ---------
+    api : solarforecastarbiter.io.api.APISession
+        An active Reference user session.
+    site_observations : list of solarforecastarbiter.datamodel.Observation
+        A list of reference Observations for a site to search.
+
+    Returns
+    -------
+    pandas.Timestamp
+    """
+    now = _utcnow()
+    out = now
+    for obs in site_observations:
+        maxt = api.get_observation_time_range(obs.observation_id)[1]
+        if pd.notna(maxt) and maxt < out:
+            out = maxt
+
+    weekago = now - pd.Timedelta('7d')
+    if out == now or out < weekago:
+        out = weekago
+    return out
+
+
 def update_site_observations(api, fetch_func, site, observations,
                              start, end):
     """Updates data for all reference observations at a given site
     for the period between start and end.
 
-    Prameters
+    Parameters
     ---------
     api : solarforecastarbiter.io.api.APISession
         An active Reference user session.
-
     fetch_func : function
         A function that requests data and returns a DataFrame for a given site.
         The function should accept the parameters (api, site, start end) as
@@ -227,12 +260,22 @@ def update_site_observations(api, fetch_func, site, observations,
         The Site with observations to update.
     observations : list of solarforecastarbiter.datamodel.Observation
         A full list of reference Observations to search.
+    start : pandas.Timestamp or None
+        Start time to get data for. If None, try finding the last
+        value in the API and use that time (with a limit of now - 7 days).
+        If None and no values in the API, use now - 7 day.
+    end : pandas.Timestamp or None
+        End time to get data for. If None, use now.
     """
+    site_observations = [obs for obs in observations if obs.site == site]
+    if start is None:
+        start = get_last_site_timestamp(api, site_observations)
+    if end is None:
+        end = _utcnow()
     obs_df = fetch_func(api, site, start, end)
     data_in_range = obs_df[start:end]
     if data_in_range.empty:
         return
-    site_observations = [obs for obs in observations if obs.site == site]
     for obs in site_observations:
         post_observation_data(api, obs, data_in_range, start, end)
 
@@ -243,7 +286,7 @@ def _prepare_data_to_post(data, variable, observation, start, end):
     data = data[[variable]]
     data = data.rename(columns={variable: 'value'})
     # remove all future values, some files have forward filled nightly data
-    data = data[start:min(end, pd.Timestamp.now(tz='UTC'))]
+    data = data[start:min(end, _utcnow())]
     # we assume any reference data is given at the proper intervals
     # and already averaged if appropriate
     # so just reindex the data to put nans where required

--- a/solarforecastarbiter/io/reference_observations/tests/test_common.py
+++ b/solarforecastarbiter/io/reference_observations/tests/test_common.py
@@ -401,6 +401,14 @@ def test_get_last_site_timestamp_none(mock_api, now, site_obs):
     assert ret == now - pd.Timedelta('7d')
 
 
+def test_get_last_site_timestamp_some_nat(mock_api, now, site_obs):
+    retvals = {site_obs[0].observation_id: (0, pd.Timestamp('20190105T0020Z')),
+               site_obs[1].observation_id: (0, pd.NaT)}
+    mock_api.get_observation_time_range.side_effect = lambda x: retvals[x]
+    ret = common.get_last_site_timestamp(mock_api, site_obs, now)
+    assert ret == pd.Timestamp('20190105T0020Z')
+
+
 def test_get_last_site_timestamp_uptodate(mock_api, now, site_obs):
     mock_api.get_observation_time_range.return_value = (0, now)
     ret = common.get_last_site_timestamp(mock_api, site_obs, now)

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -832,6 +832,60 @@ def test_apisession_get_user_info(requests_mock):
     assert out['test'] == 'key'
 
 
+time_range_params = pytest.mark.parametrize('mint,maxt,expected', [
+    ('"2020-03-03T11:34:23+00:00"', '"2020-03-04T13:00:00+00:00"',
+     (pd.Timestamp(year=2020, month=3, day=3, hour=11, minute=34, second=23,
+                   tz='UTC'),
+      pd.Timestamp(year=2020, month=3, day=4, hour=13, tz='UTC'))),
+    ('null', 'null', (pd.NaT, pd.NaT)),
+    ('"2020-03-03T11:34:23"', '"2020-03-04T13:00:00+00:00"',
+     (pd.Timestamp(year=2020, month=3, day=3, hour=11, minute=34, second=23,
+                   tz='UTC'),
+      pd.Timestamp(year=2020, month=3, day=4, hour=13, tz='UTC'))),
+    ('"2020-03-03T11:00:00+00:00"', '"2020-03-11T23:01:00"',
+     (pd.Timestamp(year=2020, month=3, day=3, hour=11, tz='UTC'),
+      pd.Timestamp(year=2020, month=3, day=11, hour=23, minute=1,
+                   tz='UTC')))
+])
+
+
+@time_range_params
+def test_get_observation_time_range(requests_mock, mint, maxt, expected):
+    session = api.APISession('')
+    requests_mock.register_uri(
+        'GET', f'{session.base_url}/observations/obsid/values/timerange',
+        content=(
+            '{"observation_id": "obsid", "min_timestamp": '
+            f'{mint}, "max_timestamp": {maxt}' + '}').encode())
+    out = session.get_observation_time_range('obsid')
+    assert out == expected
+
+
+@time_range_params
+def test_get_cdf_forecast_time_range(requests_mock, mint, maxt, expected):
+    session = api.APISession('')
+    requests_mock.register_uri(
+        'GET',
+        f'{session.base_url}/forecasts/cdf/single/fxid/values/timerange',
+        content=(
+            '{"forecast_id": "fxid", "min_timestamp": '
+            f'{mint}, "max_timestamp": {maxt}' + '}').encode())
+    out = session.get_probabilistic_forecast_constant_value_time_range('fxid')
+    assert out == expected
+
+
+@time_range_params
+def test_get_forecast_time_range(requests_mock, mint, maxt, expected):
+    session = api.APISession('')
+    requests_mock.register_uri(
+        'GET', f'{session.base_url}/forecasts/single/fxid/values/timerange',
+        content=(
+            '{"forecast_id": "fxid", "min_timestamp": '
+            f'{mint}, "max_timestamp": {maxt}' + '}').encode())
+    out = session.get_forecast_time_range('fxid')
+    assert out == expected
+
+
 @pytest.fixture(scope='session')
 def auth_token():
     try:
@@ -1138,3 +1192,27 @@ def test_real_apisession_get_aggregate_values(real_session):
 def test_real_apisession_get_user_info(real_session):
     user_info = real_session.get_user_info()
     assert user_info['organization'] == 'Organization 1'
+
+
+def test_real_apisession_get_observation_time_range(real_session):
+    out = real_session.get_observation_time_range(
+        '123e4567-e89b-12d3-a456-426655440000')
+    assert out == (
+        pd.Timestamp('2019-04-14T00:00:00Z'),
+        pd.Timestamp('2019-04-17T06:55:00Z'))
+
+
+def test_real_apisession_get_forecast_time_range(real_session):
+    out = real_session.get_forecast_time_range(
+        'f8dd49fa-23e2-48a0-862b-ba0af6dec276')
+    assert out == (
+        pd.Timestamp('2019-04-14T00:00:00Z'),
+        pd.Timestamp('2019-04-17T06:59:00Z'))
+
+
+def test_real_apisession_get_cdf_forecast_time_range(real_session):
+    out = real_session.get_probabilistic_forecast_constant_value_time_range(
+        '633f9b2a-50bb-11e9-8647-d663bd873d93')
+    assert out == (
+        pd.Timestamp('2019-04-14T00:00:00Z'),
+        pd.Timestamp('2019-04-17T06:55:00Z'))

--- a/solarforecastarbiter/tests/test_cli.py
+++ b/solarforecastarbiter/tests/test_cli.py
@@ -167,8 +167,10 @@ def test_referencedata_update(cli_token, mocker):
     mocked = mocker.patch(
         'solarforecastarbiter.cli.reference_data.update_reference_observations')  # NOQA
     runner = CliRunner()
-    runner.invoke(cli.referencedata_update,
-                  ['-u user', '-p pass', '20190101T0000Z', '20190101T235959Z'])
+    res = runner.invoke(cli.referencedata_update,
+                        ['-u user', '-p pass', '--start=20190101T0000Z',
+                         '--end=20190101T235959Z'])
+    assert res.exit_code == 0
     assert mocked.called
     assert mocked.call_args[0][:3] == ('TOKEN', pd.Timestamp('20190101T0000Z'),
                                        pd.Timestamp('20190101T235959Z'))


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #353 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
