### PR TITLE
Add event timeseries support to plotting module

### DIFF
--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -58,7 +58,8 @@ API Changes
   :py:func:`solarforecastarbiter.metrics.calculator.calculate_metrics` modification,
   :py:func:`solarforecastarbiter.metrics.calculator.calculate_event_metrics` addition and
   :py:func:`solarforecastarbiter.metrics.preprocessing.resample_and_align` modifications. (:issue:`357`) (:issue:`380`) (:pull:`361`)
-
+* Added support for plotting timeseries of event observations and forecasts to
+  :py:func:`solararbiter.plotting.timeseries.make_basic_timeseries`. (:pull:`394`)
 
 Enhancements
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/plotting/tests/test_plotting_utils.py
+++ b/solarforecastarbiter/plotting/tests/test_plotting_utils.py
@@ -53,6 +53,7 @@ def test_align_index_limit():
     ('instant', 'line'),
     ('beginning', 'step'),
     ('ending', 'step'),
+    ('event', 'step'),
     pytest.param('other', '', marks=pytest.mark.xfail(raises=ValueError))
 ])
 def test_line_or_step(label, method):

--- a/solarforecastarbiter/plotting/tests/test_timeseries.py
+++ b/solarforecastarbiter/plotting/tests/test_timeseries.py
@@ -91,6 +91,21 @@ def test_make_basic_timeseries(label, df):
     assert 'OBJECT'in fig.title.text
 
 
+def test_make_basic_event_timeseries():
+    df = pd.DataFrame(
+        index=pd.date_range(start='now', freq='1min',
+                            periods=2, tz='UTC', name='timestamp'))
+    source = bokeh.models.ColumnDataSource(df)
+    fig = timeseries.make_basic_timeseries(source, 'OBJECT', 'event',
+                                           'event', 800)
+
+    assert fig.yaxis.ticker.ticks == [0, 1]
+    assert list(fig.yaxis.major_label_overrides.values()) == ['True', 'False']
+    assert 'Time' in fig.xaxis[0].axis_label
+    assert 'Event' in fig.yaxis[0].axis_label
+    assert 'OBJECT'in fig.title.text
+
+
 def test_generate_forecast_figure(ac_power_forecast_metadata,
                                   forecast_values):
     # not great, just testing that script and div are returned

--- a/solarforecastarbiter/plotting/timeseries.py
+++ b/solarforecastarbiter/plotting/timeseries.py
@@ -209,6 +209,9 @@ def make_basic_timeseries(source, object_name, variable, interval_label,
                               **plot_kwargs)
     fig.yaxis.axis_label = plot_utils.format_variable_name(variable)
     fig.xaxis.axis_label = 'Time (UTC)'
+    if variable == 'event':
+        fig.yaxis.ticker = [0, 1]
+        fig.yaxis.major_label_overrides = {1: 'True', 0: 'False'}
     add_hover_tool(fig, source, **hover_kwargs)
     return fig
 

--- a/solarforecastarbiter/plotting/utils.py
+++ b/solarforecastarbiter/plotting/utils.py
@@ -65,9 +65,15 @@ def line_or_step(interval_label):
         hover_kwargs = dict(line_policy='next',
                             attachment='right',
                             add_line=True)
+    elif interval_label == 'event':
+        plot_method = 'step'
+        plot_kwargs = dict(mode='before')
+        hover_kwargs = dict(line_policy='next',
+                            attachment='right',
+                            add_line=True)
     else:
         raise ValueError(
             'interval_label must be one of "instant", "beginning", '
-            'or "ending"')
+            '"event", or "ending"')
 
     return plot_method, plot_kwargs, hover_kwargs


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #393  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Adds ability to plot event timeseries to the plotting module. Will need to be rebased on master when #361 is merged. A screenshot of the event timeseries is as below. 
![Screenshot from 2020-04-16 15-53-25](https://user-images.githubusercontent.com/21206164/79514445-07a51680-7ffb-11ea-8990-ee2101672dbf.png)
