### PR TITLE
Fix label cutoff for total metric plots.

### DIFF
--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -11,7 +11,7 @@ API Changes
 * Added :py:mod:`solarforecastarbiter.reports.figures` which contains modules
   for creating Bokeh and Plotly report figures.
 * Added :py:mod:`solarforecastarbiter.reports.figures.plotly_figures` to create
-  report figures using plotly (:pull:`359`)
+  report figures using plotly (:pull:`359`)(:pull:`388`)
 * :py:func:`solarforecastarbiter.reports.figures.bokeh_figures.output_svg`
   now takes a :py:class:`selenium.webdriver.remote.webdriver.WebDriver` as an
   optional argument (:pull:`345`)

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -537,10 +537,15 @@ def bar(df, metric):
     fig = go.Figure()
     fig.add_trace(go.Bar(x=x_values, y=data['value'],
                          marker=go.bar.Marker(color=palette)))
+    # remove height limit when long abbreviations are used or there are more
+    # than 5 pairs to problems with labels being cutt off.
+    plot_layout_args = PLOT_LAYOUT_DEFAULTS.copy()
+    if x_values.map(len).max() > 15 or x_values.size > 6:
+        plot_layout_args.pop('height')
     fig.update_layout(
         title=f'<b>{metric_name}</b>',
         xaxis_title=metric_name,
-        **PLOT_LAYOUT_DEFAULTS)
+        **plot_layout_args)
     configure_axes(fig, None, y_range)
     return fig
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [ ] Closes #xxxx .
  - [ ] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

This PR removes the static height setting for metric plots with the "total" category  when abbreviated names are greater than 15 characters, or there are more than 6 pairs. 
This avoids an issue with cuttoff x axis labels as seen in the screenshot below:
<img width="792" alt="cuttoff_xlabel" src="https://user-images.githubusercontent.com/21206164/78950066-74139900-7a82-11ea-9faf-cb14f5d176fe.png">

The PR solves the issue but has one unavoidable quirk  when few pairs exist with really long names: plotly makes room on the right of the plot to allow room for angled labels as shown below.
![Screenshot from 2020-04-09 15-07-15](https://user-images.githubusercontent.com/21206164/78950184-c81e7d80-7a82-11ea-856c-4668adcfc63c.png)




