### PR TITLE
account for uncertainty using deadband

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+*.ipynb
 
 # pyenv
 .python-version
@@ -110,3 +111,10 @@ venv.bak/
 *.swo
 
 .vscode/
+
+*.json
+*.html
+!solarforecastarbiter/reports/templates/*.html
+*.md
+
+*.csv

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -459,6 +459,15 @@ Functions to compute forecast deterministic performance metrics:
    metrics.deterministic.over
    metrics.deterministic.combined_performance_index
 
+Functions to compute errors and deadbands:
+
+.. autosummary::
+   :toctree: generated/
+
+   metrics.deterministic.deadband_mask
+   metrics.deterministic.error
+   metrics.deterministic.error_deadband
+
 Probabilistic
 -------------
 

--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -74,10 +74,13 @@ Enhancements
   now be calculated using a deadband. The deadband is specified as a
   percentage of the observations. The error forecast - observation is
   set to 0 within the deadband. The deadband is controlled using the
-  :py:class:`solarforecastarbiter.datamodel.ForecastObservation`
-  ``uncertainty`` argument. ``None`` implies no deadband, a float sets
-  the deadband, or the string ``'observation_uncertainty'`` may be
-  supplied to set the deadband equal to
+  :py:class:`solarforecastarbiter.datamodel.ForecastObservation` and
+  :py:class:`solarforecastarbiter.datamodel.ForecastAggregate`
+  ``uncertainty`` argument. ``None`` implies no deadband and a float
+  sets the deadband. Additionally, for
+  :py:class:`solarforecastarbiter.datamodel.ForecastObservation`,
+  the string ``'observation_uncertainty'`` may be supplied to set the
+  deadband equal to
   :py:attr:`solarforecastarbiter.datamodel.Observation.uncertainty`.
   (:issue:`358`, :pull:`378`)
 

--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -38,6 +38,11 @@ API Changes
   :py:func:`solarforecastarbiter.metrics.calculate_deterministic_metrics`.
   Normalization is now determined by the attributes of the datamodel objects.
   (:pull:`379`)
+* Many functions in :py:mod:`solarforecastarbiter.metrics.deterministic` gain
+  a keyword argument ``error_fnc`` for specifying a function that calculates
+  the nominal difference forecast - observation. Among other things, this
+  is useful for specifying a deadband. (:pull:`378`)
+
 
 Enhancements
 ~~~~~~~~~~~~
@@ -60,6 +65,17 @@ Enhancements
   AC power observations are normalized by AC capacity; DC power by DC
   capacity. Normalized metrics set to ``nan`` for all other variables.
   (:issue:`370`) (:pull:`379`)
+* Metrics ``'mae', 'mbe', 'rmse', 'mape', 'nmae', 'nmbe', 'nrmse'`` may
+  now be calculated using a deadband. The deadband is specified as a
+  percentage of the observations. The error forecast - observation is
+  set to 0 within the deadband. A user-specified deadband may be supplied to
+  :py:func:`solarforecastarbiter.metrics.calculator.calculate_metrics`,
+  or a string 'observation_uncertainty' may be supplied to direct the
+  function to set the deadband equal to
+  :py:attr:`solarforecastarbiter.datamodel.Observation.uncertainty`.
+  Actually this calculator change won't work if deadband could be user supplied for one
+  `ForecastObservation` but observation-supplied for another.
+  (:issue:`358`, :pull:`378`)
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -73,13 +73,12 @@ Enhancements
 * Metrics ``'mae', 'mbe', 'rmse', 'mape', 'nmae', 'nmbe', 'nrmse'`` may
   now be calculated using a deadband. The deadband is specified as a
   percentage of the observations. The error forecast - observation is
-  set to 0 within the deadband. A user-specified deadband may be supplied to
-  :py:func:`solarforecastarbiter.metrics.calculator.calculate_metrics`,
-  or a string 'observation_uncertainty' may be supplied to direct the
-  function to set the deadband equal to
+  set to 0 within the deadband. The deadband is controlled using the
+  :py:class:`solarforecastarbiter.datamodel.ForecastObservation`
+  ``uncertainty`` argument. ``None`` implies no deadband, a float sets
+  the deadband, or the string ``'observation_uncertainty'`` may be
+  supplied to set the deadband equal to
   :py:attr:`solarforecastarbiter.datamodel.Observation.uncertainty`.
-  Actually this calculator change won't work if deadband could be user supplied for one
-  `ForecastObservation` but observation-supplied for another.
   (:issue:`358`, :pull:`378`)
 
 

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1365,7 +1365,10 @@ def report_objects(aggregate):
         observation,
         normalization=1000.,
         uncertainty=15.)
-    fxagg0 = datamodel.ForecastAggregate(forecast_agg, aggregate)
+    fxagg0 = datamodel.ForecastAggregate(
+        forecast_agg,
+        aggregate,
+        uncertainty=5.)
     quality_flag_filter = datamodel.QualityFlagFilter(
         (
             "USER FLAGGED",
@@ -1467,7 +1470,8 @@ def report_params_dict(report_objects, quality_filter_dict,
              'normalization': 1000.,
              'uncertainty': 15.},
             {'forecast': forecast_agg.to_dict(),
-             'aggregate': aggregate.to_dict()},
+             'aggregate': aggregate.to_dict(),
+             'uncertainty': 5.},
         ),
         'metrics': ('mae', 'rmse', 'mbe'),
         'filters': (quality_filter_dict, timeofdayfilter_dict),
@@ -1522,7 +1526,8 @@ def report_text():
               "normalization": "1000",
               "uncertainty": "15"},
              {"forecast": "49220780-76ae-4b11-bef1-7a75bdc784e3",
-              "aggregate": "458ffc27-df0b-11e9-b622-62adb5fd6af0"}
+              "aggregate": "458ffc27-df0b-11e9-b622-62adb5fd6af0",
+              "uncertainty": "5"}
          ]
      },
      "raw_report": null,

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1313,7 +1313,7 @@ def report_objects(aggregate):
         interval_length=pd.Timedelta("15min"),
         interval_label="ending",
         site=site,
-        uncertainty=0.0,
+        uncertainty=1.0,
         observation_id="9f657636-7e49-11e9-b77f-0a580a8003e9",
         extra_parameters='{"network": "NREL MIDC", "network_api_id": "UAT", "network_api_abbreviation": "UA OASIS", "observation_interval_length": 1, "network_data_label": "Global Horiz (platform) [W/m^2]"}',  # NOQA
     )
@@ -1355,8 +1355,16 @@ def report_objects(aggregate):
         forecast_id="49220780-76ae-4b11-bef1-7a75bdc784e3",
         extra_parameters='',
     )
-    fxobs0 = datamodel.ForecastObservation(forecast_0, observation)
-    fxobs1 = datamodel.ForecastObservation(forecast_1, observation)
+    fxobs0 = datamodel.ForecastObservation(
+        forecast_0,
+        observation,
+        # report_text parsing will ensure unc can be done dynamically too
+        uncertainty=observation.uncertainty)
+    fxobs1 = datamodel.ForecastObservation(
+        forecast_1,
+        observation,
+        normalization=1000.,
+        uncertainty=15.)
     fxagg0 = datamodel.ForecastAggregate(forecast_agg, aggregate)
     quality_flag_filter = datamodel.QualityFlagFilter(
         (
@@ -1452,9 +1460,12 @@ def report_params_dict(report_objects, quality_filter_dict,
         'end': report_params.end,
         'object_pairs': (
             {'forecast': forecast_0.to_dict(),
-             'observation': observation.to_dict()},
+             'observation': observation.to_dict(),
+             'uncertainty': observation.uncertainty},
             {'forecast': forecast_1.to_dict(),
-             'observation': observation.to_dict()},
+             'observation': observation.to_dict(),
+             'normalization': 1000.,
+             'uncertainty': 15.},
             {'forecast': forecast_agg.to_dict(),
              'aggregate': aggregate.to_dict()},
         ),
@@ -1504,9 +1515,12 @@ def report_text():
          "categories": ["total", "date", "hour"],
          "object_pairs": [
              {"forecast": "da2bc386-8712-11e9-a1c7-0a580a8200ae",
-              "observation": "9f657636-7e49-11e9-b77f-0a580a8003e9"},
+              "observation": "9f657636-7e49-11e9-b77f-0a580a8003e9",
+              "uncertainty": "observation_uncertainty"},
              {"forecast": "68a1c22c-87b5-11e9-bf88-0a580a8200ae",
-              "observation": "9f657636-7e49-11e9-b77f-0a580a8003e9"},
+              "observation": "9f657636-7e49-11e9-b77f-0a580a8003e9",
+              "normalization": "1000",
+              "uncertainty": "15"},
              {"forecast": "49220780-76ae-4b11-bef1-7a75bdc784e3",
               "aggregate": "458ffc27-df0b-11e9-b622-62adb5fd6af0"}
          ]

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1231,6 +1231,15 @@ def many_prob_forecasts_observation(many_prob_forecasts, many_observations):
     return [datamodel.ForecastObservation(*c) for c in cart_prod]
 
 
+@pytest.fixture(params=[None, 100, 'observation_uncertainty'])
+def single_forecast_observation_uncert(
+        request, single_forecast, single_observation):
+    return datamodel.ForecastObservation(
+        single_forecast,
+        single_observation,
+        uncertainty=request.param)
+
+
 @pytest.fixture()
 def single_forecast_ac_observation(
         ac_power_forecast_metadata, ac_power_observation_metadata):

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1231,6 +1231,15 @@ def many_prob_forecasts_observation(many_prob_forecasts, many_observations):
     return [datamodel.ForecastObservation(*c) for c in cart_prod]
 
 
+@pytest.fixture(params=[None, 1000])
+def single_forecast_observation_norm(
+        request, single_forecast, single_observation):
+    return datamodel.ForecastObservation(
+        single_forecast,
+        single_observation,
+        normalization=request.param)
+
+
 @pytest.fixture(params=[None, 100, 'observation_uncertainty'])
 def single_forecast_observation_uncert(
         request, single_forecast, single_observation):

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1019,6 +1019,8 @@ class ForecastAggregate(BaseModel):
     def __post_init__(self):
         if self.normalization is None:
             __set_aggregate_normalization__(self)
+        if self.uncertainty is not None:
+            object.__setattr__(self, 'uncertainty', float(self.uncertainty))
         object.__setattr__(self, 'data_object', self.aggregate)
         __check_units__(self.forecast, self.data_object)
         __check_interval_compatibility__(self.forecast, self.data_object)

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -991,12 +991,16 @@ class ForecastAggregate(BaseModel):
     reference_forecast: :py:class:`solarforecastarbiter.datamodel.Forecast` or None
     normalization: float or None
         If None, assigned 1.
+    uncertainty: None or float
+        If None, uncertainty is not accounted for. Float specifies the
+        uncertainty as a percentage from 0 to 100%.
     cost_per_unit_error: float
     """  # NOQA
     forecast: Forecast
     aggregate: Aggregate
     reference_forecast: Union[Forecast, None] = None
     normalization: Union[float, None] = None
+    uncertainty: Union[float, None] = None
     cost_per_unit_error: float = 0.0
     data_object: Aggregate = field(init=False)
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -990,7 +990,6 @@ def __set_uncertainty__(self):
             object.__setattr__(self, 'uncertainty', unc)
 
 
-
 @dataclass(frozen=True)
 class ForecastAggregate(BaseModel):
     """

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -775,13 +775,15 @@ class APISession(requests.Session):
         for o in rep_params['object_pairs']:
             fx = self.get_forecast(o['forecast'])
             norm = o.get('normalization')
+            unc = o.get('uncertainty')
             if 'observation' in o:
                 obs = self.get_observation(o['observation'])
                 pair = datamodel.ForecastObservation(
-                    fx, obs, normalization=norm)
+                    fx, obs, normalization=norm, uncertainty=unc)
             elif 'aggregate' in o:
                 agg = self.get_aggregate(o['aggregate'])
-                pair = datamodel.ForecastAggregate(fx, agg, normalization=norm)
+                pair = datamodel.ForecastAggregate(
+                    fx, agg, normalization=norm, uncertainty=unc)
             else:
                 raise ValueError('must provide observation or aggregate in all'
                                  'object_pairs')

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -94,7 +94,7 @@ def _apply_deterministic_metric_func(metric, fx, obs, **kwargs):
 
 
 def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
-                                    ref_fx_obs=None):
+                                    ref_fx_obs=None, deadband=None):
     """
     Calculate deterministic metrics for the processed data using the provided
     categories and metric types.
@@ -191,7 +191,11 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
                 # Calculate
                 res = _apply_deterministic_metric_func(
                     metric_, group.forecast, group.observation,
+<<<<<<< HEAD
                     ref_fx=ref_fx, normalization=normalization)
+=======
+                    ref_fx=ref_fx, normalizer=normalizer, deadband=deadband)
+>>>>>>> add deadband
 
                 # Change category label of the group from numbers
                 # to e.g. January or Monday

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -101,9 +101,11 @@ def _apply_deterministic_metric_func(metric, fx, obs, **kwargs):
         _kw['error_fnc'] = partial(
             deterministic.error_deadband, deadband=deadband)
 
+    # ref is an arg, but seems cleaner to handle as a kwarg here
     if metric in deterministic._REQ_REF_FX:
         _kw['ref'] = kwargs['ref_fx']
 
+    # same arg/kwarg comment as for ref
     if metric in deterministic._REQ_NORM:
         _kw['norm'] = kwargs['normalization']
 

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -9,6 +9,7 @@ Todo
 * Support probabilistic metrics and forecasts with new functions
 * Support event metrics and forecasts with new functions
 """
+from functools import partial
 import calendar
 import logging
 
@@ -90,8 +91,10 @@ def _apply_deterministic_metric_func(metric, fx, obs, **kwargs):
     metric functions. """
     metric_func = deterministic._MAP[metric][0]
     _kw = {}
-    if metric in deterministic._DEADBAND_ALLOWED:
-        _kw['deadband'] = kwargs.get('deadband', None)
+    deadband = kwargs.get('deadband', None)
+    if metric in deterministic._DEADBAND_ALLOWED and deadband:
+        _kw['error_fnc'] = partial(
+            deterministic.error_deadband, deadband=deadband)
     if metric in deterministic._REQ_REF_FX:
         return metric_func(obs, fx, kwargs['ref_fx'], **_kw)
     elif metric in deterministic._REQ_NORM:

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -103,8 +103,10 @@ def _apply_deterministic_metric_func(metric, fx, obs, **kwargs):
     # than a try/except pattern
     deadband = kwargs.get('deadband', None)
     if metric in deterministic._DEADBAND_ALLOWED and deadband:
+        # metrics assumes fractional deadband, datamodel assumes %, so / 100
+        deadband_frac = deadband / 100
         _kw['error_fnc'] = partial(
-            deterministic.error_deadband, deadband=deadband)
+            deterministic.error_deadband, deadband=deadband_frac)
 
     # ref is an arg, but seems cleaner to handle as a kwarg here
     if metric in deterministic._REQ_REF_FX:
@@ -209,7 +211,7 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
     # get normalization factor
     normalization = processed_fx_obs.normalization_factor
 
-    # get uncertainty
+    # get uncertainty.
     deadband = processed_fx_obs.uncertainty
 
     # Force `groupby` to be consistent with `interval_label`, i.e., if

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -90,17 +90,24 @@ def _apply_deterministic_metric_func(metric, fx, obs, **kwargs):
     """Helper function to deal with variable number of arguments possible for
     metric functions. """
     metric_func = deterministic._MAP[metric][0]
+
+    # the keyword arguments that will be passed to the functions
     _kw = {}
+
+    # deadband could be supplied as None, so this is a little cleaner
+    # than a try/except pattern
     deadband = kwargs.get('deadband', None)
     if metric in deterministic._DEADBAND_ALLOWED and deadband:
         _kw['error_fnc'] = partial(
             deterministic.error_deadband, deadband=deadband)
+
     if metric in deterministic._REQ_REF_FX:
-        return metric_func(obs, fx, kwargs['ref_fx'], **_kw)
-    elif metric in deterministic._REQ_NORM:
-        return metric_func(obs, fx, kwargs['normalization'], **_kw)
-    else:
-        return metric_func(obs, fx, **_kw)
+        _kw['ref'] = kwargs['ref_fx']
+
+    if metric in deterministic._REQ_NORM:
+        _kw['norm'] = kwargs['normalization']
+
+    return metric_func(obs, fx, **_kw)
 
 
 def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -22,7 +22,7 @@ def deadband_mask(obs, fx, deadband):
     fx : (n,) array_like
         Forecasted values.
     deadband : float
-        Fractional tolerance
+        Fractional tolerance relative to the observed values.
 
     Returns
     -------

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -17,7 +17,7 @@ def deadband_mask(obs, fx, deadband):
     fx : (n,) array_like
         Forecasted values.
     deadband : float
-        Number between 0 and 1
+        Fractional tolerance
 
     Returns
     -------
@@ -29,7 +29,8 @@ def deadband_mask(obs, fx, deadband):
 
 def _error_deadband(obs, fx, deadband):
     error = fx - obs
-    if deadband is not None:
+    # only apply deadband if deadband != 0 and is not None
+    if deadband:
         mask = deadband_mask(obs, fx, deadband)
         error = np.where(mask, 0, error)
     return error

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -10,6 +10,11 @@ def deadband_mask(obs, fx, deadband):
 
     .. math:: \\text{mask_i} = | fx_i - obs_i | <= deadband * | obs_i |
 
+    Floating point arithmetic makes the equality difficult to guarantee
+    so do not rely on it.
+
+    Equality
+
     Parameters
     ----------
     obs : (n,) array_like
@@ -24,7 +29,7 @@ def deadband_mask(obs, fx, deadband):
     mask : array_like
         1 if a point is within the deadband, 0 if not
     """
-    return np.isclose(fx, obs, atol=0, rtol=deadband)
+    return np.isclose(fx, obs, rtol=deadband)
 
 
 def error(obs, fx):
@@ -33,7 +38,7 @@ def error(obs, fx):
 
 
 def error_deadband(obs, fx, deadband):
-    """Error accounting for a deadband.
+    """Error fx - obs, accounting for a deadband.
 
     error = 0 for points where error <= deadband * obs
 
@@ -71,7 +76,8 @@ def mean_absolute(obs, fx, error_fnc=error):
     fx : (n,) array-like
         Forecasted values.
     error_fnc : function
-        First argument is obs, second argument is fx.
+        A function that returns the error, default fx - obs. First
+        argument is obs, second argument is fx.
 
     Returns
     -------
@@ -82,7 +88,7 @@ def mean_absolute(obs, fx, error_fnc=error):
     --------
     Standard MAE:
     >>> obs = np.array([1, 2, 3, 4])
-    >>> fx = np.array([2, 2.04, 1, 3.96])
+    >>> fx = np.array([2, 2.04, 2, 3.96])
     >>> mean_absolute(obs, fx)
     0.52
 
@@ -106,6 +112,9 @@ def mean_bias(obs, fx, error_fnc=error):
         Observed values.
     fx : (n,) array-like
         Forecasted values.
+    error_fnc : function
+        A function that returns the error, default fx - obs. First
+        argument is obs, second argument is fx.
 
     Returns
     -------
@@ -130,6 +139,9 @@ def root_mean_square(obs, fx, error_fnc=error):
         Observed values.
     fx : (n,) array-like
         Forecasted values.
+    error_fnc : function
+        A function that returns the error, default fx - obs. First
+        argument is obs, second argument is fx.
 
     Returns
     -------
@@ -155,6 +167,9 @@ def mean_absolute_percentage(obs, fx, error_fnc=error):
         Observed values.
     fx : (n,) array-like
         Forecasted values.
+    error_fnc : function
+        A function that returns the error, default fx - obs. First
+        argument is obs, second argument is fx.
 
     Returns
     -------
@@ -179,6 +194,9 @@ def normalized_mean_absolute(obs, fx, norm, error_fnc=error):
         Forecasted values.
     norm : float
         Normalized factor, in the same units as obs and fx.
+    error_fnc : function
+        A function that returns the error, default fx - obs. First
+        argument is obs, second argument is fx.
 
     Returns
     -------
@@ -187,7 +205,7 @@ def normalized_mean_absolute(obs, fx, norm, error_fnc=error):
 
     """
 
-    return mean_absolute(obs, fx, error_fnc=error) / norm * 100.0
+    return mean_absolute(obs, fx, error_fnc=error_fnc) / norm * 100.0
 
 
 def normalized_mean_bias(obs, fx, norm, error_fnc=error):
@@ -203,6 +221,9 @@ def normalized_mean_bias(obs, fx, norm, error_fnc=error):
         Forecasted values.
     norm : float
         Normalized factor, in the same units as obs and fx.
+    error_fnc : function
+        A function that returns the error, default fx - obs. First
+        argument is obs, second argument is fx.
 
     Returns
     -------
@@ -211,7 +232,7 @@ def normalized_mean_bias(obs, fx, norm, error_fnc=error):
 
     """
 
-    return mean_bias(obs, fx, error_fnc=error) / norm * 100.0
+    return mean_bias(obs, fx, error_fnc=error_fnc) / norm * 100.0
 
 
 def normalized_root_mean_square(obs, fx, norm, error_fnc=error):
@@ -227,6 +248,9 @@ def normalized_root_mean_square(obs, fx, norm, error_fnc=error):
         Forecasted values.
     norm : float
         Normalized factor, in the same units as obs and fx.
+    error_fnc : function
+        A function that returns the error, default fx - obs. First
+        argument is obs, second argument is fx.
 
     Returns
     -------
@@ -235,7 +259,7 @@ def normalized_root_mean_square(obs, fx, norm, error_fnc=error):
 
     """
 
-    return root_mean_square(obs, fx, error_fnc=error) / norm * 100.0
+    return root_mean_square(obs, fx, error_fnc=error_fnc) / norm * 100.0
 
 
 def forecast_skill(obs, fx, ref, error_fnc=error):
@@ -254,6 +278,9 @@ def forecast_skill(obs, fx, ref, error_fnc=error):
         Forecasted values.
     ref : (n,) array_like
         Reference forecast values.
+    error_fnc : function
+        A function that returns the error, default fx - obs. First
+        argument is obs, second argument is fx.
 
     Returns
     -------
@@ -263,8 +290,8 @@ def forecast_skill(obs, fx, ref, error_fnc=error):
 
     """
 
-    rmse_fx = root_mean_square(obs, fx, error_fnc=error)
-    rmse_ref = root_mean_square(obs, ref, error_fnc=error)
+    rmse_fx = root_mean_square(obs, fx, error_fnc=error_fnc)
+    rmse_ref = root_mean_square(obs, ref, error_fnc=error_fnc)
     return 1.0 - rmse_fx / rmse_ref
 
 

--- a/solarforecastarbiter/metrics/deterministic.py
+++ b/solarforecastarbiter/metrics/deterministic.py
@@ -95,7 +95,7 @@ def mean_absolute(obs, fx, error_fnc=error):
     return np.mean(np.abs(error))
 
 
-def mean_bias(obs, fx, deadband=None):
+def mean_bias(obs, fx, error_fnc=error):
     """Mean bias error (MBE).
 
     .. math:: \\text{MBE} = 1/n \\sum_{i=1}^n (\\text{fx}_i - \\text{obs}_i)
@@ -113,11 +113,11 @@ def mean_bias(obs, fx, deadband=None):
         The MBE of the forecast.
 
     """
-    error = _error_deadband(obs, fx, deadband)
+    error = error_fnc(obs, fx)
     return np.mean(error)
 
 
-def root_mean_square(obs, fx, deadband=None):
+def root_mean_square(obs, fx, error_fnc=error):
     """Root mean square error (RMSE).
 
     .. math::
@@ -137,11 +137,11 @@ def root_mean_square(obs, fx, deadband=None):
         The RMSE of the forecast.
 
     """
-    error = _error_deadband(obs, fx, deadband)
+    error = error_fnc(obs, fx)
     return np.sqrt(np.mean(error * error))
 
 
-def mean_absolute_percentage(obs, fx, deadband=None):
+def mean_absolute_percentage(obs, fx, error_fnc=error):
     """Mean absolute percentage error (MAPE).
 
     .. math::
@@ -162,11 +162,11 @@ def mean_absolute_percentage(obs, fx, deadband=None):
         The MAPE [%] of the forecast.
 
     """
-    error = _error_deadband(obs, fx, deadband)
+    error = error_fnc(obs, fx)
     return np.mean(np.abs(error / obs)) * 100.0
 
 
-def normalized_mean_absolute(obs, fx, norm, deadband=None):
+def normalized_mean_absolute(obs, fx, norm, error_fnc=error):
     """Normalized mean absolute error (NMAE).
 
     .. math:: \\text{NMAE} = \\text{MAE} / \\text{norm} * 100%
@@ -187,10 +187,10 @@ def normalized_mean_absolute(obs, fx, norm, deadband=None):
 
     """
 
-    return mean_absolute(obs, fx, deadband) / norm * 100.0
+    return mean_absolute(obs, fx, error_fnc=error) / norm * 100.0
 
 
-def normalized_mean_bias(obs, fx, norm, deadband=None):
+def normalized_mean_bias(obs, fx, norm, error_fnc=error):
     """Normalized mean bias error (NMBE).
 
     .. math:: \\text{NMBE} = \\text{MBE} / \\text{norm} * 100%
@@ -211,10 +211,10 @@ def normalized_mean_bias(obs, fx, norm, deadband=None):
 
     """
 
-    return mean_bias(obs, fx, deadband) / norm * 100.0
+    return mean_bias(obs, fx, error_fnc=error) / norm * 100.0
 
 
-def normalized_root_mean_square(obs, fx, norm, deadband=None):
+def normalized_root_mean_square(obs, fx, norm, error_fnc=error):
     """Normalized root mean square error (NRMSE).
 
     .. math:: \\text{NRMSE} = \\text{RMSE} / \\text{norm} * 100%
@@ -235,10 +235,10 @@ def normalized_root_mean_square(obs, fx, norm, deadband=None):
 
     """
 
-    return root_mean_square(obs, fx, deadband) / norm * 100.0
+    return root_mean_square(obs, fx, error_fnc=error) / norm * 100.0
 
 
-def forecast_skill(obs, fx, ref, deadband=None):
+def forecast_skill(obs, fx, ref, error_fnc=error):
     """Forecast skill (s).
 
     .. math:: s = 1 - \\text{RMSE}_\\text{fx} / \\text{RMSE}_\\text{ref}
@@ -263,8 +263,8 @@ def forecast_skill(obs, fx, ref, deadband=None):
 
     """
 
-    rmse_fx = root_mean_square(obs, fx, deadband)
-    rmse_ref = root_mean_square(obs, ref, deadband)
+    rmse_fx = root_mean_square(obs, fx, error_fnc=error)
+    rmse_ref = root_mean_square(obs, ref, error_fnc=error)
     return 1.0 - rmse_fx / rmse_ref
 
 

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -263,7 +263,8 @@ def process_forecast_observations(forecast_observations, filters, data,
                 preprocessing_results=preproc_results,
                 forecast_values=forecast_values,
                 observation_values=observation_values,
-                normalization_factor=fxobs.normalization
+                normalization_factor=fxobs.normalization,
+                uncertainty=fxobs.uncertainty
                 )
             processed_fxobs[name] = processed
     return tuple(processed_fxobs.values())

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -215,9 +215,10 @@ def process_forecast_observations(forecast_observations, filters, data,
                     data[fxobs.data_object],
                     qfilter,
                     exclude)
-            except Exception:
+            except Exception as e:
                 logger.error(
-                    'Failed to validate data for %s', fxobs.data_object.name)
+                    'Failed to validate data for %s. %s',
+                    fxobs.data_object.name, e)
                 preproc_results = (datamodel.PreprocessingResult(
                     name=VALIDATION_RESULT_TOTAL_STRING,
                     count=-1), )

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -53,7 +53,10 @@ def create_processed_fxobs(create_dt_index):
             interval_label,
             valid_point_count=len(fx_values),
             forecast_values=conv_fx_values,
-            observation_values=conv_obs_values)
+            observation_values=conv_obs_values,
+            normalization_factor=fxobs.normalization,
+            uncertainty=fxobs.uncertainty
+            )
 
     return _create_processed_fxobs
 
@@ -201,6 +204,19 @@ def test_calculate_metrics_single(single_forecast_data_obj,
     assert isinstance(result, list)
     assert isinstance(result[0], datamodel.MetricResult)
     assert len(result) == 1
+
+
+def test_calculate_metrics_single_uncert(single_forecast_observation_uncert,
+                                         create_processed_fxobs):
+    inp = [create_processed_fxobs(single_forecast_observation_uncert,
+                                  np.array([1.9, 1, 1.0005]), np.array([1, 1, 1]))]
+    result = calculator.calculate_metrics(inp, ['total'], ['mae'])
+    assert isinstance(result, list)
+    assert isinstance(result[0], datamodel.MetricResult)
+    assert len(result) == 1
+    expected_values = {None: (0.9 + 0.0005)/3, 100.: 0., 0.1: 0.3}
+    expected = expected_values[single_forecast_observation_uncert.uncertainty]
+    assert result[0].values[0].value == expected
 
 
 @pytest.mark.filterwarnings('ignore::RuntimeWarning')
@@ -720,22 +736,27 @@ def test_calculate_probabilistic_metrics_from_df(categories, df, metrics,
 
 
 @pytest.mark.filterwarnings('ignore::RuntimeWarning')
-@pytest.mark.parametrize('metric,fx,obs,ref_fx,norm,expect', [
-    ('mae', [], [], None, None, np.NaN),
-    ('mae', [1, 1, 1], [0, 1, -1], None, None, 1.0),
-    ('mbe', [1, 1, 1], [0, 1, -1], None, None, 1.0),
-    ('rmse', [1, 0, 1], [0, -1, 2], None, None, 1.0),
-    ('nrmse', [1, 0, 1], [0, -1, 2], None, None, None),
-    ('nrmse', [1, 0, 1], [0, -1, 2], None, 2.0, 100/2),
-    ('mape', [2, 3, 1], [4, 2, 2], None, None, 50.0),
-    ('s', [1, 0, 1], [0, -1, 2], None, None, None),
-    ('s', [1, 0, 1], [0, -1, 2], [2, 1, 0], None, 0.5),
-    ('r', [3, 2, 1], [1, 2, 3], None, None, -1.0),
-    ('r^2', [3, 2, 1], [1, 2, 3], None, None, -3.0),
-    ('crmse', [1, 1, 1], [0, 1, 2], None, None, np.sqrt(2/3))
+@pytest.mark.parametrize('metric,fx,obs,ref_fx,norm,dead,expect', [
+    ('mae', [], [], None, None, None, np.NaN),
+    ('mae', [], [], None, None, 1, np.NaN),
+    ('mae', [1, 1, 1], [0, 1, -1], None, None, None, 1.0),
+    ('mae', [0, 1, 4], [1, 1, 1], None, None, 100, 1.),
+    ('mbe', [1, 1, 1], [0, 1, -1], None, None, None, 1.0),
+    ('rmse', [1, 0, 1], [0, -1, 2], None, None, None, 1.0),
+    ('nrmse', [1, 0, 1], [0, -1, 2], None, None, None, None),
+    ('nrmse', [1, 0, 1], [0, -1, 2], None, 2.0, None, 100/2),
+    ('nrmse', [0.9, 1, 0.1], [1, 0, 1], None, 2.0, 100, 100*np.sqrt(1/3)/2),
+    ('mape', [2, 3, 1], [4, 2, 2], None, None, None, 50.0),
+    ('s', [1, 0, 1], [0, -1, 2], None, None, None, None),
+    ('s', [1, 0, 1], [0, -1, 2], [2, 1, 0], None, None, 0.5),
+    # unc shouldn't effect s result since it isn't supported
+    ('s', [1, 0, 1], [0, -1, 2], [2, 1, 0], None, 100, 0.5),
+    ('r', [3, 2, 1], [1, 2, 3], None, None, None, -1.0),
+    ('r^2', [3, 2, 1], [1, 2, 3], None, None, None, -3.0),
+    ('crmse', [1, 1, 1], [0, 1, 2], None, None, None, np.sqrt(2/3))
 ])
 def test_apply_deterministic_metric_func(metric, fx, obs, ref_fx, norm,
-                                         expect):
+                                         dead, expect):
     fx_series = np.array(fx)
     obs_series = np.array(obs)
     # Check require reference forecast kwarg
@@ -748,7 +769,8 @@ def test_apply_deterministic_metric_func(metric, fx, obs, ref_fx, norm,
         else:
             ref_fx_series = np.array(ref_fx)
             metric_value = calculator._apply_deterministic_metric_func(
-                metric, fx_series, obs_series, ref_fx=ref_fx_series)
+                metric, fx_series, obs_series, ref_fx=ref_fx_series,
+                deadband=dead)
             np.testing.assert_approx_equal(metric_value, expect)
 
     # Check requires normalization kwarg
@@ -760,13 +782,14 @@ def test_apply_deterministic_metric_func(metric, fx, obs, ref_fx, norm,
                     metric, fx_series, obs_series)
         else:
             metric_value = calculator._apply_deterministic_metric_func(
-                metric, fx_series, obs_series, normalization=norm)
+                metric, fx_series, obs_series, normalization=norm,
+                deadband=dead)
             np.testing.assert_approx_equal(metric_value, expect)
 
     # Does not require kwarg
     else:
         metric_value = calculator._apply_deterministic_metric_func(
-            metric, fx_series, obs_series)
+            metric, fx_series, obs_series, deadband=dead)
         if np.isnan(expect):
             assert np.isnan(metric_value)
         else:

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -209,7 +209,8 @@ def test_calculate_metrics_single(single_forecast_data_obj,
 def test_calculate_metrics_single_uncert(single_forecast_observation_uncert,
                                          create_processed_fxobs):
     inp = [create_processed_fxobs(single_forecast_observation_uncert,
-                                  np.array([1.9, 1, 1.0005]), np.array([1, 1, 1]))]
+                                  np.array([1.9, 1, 1.0005]),
+                                  np.array([1, 1, 1]))]
     result = calculator.calculate_metrics(inp, ['total'], ['mae'])
     assert isinstance(result, list)
     assert isinstance(result[0], datamodel.MetricResult)

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_allclose
 import pandas as pd
 import pytest
 import itertools
@@ -342,16 +343,20 @@ def test_calculate_deterministic_metrics_missing_values(
 
 
 def test_calculate_deterministic_metrics_normalizer(
-        create_processed_fxobs, single_forecast_observation):
-    pair = create_processed_fxobs(single_forecast_observation,
+        create_processed_fxobs, single_forecast_observation_norm):
+    pair = create_processed_fxobs(single_forecast_observation_norm,
                                   np.random.randn(10), np.random.randn(10))
     s_normed = calculator.calculate_deterministic_metrics(
         pair, ['total'], deterministic._REQ_NORM)
     unnormed = [x.lstrip('n') for x in deterministic._REQ_NORM]
     s_unnormed = calculator.calculate_deterministic_metrics(
         pair, ['total'], unnormed)
+    norm = single_forecast_observation_norm.normalization
     for v_normed, v_unnormed in zip(s_normed.values, s_unnormed.values):
-        assert v_normed.value == v_unnormed.value * 100
+        if np.isnan(norm):
+            assert np.isnan(v_normed.value)
+        else:
+            assert_allclose(v_normed.value, v_unnormed.value * 100 / norm)
 
 
 def test_calculate_deterministic_metrics_reference(

--- a/solarforecastarbiter/reports/templates/body.html
+++ b/solarforecastarbiter/reports/templates/body.html
@@ -134,6 +134,7 @@ generate a new report after the data provider submits new data.
 
 {% block metrics %}
 <h2 id="metrics">Metrics</h2>
+{% include "metrics_meta_table.html" %}
 <p>
   A table of metrics over the entire study period and figures for the selected
   categories are shown below.

--- a/solarforecastarbiter/reports/templates/metrics_meta_table.html
+++ b/solarforecastarbiter/reports/templates/metrics_meta_table.html
@@ -1,11 +1,19 @@
 <p>The table below shows the normalization and deadband parameters
 used in calculating the metrics. The <em>normalization</em> factor
-is applied when calculating metrics such as NMAE and NRMSE. The
-normalization is in the same units as the forecast and observation. The
-<em>deadband</em> accounts for observation uncertainty by setting
+is applied when calculating the metrics NMAE, NMBE, and NRMSE. The
+normalization is in the same units as the forecast and observation. By
+default, AC power forecasts are normalized by AC capacity and DC power
+forecasts are normalized by DC capacity. Normalization for all other
+forecasts is undefined, and the metric values are set to <code>nan</code>.
+The <em>deadband</em> accounts for observation uncertainty by setting
 the error (forecast - observation) equal to 0 for any point that is
-within the deadband. The deadband is specified as a percentage of the
-observation value at each time. </p>
+within the deadband. The error is unchanged for any point that is outside
+the deadband. The deadband is specified as a percentage of the
+observation value at each time. A value of <code>None</code>
+indicates that no deadband was applied for that observation/forecast pair.
+The deadband is accounted for in the following metrics:
+MAE, MBE, RMSE, MAPE, NMAE, NMBE, NRMSE. It is ignored for all other metrics.
+</p>
 <table class="table table-striped table-borderless" style="width:100%; ">
     <caption style="caption-side: top; text-align: center;">
     Table of metrics metadata

--- a/solarforecastarbiter/reports/templates/metrics_meta_table.html
+++ b/solarforecastarbiter/reports/templates/metrics_meta_table.html
@@ -1,0 +1,38 @@
+<p>The table below shows the normalization and deadband parameters
+used in calculating the metrics. The <em>normalization</em> factor
+is applied when calculating metrics such as NMAE and NRMSE. The
+normalization is in the same units as the forecast and observation. The
+<em>deadband</em> accounts for observation uncertainty by setting
+the error (forecast - observation) equal to 0 for any point that is
+within the deadband. The deadband is specified as a percentage of the
+observation value at each time. </p>
+<table class="table table-striped table-borderless" style="width:100%; ">
+    <caption style="caption-side: top; text-align: center;">
+    Table of metrics metadata
+    </caption>
+    <colgroup>
+    <col style="width: 50%">
+    <col style="width: 25%">
+    <col style="width: 25%">
+    </colgroup>
+    <thead style="text-align: left;">
+    <tr class="header" style="text-align: center;">
+        <th colspan="1">Name</th>
+        <th colspan="1">Normalization</th>
+        <th colspan="1">Deadband (%)</th>
+    </tr>
+    </thead>
+    <tbody style="text-align: left; overflow-wrap: break-word;">
+    {% for pfxobs in report.raw_report.processed_forecasts_observations %}
+    <tr>
+        <td>{{ pfxobs.name }}</td>
+        <td>
+        {{ pfxobs.normalization_factor }}
+        </td>
+        <td>
+        {{ pfxobs.uncertainty }}
+        </td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -752,3 +752,10 @@ def test_ForecastObservation_normalization_dc(single_forecast_dc_observation):
 def test_ForecastObservation_normalization_wind_speed(
         single_forecast_wind_speed_observation):
     assert np.isnan(single_forecast_wind_speed_observation.normalization)
+
+
+def test_ForecastObservation_uncertainty_invalid(
+        single_forecast, single_observation):
+    with pytest.raises(ValueError):
+        datamodel.ForecastObservation(
+            single_forecast, single_observation, uncertainty='nope')

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -754,8 +754,40 @@ def test_ForecastObservation_normalization_wind_speed(
     assert np.isnan(single_forecast_wind_speed_observation.normalization)
 
 
+@pytest.mark.parametrize('uncertainty,expected', [
+    (5, 5.),
+    ('5', 5.),
+    ('observation_uncertainty', 0.1),
+    (None, None)
+])
+def test_ForecastObservation_uncertainty(
+        single_forecast, single_observation, uncertainty, expected):
+    fxobs = datamodel.ForecastObservation(
+        single_forecast, single_observation, uncertainty=uncertainty)
+    assert fxobs.uncertainty == expected
+
+
 def test_ForecastObservation_uncertainty_invalid(
         single_forecast, single_observation):
     with pytest.raises(ValueError):
         datamodel.ForecastObservation(
             single_forecast, single_observation, uncertainty='nope')
+
+
+@pytest.mark.parametrize('uncertainty,expected', [
+    (5, 5.),
+    ('5', 5.),
+    (None, None)
+])
+def test_ForecastAggregate_uncertainty(
+        aggregateforecast, aggregate, uncertainty, expected):
+    fxobs = datamodel.ForecastAggregate(
+        aggregateforecast, aggregate, uncertainty=uncertainty)
+    assert fxobs.uncertainty == expected
+
+
+def test_ForecastAggregate_uncertainty_invalid(
+        aggregateforecast, aggregate):
+    with pytest.raises(ValueError):
+        datamodel.ForecastAggregate(
+            aggregateforecast, aggregate, uncertainty='anystring')


### PR DESCRIPTION
  - [x] Closes #358 
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Initial attempt at accounting for uncertainty using a deadband. Example code in details below. @alorenzo175 let me know what you think of this approach before I clean it up. I'm trying to leave some flexibility for the dashboard to say "use this deadband for all or use preset uncertainty for all". In the long run it might be nice to let the dashboard set the deadband for each, but I think that would require more refactoring in `calculator` than is in scope here.

<details>

```python
latitude = 32.2
longitude = -110.9
elevation = 700

site = datamodel.Site(
    name='Tucson, AZ',
    latitude=latitude,
    longitude=longitude,
    elevation=elevation,
    timezone='America/Phoenix'
)

name = 'OASIS DA GHI'
variable = 'ghi'

fx1 = datamodel.Forecast(
    name=name + ' 15',
    site=site,
    variable=variable,
    interval_label='ending',
    interval_value_type='mean',
    interval_length=pd.Timedelta('1h'),
    issue_time_of_day=datetime.time(hour=0, minute=45),
    run_length=pd.Timedelta('1h'),
    lead_time_to_start=pd.Timedelta('15min'),
    forecast_id='',
    extra_parameters='',
)

fx2 = datamodel.Forecast(
    name=name + ' 75',
    site=site,
    variable=variable,
    interval_label='ending',
    interval_value_type='mean',
    interval_length=pd.Timedelta('1h'),
    issue_time_of_day=datetime.time(hour=0, minute=45),
    run_length=pd.Timedelta('1h'),
    lead_time_to_start=pd.Timedelta('75min'),
    forecast_id='',
    extra_parameters='',
)

obs = datamodel.Observation(
    name=name,
    site=site,
    variable=variable,
    interval_label='ending',
    interval_value_type='mean',
    interval_length=pd.Timedelta('1h'),
    uncertainty=1
)

fxobs1 = datamodel.ForecastObservation(
    forecast=fx1,
    observation=obs
)

fxobs2 = datamodel.ForecastObservation(
    forecast=fx2,
    observation=obs
)

index = pd.date_range('20200401T1900', freq='1h', periods=3, tz='UTC')

obs_data = pd.DataFrame({'value': [1, 1, 1], 'quality_flag': 2}, index=index)
fx1_data = pd.Series([1, 2, 3], index=index)
fx2_data = pd.Series([0, 1, 2], index=index)

data = {
    fx1: fx1_data,
    fx2: fx2_data,
    obs: obs_data
}

filters = [datamodel.QualityFlagFilter()]

procs = preprocessing.process_forecast_observations([fxobs1, fxobs2], filters, data, 'UTC')

categories = ('total', )
metrics = ('mae', 'mbe', 'ksi')

metrics_result = calculator.calculate_metrics(procs, categories, metrics)

print('default\n', metrics_result)

metrics_result = calculator.calculate_metrics(procs, categories, metrics, deadband=1)

print('\nset deadband\n', metrics_result)

metrics_result = calculator.calculate_metrics(procs, categories, metrics, deadband='observation_uncertainty')

print('\ninfer deadband\n', metrics_result)

default
 [MetricResult(name='OASIS DA GHI 15', forecast_id='', values=(MetricValue(category='total', metric='mae', index='0', value=1.0), MetricValue(category='total', metric='mbe', index='0', value=1.0), MetricValue(category='total', metric='ksi', index='0', value=1.0)), observation_id='', aggregate_id=None), MetricResult(name='OASIS DA GHI 75', forecast_id='', values=(MetricValue(category='total', metric='mae', index='0', value=0.6666666666666666), MetricValue(category='total', metric='mbe', index='0', value=0.0), MetricValue(category='total', metric='ksi', index='0', value=0.6666666666666665)), observation_id='', aggregate_id=None)]

set deadband
 [MetricResult(name='OASIS DA GHI 15', forecast_id='', values=(MetricValue(category='total', metric='mae', index='0', value=0.6666666666666666), MetricValue(category='total', metric='mbe', index='0', value=0.6666666666666666), MetricValue(category='total', metric='ksi', index='0', value=1.0)), observation_id='', aggregate_id=None), MetricResult(name='OASIS DA GHI 75', forecast_id='', values=(MetricValue(category='total', metric='mae', index='0', value=0.0), MetricValue(category='total', metric='mbe', index='0', value=0.0), MetricValue(category='total', metric='ksi', index='0', value=0.6666666666666665)), observation_id='', aggregate_id=None)]

infer deadband
 [MetricResult(name='OASIS DA GHI 15', forecast_id='', values=(MetricValue(category='total', metric='mae', index='0', value=0.6666666666666666), MetricValue(category='total', metric='mbe', index='0', value=0.6666666666666666), MetricValue(category='total', metric='ksi', index='0', value=1.0)), observation_id='', aggregate_id=None), MetricResult(name='OASIS DA GHI 75', forecast_id='', values=(MetricValue(category='total', metric='mae', index='0', value=0.0), MetricValue(category='total', metric='mbe', index='0', value=0.0), MetricValue(category='total', metric='ksi', index='0', value=0.6666666666666665)), observation_id='', aggregate_id=None)]
```

</details>