### PR TITLE
add classes to report tables

### DIFF
--- a/solarforecastarbiter/reports/templates/macros.j2
+++ b/solarforecastarbiter/reports/templates/macros.j2
@@ -1,5 +1,5 @@
 {% macro metric_table_fx_vert(report_metrics, category, metric_ordering) %}
-<table class="table table-striped" style="width:100%;">
+<table class="table table-striped metric-table-fx-vert" style="width:100%;">
   <caption style="caption-side:top; text-align:center">
     Table of {{ category }} metrics
   </caption>
@@ -87,7 +87,7 @@
 
 
 {% macro validation_table(proc_fxobs_list, quality_filters) %}
-<table class="table table-striped" style="width:100%;">
+<table class="table table-striped validation-table" style="width:100%;">
   <caption style="caption-side:top; text-align:center">
     Table of data validation results
   </caption>
@@ -128,7 +128,7 @@
     {% endif %}
   {% endfor %}
 {% endfor %}
-<table class="table table-striped" style="width:100%;">
+<table class="table table-striped preprocessing-table" style="width:100%;">
   <caption style="caption-side:top; text-align:center">
     Table of data preprocessing results
   </caption>

--- a/solarforecastarbiter/reports/templates/metrics_meta_table.html
+++ b/solarforecastarbiter/reports/templates/metrics_meta_table.html
@@ -14,7 +14,7 @@ indicates that no deadband was applied for that observation/forecast pair.
 The deadband is accounted for in the following metrics:
 MAE, MBE, RMSE, MAPE, NMAE, NMBE, NRMSE. It is ignored for all other metrics.
 </p>
-<table class="table table-striped table-borderless" style="width:100%; ">
+<table class="table table-striped table-borderless metrics-meta-table" style="width:100%; ">
     <caption style="caption-side: top; text-align: center;">
     Table of metrics metadata
     </caption>

--- a/solarforecastarbiter/reports/templates/obsfx_table.html
+++ b/solarforecastarbiter/reports/templates/obsfx_table.html
@@ -8,7 +8,7 @@ observation data to the forecast data. The aligned and resampled
 parameters are also shown below, including a unique name for the
 aligned and resampled observation/forecast pair that appears in
 the metrics plots, tables, and CSV download.</p>
-<table class="table table-striped table-borderless" style="width:100%; ">
+<table class="table table-striped table-borderless obsfx-table" style="width:100%; ">
   <caption style="caption-side: top; text-align: center;">
     Table of data alignment parameters
   </caption>

--- a/solarforecastarbiter/reports/tests/test_macros.py
+++ b/solarforecastarbiter/reports/tests/test_macros.py
@@ -20,7 +20,7 @@ def macro_test_template():
     return fn
 
 
-metric_table_fx_vert_format = """<table class="table table-striped" style="width:100%;">
+metric_table_fx_vert_format = """<table class="table table-striped metric-table-fx-vert" style="width:100%;">
   <caption style="caption-side:top; text-align:center">
     Table of {} metrics
   </caption>
@@ -102,7 +102,7 @@ def test_metric_table_fx_horz(report_with_raw, macro_test_template):
             category, len(metrics), expected_metric[0].name)
 
 
-validation_table_format = """<table class="table table-striped" style="width:100%;">
+validation_table_format = """<table class="table table-striped validation-table" style="width:100%;">
   <caption style="caption-side:top; text-align:center">
     Table of data validation results
   </caption>
@@ -153,7 +153,7 @@ def test_validation_table(report_with_raw, macro_test_template):
         *qfilters)
 
 
-preprocessing_table_format = """<table class="table table-striped" style="width:100%;">
+preprocessing_table_format = """<table class="table table-striped preprocessing-table" style="width:100%;">
   <caption style="caption-side:top; text-align:center">
     Table of data preprocessing results
   </caption>


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [ ] Closes #xxxx .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Adds css classes to the <table> elements in reports for easier selection with css rules, to address an issue with table crowding found in #361 