### PR TITLE
add cloudy flag to ghi and nighttime to power variables

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -601,10 +601,10 @@ Perform a sequence of validation steps. Used by the API to initiate validation.
    validation.tasks.validate_dni
    validation.tasks.validate_dhi
    validation.tasks.validate_poa_global
+   validation.tasks.validate_defaults
    validation.tasks.validate_air_temperature
    validation.tasks.validate_wind_speed
    validation.tasks.validate_relative_humidity
-   validation.tasks.validate_timestamp
    validation.tasks.validate_daily_ghi
    validation.tasks.validate_daily_dc_power
    validation.tasks.validate_daily_ac_power

--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -29,6 +29,10 @@ API Changes
   (:pull:`369`)
 * Start and end are now optional parameters for the
   `solararbiter referencedata update` CLI command (:pull:`369`)
+* :py:func:`solarforecastarbiter.vavlidation.tasks.validate_timestamp` has been
+  replaced with
+  :py:func:`solarforecastarbiter.vavlidation.tasks.validate_defaults` which
+  also adds a nighttime flag (:pull:`382`)
 
 Enhancements
 ~~~~~~~~~~~~
@@ -36,13 +40,17 @@ Enhancements
   :py:mod:`solarforecastarbiter.reports.figures.bokeh_figures` for users
   still interested in bokeh figures.(:pull:`359`)
 * Report timeseries plots no longer draw lines over missing data points
-  (:issue:`351`). 
+  (:issue:`351`).
 * Double clicking a forecast or observation in the legend of report timeseries
   plots will toggle the display of all other timeseries. (:issue:`253`)
 * Clean up any PhantomJS drivers created to render SVGs (:issue:`344`)
   (:pull:`349`)
 * Reference data updates can now proceed from the last value in the API
   to avoid any artificial data gaps (:pull:`369`) (:issue:`353`)
+* GHI validation now includes checks on if a period is cloud-free and will be
+  flagged with CLEARSKY (:issue:`210`) (:pull:`382`)
+* All data validation now includes the generation of the NIGHTTIME flag
+  (:issue:`293`) (:pull:`382`)
 
 Bug fixes
 ~~~~~~~~~

--- a/solarforecastarbiter/plotting/timeseries.py
+++ b/solarforecastarbiter/plotting/timeseries.py
@@ -26,7 +26,7 @@ FLAG_COLORS = {
     'NOT VALIDATED': '#ff7f0e',
     'USER FLAGGED': '#d62728',
     'NIGHTTIME': None,
-    'CLOUDY': None,
+    'CLOUD FREE': None,
     'SHADED': None,
     'UNEVEN FREQUENCY': None,
     'LIMITS EXCEEDED': None,

--- a/solarforecastarbiter/plotting/timeseries.py
+++ b/solarforecastarbiter/plotting/timeseries.py
@@ -26,7 +26,7 @@ FLAG_COLORS = {
     'NOT VALIDATED': '#ff7f0e',
     'USER FLAGGED': '#d62728',
     'NIGHTTIME': None,
-    'CLOUD FREE': None,
+    'CLEARSKY': None,
     'SHADED': None,
     'UNEVEN FREQUENCY': None,
     'LIMITS EXCEEDED': None,

--- a/solarforecastarbiter/validation/quality_mapping.py
+++ b/solarforecastarbiter/validation/quality_mapping.py
@@ -29,7 +29,7 @@ BITMASK_DESCRIPTION_DICT = {1: {
     'VERSION IDENTIFIER 1': 1 << 2,
     'VERSION IDENTIFIER 2': 1 << 3,
     'NIGHTTIME': 1 << 4,
-    'CLOUDY': 1 << 5,
+    'CLOUD FREE': 1 << 5,
     'SHADED': 1 << 6,
     'UNEVEN FREQUENCY': 1 << 7,
     'LIMITS EXCEEDED': 1 << 8,

--- a/solarforecastarbiter/validation/quality_mapping.py
+++ b/solarforecastarbiter/validation/quality_mapping.py
@@ -29,7 +29,7 @@ BITMASK_DESCRIPTION_DICT = {1: {
     'VERSION IDENTIFIER 1': 1 << 2,
     'VERSION IDENTIFIER 2': 1 << 3,
     'NIGHTTIME': 1 << 4,
-    'CLOUD FREE': 1 << 5,
+    'CLEARSKY': 1 << 5,
     'SHADED': 1 << 6,
     'UNEVEN FREQUENCY': 1 << 7,
     'LIMITS EXCEEDED': 1 << 8,

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -1,6 +1,7 @@
 import logging
 
 
+import pandas as pd
 from pvlib.irradiance import get_extra_radiation
 
 
@@ -47,7 +48,8 @@ def validate_ghi(observation, values):
         `validator.check_timestamp_spacing`,
         `validator.check_irradiance_day_night`,
         `validator.check_ghi_limits_QCRad`,
-        `validator.check_ghi_clearsky`
+        `validator.check_ghi_clearsky`,
+        `validator.detect_clearsky_ghi`
     """
     solar_position, dni_extra, timestamp_flag, night_flag = _solpos_dni_extra(
         observation, values)
@@ -60,7 +62,10 @@ def validate_ghi(observation, values):
         _return_mask=True)
     ghi_clearsky_flag = validator.check_ghi_clearsky(values, clearsky['ghi'],
                                                      _return_mask=True)
-    return timestamp_flag, night_flag, ghi_limit_flag, ghi_clearsky_flag
+    cloudy_flag = validator.detect_clearsky_ghi(values, clearsky['ghi'],
+                                                _return_mask=True)
+    return (timestamp_flag, night_flag, ghi_limit_flag,
+            ghi_clearsky_flag, cloudy_flag)
 
 
 def validate_dni(observation, values):

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -165,30 +165,6 @@ def validate_poa_global(observation, values):
     return timestamp_flag, night_flag, poa_clearsky_flag
 
 
-def validate_defaults(observation, values):
-    """
-    Run default validation checks on an observation.
-
-    Parameters
-    ----------
-    observation : solarforecastarbiter.datamodel.Observation
-       Observation object that the data is associated with
-    values : pandas.Series
-       Series of observation values
-
-    Returns
-    -------
-    tuple
-        Tuple of integer bitmask series of flags from the following tests, in
-        order,
-        `validator.check_timestamp_spacing`
-        `validator.check_irradiance_day_night`
-    """
-    timestamp_flag = _validate_timestamp(observation, values)
-    _, night_flag = _solpos_night(observation, values)
-    return timestamp_flag, night_flag
-
-
 def validate_air_temperature(observation, values):
     """
     Run validation checks on an air temperature observation.
@@ -264,6 +240,30 @@ def validate_relative_humidity(observation, values):
     timestamp_flag, night_flag = validate_defaults(observation, values)
     rh_limit_flag = validator.check_rh_limits(values, _return_mask=True)
     return timestamp_flag, night_flag, rh_limit_flag
+
+
+def validate_defaults(observation, values):
+    """
+    Run default validation checks on an observation.
+
+    Parameters
+    ----------
+    observation : solarforecastarbiter.datamodel.Observation
+       Observation object that the data is associated with
+    values : pandas.Series
+       Series of observation values
+
+    Returns
+    -------
+    tuple
+        Tuple of integer bitmask series of flags from the following tests, in
+        order,
+        `validator.check_timestamp_spacing`
+        `validator.check_irradiance_day_night`
+    """
+    timestamp_flag = _validate_timestamp(observation, values)
+    _, night_flag = _solpos_night(observation, values)
+    return timestamp_flag, night_flag
 
 
 def validate_daily_ghi(observation, values):

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -46,15 +46,14 @@ def validate_ghi(observation, values):
 
     Returns
     -------
-    tuple
-        Tuple of integer bitmask series of flags from the following tests, in
-        order,
-        `validator.check_timestamp_spacing`,
-        `validator.check_irradiance_day_night`,
-        `validator.check_ghi_limits_QCRad`,
-        `validator.check_ghi_clearsky`,
-        `validator.detect_clearsky_ghi`
-    """
+    timestamp_flag, night_flag, ghi_limit_flag, ghi_clearsky_flag, cloud_free_flag : pandas.Series
+        Integer bitmask series from
+        :py:func:`.validator.check_timestamp_spacing`,
+        :py:func:`.validator.check_irradiance_day_night`,
+        :py:func:`.validator.check_ghi_limits_QCRad`,
+        :py:func:`.validator.check_ghi_clearsky`,
+        :py:func:`.validator.detect_clearsky_ghi` respectively
+    """  # NOQA
     solar_position, dni_extra, timestamp_flag, night_flag = _solpos_dni_extra(
         observation, values)
     clearsky = pvmodel.calculate_clearsky(
@@ -85,12 +84,11 @@ def validate_dni(observation, values):
 
     Returns
     -------
-    tuple
-        Tuple of integer bitmask series of flags from the following tests, in
-        order,
-        `validator.check_timestamp_spacing`,
-        `validator.check_irradiance_day_night`,
-        `validator.check_dni_limits_QCRad`
+    timestamp_flag, night_flag, dni_limit_flag : pandas.Series
+        Integer bitmask series from
+        :py:func:`.validator.check_timestamp_spacing`,
+        :py:func:`.validator.check_irradiance_day_night`,
+        :py:func:`.validator.check_dni_limits_QCRad` respectively
     """
     solar_position, dni_extra, timestamp_flag, night_flag = _solpos_dni_extra(
         observation, values)
@@ -114,12 +112,11 @@ def validate_dhi(observation, values):
 
     Returns
     -------
-    tuple
-        Tuple of integer bitmask series of flags from the following tests, in
-        order,
-        `validator.check_timestamp_spacing`,
-        `validator.check_irradiance_day_night`,
-        `validator.check_dhi_limits_QCRad`
+    timestamp_flag, night_flag, dhi_limit_flag : pandas.Series
+        Integer bitmask series from
+        :py:func:`.validator.check_timestamp_spacing`,
+        :py:func:`.validator.check_irradiance_day_night`,
+        :py:func:`.validator.check_dhi_limits_QCRad` respectively
     """
     solar_position, dni_extra, timestamp_flag, night_flag = _solpos_dni_extra(
         observation, values)
@@ -143,12 +140,11 @@ def validate_poa_global(observation, values):
 
     Returns
     -------
-    tuple
-        Tuple of integer bitmask series of flags from the following tests, in
-        order,
-        `validator.check_timestamp_spacing`,
-        `validator.check_irradiance_day_night`,
-        `validator.check_poa_clearsky`
+    timestamp_flag, night_flag, poa_clearsky_flag : pandas.Series
+        Integer bitmask series from
+        :py:func:`.validator.check_timestamp_spacing`,
+        :py:func:`.validator.check_irradiance_day_night`,
+        :py:func:`.validator.check_poa_clearsky` respectively
     """
     solar_position, dni_extra, timestamp_flag, night_flag = _solpos_dni_extra(
         observation, values)
@@ -178,12 +174,11 @@ def validate_air_temperature(observation, values):
 
     Returns
     -------
-    tuple
-        Tuple of integer bitmask series of flags from the following tests, in
-        order,
-        `validator.check_timestamp_spacing`
-        `validator.check_irradiance_day_night`
-        `validator.check_temperature_limits`
+    timestamp_flag, night_flag, temp_limit_flag : pandas.Series
+        Integer bitmask series from
+        :py:func:`.validator.check_timestamp_spacing`,
+        :py:func:`.validator.check_irradiance_day_night`,
+        :py:func:`.validator.check_temperature_limits` respectively
     """
     timestamp_flag, night_flag = validate_defaults(observation, values)
     temp_limit_flag = validator.check_temperature_limits(
@@ -204,12 +199,11 @@ def validate_wind_speed(observation, values):
 
     Returns
     -------
-    tuple
-        Tuple of integer bitmask series of flags from the following tests, in
-        order,
-        `validator.check_timestamp_spacing`
-        `validator.check_irradiance_day_night`
-        `validator.check_wind_limits`
+    timestamp_flag, night_flag, wind_limit_flag : pandas.Series
+        Integer bitmask series from
+        :py:func:`.validator.check_timestamp_spacing`,
+        :py:func:`.validator.check_irradiance_day_night`,
+        :py:func:`.validator.check_wind_limits` respectively
     """
     timestamp_flag, night_flag = validate_defaults(observation, values)
     wind_limit_flag = validator.check_wind_limits(values,
@@ -230,12 +224,11 @@ def validate_relative_humidity(observation, values):
 
     Returns
     -------
-    tuple
-        Tuple of integer bitmask series of flags from the following tests, in
-        order,
-        `validator.check_timestamp_spacing`
-        `validator.check_irradiance_day_night`
-        `validator.check_rh_limits`
+    timestamp_flag, night_flag, rh_limit_flag : pandas.Series
+        Integer bitmask series from
+        :py:func:`.validator.check_timestamp_spacing`,
+        :py:func:`.validator.check_irradiance_day_night`,
+        :py:func:`.validator.check_rh_limits` respectively
     """
     timestamp_flag, night_flag = validate_defaults(observation, values)
     rh_limit_flag = validator.check_rh_limits(values, _return_mask=True)
@@ -255,11 +248,10 @@ def validate_defaults(observation, values):
 
     Returns
     -------
-    tuple
-        Tuple of integer bitmask series of flags from the following tests, in
-        order,
-        `validator.check_timestamp_spacing`
-        `validator.check_irradiance_day_night`
+    timestamp_flag, night_flag : pandas.Series
+        Integer bitmask series from
+        :py:func:`.validator.check_timestamp_spacing`,
+        :py:func:`.validator.check_irradiance_day_night` respectively
     """
     timestamp_flag = _validate_timestamp(observation, values)
     _, night_flag = _solpos_night(observation, values)
@@ -281,12 +273,11 @@ def validate_daily_ghi(observation, values):
 
     Returns
     -------
-    tuple
-        Tuple of integer bitmask series of flags from the following tests, in
-        order,
-        tests from `validate_ghi`
-        `validator.detect_stale_values`
-        `validator.detect_interpolation`
+    *ghi_flags, stale_flag, interpolation_flag : pandas.Series
+        Integer bitmask series from
+        :py:func:`.validate_ghi`,
+        :py:func:`.validator.detect_stale_values`,
+        :py:func:`.validator.detect_interpolation`
     """
     ghi_flags = validate_ghi(observation, values)
     stale_flag = validator.detect_stale_values(values, _return_mask=True)
@@ -308,13 +299,12 @@ def validate_daily_dc_power(observation, values):
 
     Returns
     -------
-    tuple
-        Tuple of integer bitmask series of flags from the following tests, in
-        order,
-        `validator.check_timestamp_spacing`
-        `validator.check_irradiance_day_night`
-        `validator.detect_stale_values`
-        `validator.detect_interpolation`
+    timestamp_flag, night_flag, stale_flag, interpolation_flag : pandas.Series
+        Integer bitmask series from
+        :py:func:`.validator.check_timestamp_spacing`,
+        :py:func:`.validator.check_irradiance_day_night`,
+        :py:func:`.validator.detect_stale_values`,
+        :py:func:`.validator.detect_interpolation`
     """
     timestamp_flag, night_flag = validate_defaults(observation, values)
     stale_flag = validator.detect_stale_values(values, _return_mask=True)
@@ -336,15 +326,14 @@ def validate_daily_ac_power(observation, values):
 
     Returns
     -------
-    tuple
-        Tuple of integer bitmask series of flags from the following tests, in
-        order,
-        `validator.check_timestamp_spacing`
-        `validator.check_irradiance_day_night`
-        `validator.detect_stale_values`
-        `validator.detect_interpolation`
-        `validator.detect_clipping`
-    """
+    timestamp_flag, night_flag, stale_flag, interpolation_flag, clipping_flag : pandas.Series
+        Integer bitmask series from
+        :py:func:`.validator.check_timestamp_spacing`,
+        :py:func:`.validator.check_irradiance_day_night`,
+        :py:func:`.validator.detect_stale_values`,
+        :py:func:`.validator.detect_interpolation`,
+        :py:func:`.validator.detect_clipping`
+    """  # NOQA
     timestamp_flag, night_flag = validate_defaults(observation, values)
     stale_flag = validator.detect_stale_values(values, _return_mask=True)
     interpolation_flag = validator.detect_interpolation(values,

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -1,7 +1,6 @@
 import logging
 
 
-import pandas as pd
 from pvlib.irradiance import get_extra_radiation
 
 
@@ -62,10 +61,10 @@ def validate_ghi(observation, values):
         _return_mask=True)
     ghi_clearsky_flag = validator.check_ghi_clearsky(values, clearsky['ghi'],
                                                      _return_mask=True)
-    cloudy_flag = validator.detect_clearsky_ghi(values, clearsky['ghi'],
-                                                _return_mask=True)
+    cloud_free_flag = validator.detect_clearsky_ghi(values, clearsky['ghi'],
+                                                    _return_mask=True)
     return (timestamp_flag, night_flag, ghi_limit_flag,
-            ghi_clearsky_flag, cloudy_flag)
+            ghi_clearsky_flag, cloud_free_flag)
 
 
 def validate_dni(observation, values):

--- a/solarforecastarbiter/validation/tests/test_quality_mapping.py
+++ b/solarforecastarbiter/validation/tests/test_quality_mapping.py
@@ -160,14 +160,14 @@ def test_has_data_been_validated():
     (3, 'OK', False),
     (0, 'USER FLAGGED', False),
     (3, 'USER FLAGGED', True),
-    (0, 'CLOUD FREE', False),
+    (0, 'CLEARSKY', False),
     (16, 'OK', False),
     (1, 'USER FLAGGED', True),
     (16, 'NIGHTTIME', True),
-    (33, 'CLOUD FREE', True),
+    (33, 'CLEARSKY', True),
     (33, 'NIGHTTIME', False),
     (33, ['OK', 'NIGHTTIME'], False),
-    (33, ('OK', 'CLOUD FREE', 'USER FLAGGED'), True),
+    (33, ('OK', 'CLEARSKY', 'USER FLAGGED'), True),
     (2, ('OK', 'NIGHTTIME'), True),
     (9297, 'USER FLAGGED', True)
 ])
@@ -206,7 +206,7 @@ def test_which_data_is_ok(flags, expected):
     assert_series_equal(out, expected)
 
 
-DESCRIPTIONS = ['USER FLAGGED', 'NIGHTTIME', 'CLOUD FREE',
+DESCRIPTIONS = ['USER FLAGGED', 'NIGHTTIME', 'CLEARSKY',
                 'SHADED', 'UNEVEN FREQUENCY', 'LIMITS EXCEEDED',
                 'CLEARSKY EXCEEDED', 'STALE VALUES', 'INTERPOLATED VALUES',
                 'CLIPPED VALUES', 'INCONSISTENT IRRADIANCE COMPONENTS']
@@ -277,7 +277,7 @@ def test_convert_flag_frame_to_strings():
     (pd.Series([1, 0, 0, 0], dtype=bool), 'OK'),
     (pd.Series([0, 1, 0, 1], dtype=bool), 'USER FLAGGED'),
     (pd.Series([0, 0, 1, 0], dtype=bool), 'CLEARSKY EXCEEDED'),
-    (pd.Series([0, 0, 0, 1], dtype=bool), 'CLOUD FREE'),
+    (pd.Series([0, 0, 0, 1], dtype=bool), 'CLEARSKY'),
     (pd.Series([0, 0, 0, 1], dtype=bool), 'CLIPPED VALUES'),
     (pd.Series([0, 0, 0, 0], dtype=bool), 'STALE VALUES'),
 ])
@@ -295,7 +295,7 @@ def test_check_if_series_flagged_validated_fail():
 def test_check_if_series_flagged_type_fail():
     with pytest.raises(TypeError):
         quality_mapping.check_if_series_flagged(pd.Series([2, 3, 35]),
-                                                ['OK', b'CLOUD FREE', []])
+                                                ['OK', b'CLEARSKY', []])
 
 
 def test_check_if_series_flagged_key_fail():

--- a/solarforecastarbiter/validation/tests/test_quality_mapping.py
+++ b/solarforecastarbiter/validation/tests/test_quality_mapping.py
@@ -160,14 +160,14 @@ def test_has_data_been_validated():
     (3, 'OK', False),
     (0, 'USER FLAGGED', False),
     (3, 'USER FLAGGED', True),
-    (0, 'CLOUDY', False),
+    (0, 'CLOUD FREE', False),
     (16, 'OK', False),
     (1, 'USER FLAGGED', True),
     (16, 'NIGHTTIME', True),
-    (33, 'CLOUDY', True),
+    (33, 'CLOUD FREE', True),
     (33, 'NIGHTTIME', False),
     (33, ['OK', 'NIGHTTIME'], False),
-    (33, ('OK', 'CLOUDY', 'USER FLAGGED'), True),
+    (33, ('OK', 'CLOUD FREE', 'USER FLAGGED'), True),
     (2, ('OK', 'NIGHTTIME'), True),
     (9297, 'USER FLAGGED', True)
 ])
@@ -206,7 +206,7 @@ def test_which_data_is_ok(flags, expected):
     assert_series_equal(out, expected)
 
 
-DESCRIPTIONS = ['USER FLAGGED', 'NIGHTTIME', 'CLOUDY',
+DESCRIPTIONS = ['USER FLAGGED', 'NIGHTTIME', 'CLOUD FREE',
                 'SHADED', 'UNEVEN FREQUENCY', 'LIMITS EXCEEDED',
                 'CLEARSKY EXCEEDED', 'STALE VALUES', 'INTERPOLATED VALUES',
                 'CLIPPED VALUES', 'INCONSISTENT IRRADIANCE COMPONENTS']
@@ -277,7 +277,7 @@ def test_convert_flag_frame_to_strings():
     (pd.Series([1, 0, 0, 0], dtype=bool), 'OK'),
     (pd.Series([0, 1, 0, 1], dtype=bool), 'USER FLAGGED'),
     (pd.Series([0, 0, 1, 0], dtype=bool), 'CLEARSKY EXCEEDED'),
-    (pd.Series([0, 0, 0, 1], dtype=bool), 'CLOUDY'),
+    (pd.Series([0, 0, 0, 1], dtype=bool), 'CLOUD FREE'),
     (pd.Series([0, 0, 0, 1], dtype=bool), 'CLIPPED VALUES'),
     (pd.Series([0, 0, 0, 0], dtype=bool), 'STALE VALUES'),
 ])
@@ -295,7 +295,7 @@ def test_check_if_series_flagged_validated_fail():
 def test_check_if_series_flagged_type_fail():
     with pytest.raises(TypeError):
         quality_mapping.check_if_series_flagged(pd.Series([2, 3, 35]),
-                                                ['OK', b'CLOUDY', []])
+                                                ['OK', b'CLOUD FREE', []])
 
 
 def test_check_if_series_flagged_key_fail():

--- a/solarforecastarbiter/validation/tests/test_validation_tasks.py
+++ b/solarforecastarbiter/validation/tests/test_validation_tasks.py
@@ -63,8 +63,8 @@ def test_validate_ghi(mocker, make_observation, default_index):
                 DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'],
                 pd.Series([0, 1, 0, 1, 0], index=data.index) *
                 DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'],
-                pd.Series([1, 1, 1, 1, 1], index=data.index) *
-                DESCRIPTION_MASK_MAPPING['CLOUDY'])
+                pd.Series(0, index=data.index) *
+                DESCRIPTION_MASK_MAPPING['CLOUD FREE'])
     for flag, exp in zip(flags, expected):
         assert_series_equal(flag, exp | LATEST_VERSION_FLAG,
                             check_names=False)
@@ -97,8 +97,8 @@ def test_validate_mostly_clear(mocker, make_observation):
                 DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'],
                 pd.Series(0, index=data.index) *
                 DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'],
-                pd.Series([0] * 10 + [1], index=data.index) *
-                DESCRIPTION_MASK_MAPPING['CLOUDY'])
+                pd.Series([1] * 10 + [0], index=data.index) *
+                DESCRIPTION_MASK_MAPPING['CLOUD FREE'])
     for flag, exp in zip(flags, expected):
         assert_series_equal(flag, exp | LATEST_VERSION_FLAG,
                             check_names=False)
@@ -125,18 +125,14 @@ def test_immediate_observation_validation_ghi(mocker, make_observation,
 
     out = data.copy()
     out['quality_flag'] = [
-        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] | LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
-        DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'] | LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
-        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
-        DESCRIPTION_MASK_MAPPING['USER FLAGGED'] | LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['USER FLAGGED'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['UNEVEN FREQUENCY'] | LATEST_VERSION_FLAG |
         DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'] |
-        DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'] |
-        DESCRIPTION_MASK_MAPPING['CLOUDY']]
+        DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED']
+    ]
     assert post_mock.called_once
     assert_frame_equal(post_mock.call_args[0][1], out)
 
@@ -523,8 +519,8 @@ def test_validate_daily_ghi(mocker, make_observation, daily_index):
                 pd.Series([0, 1, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0],
                           index=data.index) *
                 DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'],
-                pd.Series(1, index=data.index) *
-                DESCRIPTION_MASK_MAPPING['CLOUDY'],
+                pd.Series(0, index=data.index) *
+                DESCRIPTION_MASK_MAPPING['CLOUD FREE'],
                 pd.Series([0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0],
                           index=data.index) *
                 DESCRIPTION_MASK_MAPPING['STALE VALUES'],
@@ -560,43 +556,30 @@ def test_daily_observation_validation_ghi(mocker, make_observation,
 
     out = data.copy()
     out['quality_flag'] = [
-        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] | LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'] |
         DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'] |
-        LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
-        DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'] | LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
-        DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'] | LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
-        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
-        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
+        LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['STALE VALUES'] |
         DESCRIPTION_MASK_MAPPING['INTERPOLATED VALUES'] |
-        LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
+        LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['STALE VALUES'] |
         DESCRIPTION_MASK_MAPPING['INTERPOLATED VALUES'] |
         DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'] |
-        LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
-        DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'] | LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
-        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] | LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
+        LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['NIGHTTIME'] |
         DESCRIPTION_MASK_MAPPING['USER FLAGGED'] |
-        DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'] | LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
-        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] | LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY'],
+        DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['NIGHTTIME'] |
         DESCRIPTION_MASK_MAPPING['UNEVEN FREQUENCY'] |
-        LATEST_VERSION_FLAG |
-        DESCRIPTION_MASK_MAPPING['CLOUDY']
+        LATEST_VERSION_FLAG
     ]
     assert post_mock.called_once
     assert_frame_equal(post_mock.call_args[0][1], out)

--- a/solarforecastarbiter/validation/tests/test_validation_tasks.py
+++ b/solarforecastarbiter/validation/tests/test_validation_tasks.py
@@ -157,7 +157,7 @@ def test_immediate_observation_validation_not_listed(mocker, make_observation,
 
     out = data.copy()
     out['quality_flag'] = [
-        LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] | LATEST_VERSION_FLAG,
         LATEST_VERSION_FLAG,
         LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['USER FLAGGED'] | LATEST_VERSION_FLAG,
@@ -336,6 +336,7 @@ def test_validate_air_temp(mocker, make_observation, default_index):
                                  new=mocker.MagicMock(
                                      wraps=getattr(validator, f)))
              for f in ['check_timestamp_spacing',
+                       'check_irradiance_day_night',
                        'check_temperature_limits']]
     obs = make_observation('air_temperature')
     data = pd.Series([10, 1000, -400, 30, 20], index=default_index)
@@ -345,6 +346,8 @@ def test_validate_air_temp(mocker, make_observation, default_index):
 
     expected = (pd.Series([0, 0, 0, 0, 1], index=data.index) *
                 DESCRIPTION_MASK_MAPPING['UNEVEN FREQUENCY'],
+                pd.Series([1, 0, 0, 0, 0], index=data.index) *
+                DESCRIPTION_MASK_MAPPING['NIGHTTIME'],
                 pd.Series([0, 1, 1, 0, 0], index=data.index) *
                 DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'])
     for flag, exp in zip(flags, expected):
@@ -373,7 +376,9 @@ def test_immediate_observation_validation_air_temperature(
 
     out = data.copy()
     out['quality_flag'] = [
-        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['OK'] |
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] |
+        LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['USER FLAGGED'] | LATEST_VERSION_FLAG,
@@ -388,6 +393,7 @@ def test_validate_wind_speed(mocker, make_observation, default_index):
                                  new=mocker.MagicMock(
                                      wraps=getattr(validator, f)))
              for f in ['check_timestamp_spacing',
+                       'check_irradiance_day_night',
                        'check_wind_limits']]
     obs = make_observation('wind_speed')
     data = pd.Series([10, 1000, -400, 3, 20], index=default_index)
@@ -397,6 +403,8 @@ def test_validate_wind_speed(mocker, make_observation, default_index):
 
     expected = (pd.Series([0, 0, 0, 0, 1], index=data.index) *
                 DESCRIPTION_MASK_MAPPING['UNEVEN FREQUENCY'],
+                pd.Series([1, 0, 0, 0, 0], index=data.index) *
+                DESCRIPTION_MASK_MAPPING['NIGHTTIME'],
                 pd.Series([0, 1, 1, 0, 0], index=data.index) *
                 DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'])
     for flag, exp in zip(flags, expected):
@@ -425,7 +433,9 @@ def test_immediate_observation_validation_wind_speed(
 
     out = data.copy()
     out['quality_flag'] = [
-        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['OK'] |
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] |
+        LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['USER FLAGGED'] | LATEST_VERSION_FLAG,
@@ -440,6 +450,7 @@ def test_validate_relative_humidity(mocker, make_observation, default_index):
                                  new=mocker.MagicMock(
                                      wraps=getattr(validator, f)))
              for f in ['check_timestamp_spacing',
+                       'check_irradiance_day_night',
                        'check_rh_limits']]
     obs = make_observation('relative_humidity')
     data = pd.Series([10, 101, -400, 60, 20], index=default_index)
@@ -449,6 +460,8 @@ def test_validate_relative_humidity(mocker, make_observation, default_index):
 
     expected = (pd.Series([0, 0, 0, 0, 1], index=data.index) *
                 DESCRIPTION_MASK_MAPPING['UNEVEN FREQUENCY'],
+                pd.Series([1, 0, 0, 0, 0], index=data.index) *
+                DESCRIPTION_MASK_MAPPING['NIGHTTIME'],
                 pd.Series([0, 1, 1, 0, 0], index=data.index) *
                 DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'])
     for flag, exp in zip(flags, expected):
@@ -477,7 +490,9 @@ def test_immediate_observation_validation_relative_humidity(
 
     out = data.copy()
     out['quality_flag'] = [
-        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['OK'] |
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] |
+        LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['USER FLAGGED'] | LATEST_VERSION_FLAG,
@@ -590,6 +605,7 @@ def test_validate_daily_dc_power(mocker, make_observation, daily_index):
                                  new=mocker.MagicMock(
                                      wraps=getattr(validator, f)))
              for f in ['check_timestamp_spacing',
+                       'check_irradiance_day_night',
                        'detect_stale_values',
                        'detect_interpolation']]
     obs = make_observation('dc_power')
@@ -604,6 +620,9 @@ def test_validate_daily_dc_power(mocker, make_observation, daily_index):
     expected = (pd.Series([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
                           index=data.index) *
                 DESCRIPTION_MASK_MAPPING['UNEVEN FREQUENCY'],
+                pd.Series([1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
+                          index=data.index) *
+                DESCRIPTION_MASK_MAPPING['NIGHTTIME'],
                 pd.Series([0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0],
                           index=data.index) *
                 DESCRIPTION_MASK_MAPPING['STALE VALUES'],
@@ -639,25 +658,33 @@ def test_daily_observation_validation_dc_power(mocker, make_observation,
 
     out = data.copy()
     out['quality_flag'] = [
+        DESCRIPTION_MASK_MAPPING['OK'] |
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] |
+        LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['STALE VALUES'] |
+        DESCRIPTION_MASK_MAPPING['INTERPOLATED VALUES'] |
+        LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['STALE VALUES'] |
+        DESCRIPTION_MASK_MAPPING['INTERPOLATED VALUES'] |
+        LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
-        (DESCRIPTION_MASK_MAPPING['STALE VALUES'] |
-         DESCRIPTION_MASK_MAPPING['INTERPOLATED VALUES'] |
-         LATEST_VERSION_FLAG),
-        (DESCRIPTION_MASK_MAPPING['STALE VALUES'] |
-         DESCRIPTION_MASK_MAPPING['INTERPOLATED VALUES'] |
-         LATEST_VERSION_FLAG),
-        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
-        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
-        (DESCRIPTION_MASK_MAPPING['USER FLAGGED'] |
-         LATEST_VERSION_FLAG),
-        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
-        (DESCRIPTION_MASK_MAPPING['UNEVEN FREQUENCY'] |
-         LATEST_VERSION_FLAG)
+        DESCRIPTION_MASK_MAPPING['OK'] |
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] |
+        LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['USER FLAGGED'] |
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] |
+        LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['OK'] |
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] |
+        LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['UNEVEN FREQUENCY'] |
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] |
+        LATEST_VERSION_FLAG
     ]
     assert post_mock.called_once
     assert_frame_equal(post_mock.call_args[0][1], out)
@@ -668,6 +695,7 @@ def test_validate_daily_ac_power(mocker, make_observation, daily_index):
                                  new=mocker.MagicMock(
                                      wraps=getattr(validator, f)))
              for f in ['check_timestamp_spacing',
+                       'check_irradiance_day_night',
                        'detect_stale_values',
                        'detect_interpolation',
                        'detect_clipping']]
@@ -683,6 +711,9 @@ def test_validate_daily_ac_power(mocker, make_observation, daily_index):
     expected = (pd.Series([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
                           index=data.index) *
                 DESCRIPTION_MASK_MAPPING['UNEVEN FREQUENCY'],
+                pd.Series([1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
+                          index=data.index) *
+                DESCRIPTION_MASK_MAPPING['NIGHTTIME'],
                 pd.Series([0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0],
                           index=data.index) *
                 DESCRIPTION_MASK_MAPPING['STALE VALUES'],
@@ -721,27 +752,35 @@ def test_daily_observation_validation_ac_power(mocker, make_observation,
 
     out = data.copy()
     out['quality_flag'] = [
-        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['OK'] |
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] |
+        LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['INTERPOLATED VALUES'] | LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
-        (DESCRIPTION_MASK_MAPPING['STALE VALUES'] |
-         DESCRIPTION_MASK_MAPPING['INTERPOLATED VALUES'] |
-         DESCRIPTION_MASK_MAPPING['CLIPPED VALUES'] |
-         LATEST_VERSION_FLAG),
-        (DESCRIPTION_MASK_MAPPING['STALE VALUES'] |
-         DESCRIPTION_MASK_MAPPING['INTERPOLATED VALUES'] |
-         DESCRIPTION_MASK_MAPPING['CLIPPED VALUES'] |
-         LATEST_VERSION_FLAG),
+        DESCRIPTION_MASK_MAPPING['STALE VALUES'] |
+        DESCRIPTION_MASK_MAPPING['INTERPOLATED VALUES'] |
+        DESCRIPTION_MASK_MAPPING['CLIPPED VALUES'] |
+        LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['STALE VALUES'] |
+        DESCRIPTION_MASK_MAPPING['INTERPOLATED VALUES'] |
+        DESCRIPTION_MASK_MAPPING['CLIPPED VALUES'] |
+        LATEST_VERSION_FLAG,
         DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
-        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
-        (DESCRIPTION_MASK_MAPPING['USER FLAGGED'] |
-         LATEST_VERSION_FLAG),
-        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
-        (DESCRIPTION_MASK_MAPPING['UNEVEN FREQUENCY'] |
-         LATEST_VERSION_FLAG)
+        DESCRIPTION_MASK_MAPPING['OK'] |
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] |
+        LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['USER FLAGGED'] |
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] |
+        LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['OK'] |
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] |
+        LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['UNEVEN FREQUENCY'] |
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] |
+        LATEST_VERSION_FLAG
     ]
     assert post_mock.called_once
     assert_frame_equal(post_mock.call_args[0][1], out)

--- a/solarforecastarbiter/validation/tests/test_validation_tasks.py
+++ b/solarforecastarbiter/validation/tests/test_validation_tasks.py
@@ -64,7 +64,7 @@ def test_validate_ghi(mocker, make_observation, default_index):
                 pd.Series([0, 1, 0, 1, 0], index=data.index) *
                 DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'],
                 pd.Series(0, index=data.index) *
-                DESCRIPTION_MASK_MAPPING['CLOUD FREE'])
+                DESCRIPTION_MASK_MAPPING['CLEARSKY'])
     for flag, exp in zip(flags, expected):
         assert_series_equal(flag, exp | LATEST_VERSION_FLAG,
                             check_names=False)
@@ -98,7 +98,7 @@ def test_validate_mostly_clear(mocker, make_observation):
                 pd.Series(0, index=data.index) *
                 DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'],
                 pd.Series([1] * 10 + [0], index=data.index) *
-                DESCRIPTION_MASK_MAPPING['CLOUD FREE'])
+                DESCRIPTION_MASK_MAPPING['CLEARSKY'])
     for flag, exp in zip(flags, expected):
         assert_series_equal(flag, exp | LATEST_VERSION_FLAG,
                             check_names=False)
@@ -520,7 +520,7 @@ def test_validate_daily_ghi(mocker, make_observation, daily_index):
                           index=data.index) *
                 DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'],
                 pd.Series(0, index=data.index) *
-                DESCRIPTION_MASK_MAPPING['CLOUD FREE'],
+                DESCRIPTION_MASK_MAPPING['CLEARSKY'],
                 pd.Series([0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0],
                           index=data.index) *
                 DESCRIPTION_MASK_MAPPING['STALE VALUES'],

--- a/solarforecastarbiter/validation/tests/test_validator.py
+++ b/solarforecastarbiter/validation/tests/test_validator.py
@@ -361,7 +361,22 @@ def test_detect_clearsky_ghi(ghi_clearsky):
     assert all(flags[7:12]) and all(flags[15:-6])
 
 
-def test_detect_clearsky_ghi_error(ghi_clearsky):
-    with pytest.raises(ValueError):
-        validator.detect_clearsky_ghi(ghi_clearsky[::4],
-                                      ghi_clearsky[::4])
+def test_detect_clearsky_ghi_warn_interval_length(ghi_clearsky):
+    with pytest.warns(RuntimeWarning):
+        flags = validator.detect_clearsky_ghi(ghi_clearsky[::4],
+                                              ghi_clearsky[::4])
+    assert (flags == 0).all()
+
+
+def test_detect_clearsky_ghi_warn_regular_interval(ghi_clearsky):
+    with pytest.warns(RuntimeWarning):
+        ser = ghi_clearsky[:-2].append(ghi_clearsky[-1:])
+        flags = validator.detect_clearsky_ghi(ser, ser)
+    assert (flags == 0).all()
+
+
+def test_detect_clearsky_ghi_one_val(ghi_clearsky):
+    ser = ghi_clearsky[:1]
+    assert len(ser) == 1
+    flags = validator.detect_clearsky_ghi(ser, ser)
+    assert (flags == 0).all()

--- a/solarforecastarbiter/validation/tests/test_validator.py
+++ b/solarforecastarbiter/validation/tests/test_validator.py
@@ -378,5 +378,6 @@ def test_detect_clearsky_ghi_warn_regular_interval(ghi_clearsky):
 def test_detect_clearsky_ghi_one_val(ghi_clearsky):
     ser = ghi_clearsky[:1]
     assert len(ser) == 1
-    flags = validator.detect_clearsky_ghi(ser, ser)
+    with pytest.warns(RuntimeWarning):
+        flags = validator.detect_clearsky_ghi(ser, ser)
     assert (flags == 0).all()

--- a/solarforecastarbiter/validation/validator.py
+++ b/solarforecastarbiter/validation/validator.py
@@ -665,7 +665,7 @@ def detect_clipping(ac_power, window=4, fraction_in_window=0.75, rtol=5e-3,
     return flags
 
 
-@mask_flags('CLOUDY', invert=True)
+@mask_flags('CLOUD FREE', invert=False)
 def detect_clearsky_ghi(ghi, ghi_clearsky):
     """ Identifies times when GHI is consistent with clear sky conditions.
 
@@ -684,10 +684,6 @@ def detect_clearsky_ghi(ghi, ghi_clearsky):
     -------
     flags : Series
         True when clear sky conditions are indicated.
-
-    Raises
-    ------
-    ValueError if time intervals are greater than 15m
 
     Notes
     -----

--- a/solarforecastarbiter/validation/validator.py
+++ b/solarforecastarbiter/validation/validator.py
@@ -695,6 +695,11 @@ def detect_clearsky_ghi(ghi, ghi_clearsky):
     criteria are roughly scaled to the window length. Here, the threshold
     values are based on [1] with the scaling indicated in [2].
 
+    Warns
+    -----
+    RuntimeWarning
+        If `pvlib.clearsky.detect_clearsky` cannot be applied to the input.
+
     References
     ----------
     [1] Reno, M.J. and C.W. Hansen, "Identification of periods of clear
@@ -706,6 +711,10 @@ def detect_clearsky_ghi(ghi, ghi_clearsky):
     vol. 9, no. 4, pp. 998-1005, July 2019. doi: 10.1109/JPHOTOV.2019.2914444
     """
     if len(ghi) < 2:
+        warnings.warn(
+            'At least two datapoints are required for detect_clearsky_ghi',
+            RuntimeWarning
+        )
         return pd.Series(0, index=ghi.index)
     # determine window length in minutes, 10 x interval for intervals <= 15m
     delta = ghi.index.to_series(keep_tz=True).diff()

--- a/solarforecastarbiter/validation/validator.py
+++ b/solarforecastarbiter/validation/validator.py
@@ -665,7 +665,7 @@ def detect_clipping(ac_power, window=4, fraction_in_window=0.75, rtol=5e-3,
     return flags
 
 
-@mask_flags('CLOUD FREE', invert=False)
+@mask_flags('CLEARSKY', invert=False)
 def detect_clearsky_ghi(ghi, ghi_clearsky):
     """ Identifies times when GHI is consistent with clear sky conditions.
 

--- a/solarforecastarbiter/validation/validator.py
+++ b/solarforecastarbiter/validation/validator.py
@@ -4,6 +4,8 @@ Created on Fri Feb 15 14:08:20 2019
 
 @author: cwhanse
 """
+import warnings
+
 
 import numpy as np
 import pandas as pd
@@ -663,6 +665,7 @@ def detect_clipping(ac_power, window=4, fraction_in_window=0.75, rtol=5e-3,
     return flags
 
 
+@mask_flags('CLOUDY', invert=True)
 def detect_clearsky_ghi(ghi, ghi_clearsky):
     """ Identifies times when GHI is consistent with clear sky conditions.
 
@@ -706,10 +709,13 @@ def detect_clearsky_ghi(ghi, ghi_clearsky):
     Clear-Sky Periods From Irradiance Data," in IEEE Journal of Photovoltaics,
     vol. 9, no. 4, pp. 998-1005, July 2019. doi: 10.1109/JPHOTOV.2019.2914444
     """
+    if len(ghi) < 2:
+        return pd.Series(0, index=ghi.index)
     # determine window length in minutes, 10 x interval for intervals <= 15m
     delta = ghi.index.to_series(keep_tz=True).diff()
     delta_minutes = delta[1] / np.timedelta64(1, '60s')
-    if delta_minutes <= 15:
+    deltas_same = (delta[1:] == delta[1]).all()
+    if delta_minutes <= 15 and deltas_same:
         window_length = np.minimum(10*delta_minutes, 60.0)
         scale_factor = window_length / 10
         flags = _detect_clearsky(ghi, ghi_clearsky, ghi.index, window_length,
@@ -718,5 +724,8 @@ def detect_clearsky_ghi(ghi, ghi_clearsky):
                                  slope_dev=8*scale_factor)
         return flags
     else:
-        raise ValueError('detect_clearsky requires regular time intervals of'
-                         ' 15m or less')
+        warnings.warn(
+            'detect_clearsky requires regular time intervals of 15m or less',
+            RuntimeWarning
+        )
+        return pd.Series(0, index=ghi.index)


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #210 closes #293 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
