### PR TITLE
enforce metrics order

### DIFF
--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -97,6 +97,7 @@ Bug fixes
 * Fix type errors in observation validation by ensuring all time series values from
   :py:mod:`solarforecastaribter.io.api` functions are coerced to float
   and converting to float before validation (:issue:`252`) (:pull:`384`)
+* Enforce metric order consistency. (:issue:`352`)
 
 
 Contributors

--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -97,7 +97,7 @@ Bug fixes
 * Fix type errors in observation validation by ensuring all time series values from
   :py:mod:`solarforecastaribter.io.api` functions are coerced to float
   and converting to float before validation (:issue:`252`) (:pull:`384`)
-* Enforce metric order consistency. (:issue:`352`)
+* Enforce metric order consistency. (:issue:`352`) (:pull:`396`)
 
 
 Contributors

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -249,9 +249,39 @@ def calculate_deterministic_metrics(processed_fx_obs, categories, metrics,
                 metric_vals.append(datamodel.MetricValue(
                     category, metric_, str(cat), res))
 
-    out['values'] = tuple(metric_vals)
+    out['values'] = _sort_metrics_vals(
+        metric_vals, datamodel.ALLOWED_DETERMINISTIC_METRICS)
     calc_metrics = datamodel.MetricResult.from_dict(out)
     return calc_metrics
+
+
+def _sort_metrics_vals(metrics_vals, mapping):
+    """
+    Parameters
+    ----------
+    metrics_vals : list
+        Elements are datamodel.MetricValue
+    mapping : dict
+        Metrics mapping defined in datamodel.
+
+    Returns
+    -------
+    tuple
+        Sorted elements.
+    """
+    metric_ordering = list(mapping.keys())
+    category_ordering = list(datamodel.ALLOWED_CATEGORIES.keys())
+
+    def sorter(metricval):
+        return (
+            category_ordering.index(metricval.category),
+            metric_ordering.index(metricval.metric),
+            metricval.index,
+            metricval.value
+            )
+
+    metrics_sorted = tuple(sorted(metrics_vals, key=sorter))
+    return metrics_sorted
 
 
 def calculate_probabilistic_metrics(processed_fx_obs, categories, metrics,

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -381,7 +381,8 @@ def calculate_probabilistic_metrics(processed_fx_obs, categories, metrics,
             results = _calculate_probabilistic_metrics_from_df(
                 _create_prob_dataframe(obs, [orig], [ref]),
                 categories, single_metrics, cv.interval_label)
-            single_out['values'] = tuple(results)
+            single_out['values'] = _sort_metrics_vals(
+                results, datamodel.ALLOWED_PROBABILISTIC_METRICS)
             single_cv_results.append(datamodel.MetricResult.from_dict(
                 single_out))
 
@@ -389,11 +390,13 @@ def calculate_probabilistic_metrics(processed_fx_obs, categories, metrics,
     if dist_metrics:
         dist_out = copy.deepcopy(shared_dict)
         dist_out['forecast_id'] = processed_fx_obs.original.forecast.forecast_id  # NOQA
-        dist_out['values'] = _calculate_probabilistic_metrics_from_df(
+        results = _calculate_probabilistic_metrics_from_df(
             _create_prob_dataframe(obs, fx_fx_prob, ref_fx_fx_prob),
             categories,
             dist_metrics,
             processed_fx_obs.original.forecast.interval_label)
+        dist_out['values'] = _sort_metrics_vals(
+            results, datamodel.ALLOWED_PROBABILISTIC_METRICS)
         dist_result = datamodel.MetricResult.from_dict(dist_out)
 
     return (single_cv_results, dist_result)

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -267,7 +267,11 @@ def _sort_metrics_vals(metrics_vals, mapping):
     Returns
     -------
     tuple
-        Sorted elements.
+        Sorted elements. Sorting order is:
+            * Category
+            * Metric
+            * Index
+            * Value
     """
     metric_ordering = list(mapping.keys())
     category_ordering = list(datamodel.ALLOWED_CATEGORIES.keys())

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -257,10 +257,14 @@ def test_calculate_metrics_with_probablistic(single_observation,
         prob_forecasts, prob_forecasts.axis, constant_values=const_values)
     prfxobs = datamodel.ForecastObservation(
         conv_prob_fx, single_observation)
-    fx_values = pd.DataFrame(np.random.randn(10, 3)+10,
-                             index=create_dt_index(10))
-    obs_values = pd.Series(np.random.randn(10)+10,
-                           index=create_dt_index(10))
+    fx_values = pd.DataFrame(np.array((
+        np.linspace(0, 9., 10),
+        np.linspace(1, 10., 10),
+        np.linspace(2, 11., 10))).T,
+        index=create_dt_index(10))
+    obs_values = pd.Series(
+        np.linspace(1.5, 10.5, 10),
+        index=create_dt_index(10))
     proc_prfx_obs = create_processed_fxobs(prfxobs, fx_values,
                                            obs_values)
 
@@ -276,8 +280,7 @@ def test_calculate_metrics_with_probablistic(single_observation,
     assert isinstance(dist_results, datamodel.MetricResult)
 
     # With reference
-    ref_fx_values = pd.DataFrame(np.random.randn(10, 3)+10,
-                                 index=create_dt_index(10))
+    ref_fx_values = fx_values + .5
     conv_ref_prob_fx = copy_prob_forecast_with_axis(
         prob_forecasts, prob_forecasts.axis, constant_values=const_values)
     ref_prfxobs = datamodel.ForecastObservation(conv_ref_prob_fx,
@@ -285,9 +288,11 @@ def test_calculate_metrics_with_probablistic(single_observation,
     proc_ref_prfx_obs = create_processed_fxobs(ref_prfxobs,
                                                ref_fx_values,
                                                obs_values)
-    results = calculator.calculate_metrics([proc_prfx_obs], LIST_OF_CATEGORIES,
-                                           PROBABILISTIC_METRICS,
-                                           ref_pair=proc_ref_prfx_obs)
+    results = calculator.calculate_metrics(
+        [proc_prfx_obs], LIST_OF_CATEGORIES,
+        # reverse to ensure order output is independent
+        PROBABILISTIC_METRICS[::-1],
+        ref_pair=proc_ref_prfx_obs)
     assert isinstance(results, list)
     assert len(results) == 1
     assert isinstance(results[0], tuple)
@@ -295,6 +300,30 @@ def test_calculate_metrics_with_probablistic(single_observation,
     assert len(single_results) == len(const_values)
     assert all(isinstance(r, datamodel.MetricResult) for r in single_results)
     assert isinstance(dist_results, datamodel.MetricResult)
+    result = single_results[0]
+    expected = {
+        0: ('total', 'bs', '0', 0.00285),
+        1: ('total', 'bss', '0', 0.1428571428571429),
+        5: ('year', 'bs', '2019', 0.00285),
+        9: ('year', 'unc', '2019', 0.),
+        10: ('month', 'bs', 'Aug', 0.00285)
+    }
+    attr_order = ('category', 'metric', 'index', 'value')
+    for k, expected_attrs in expected.items():
+        for attr, expected_val in zip(attr_order, expected_attrs):
+            assert getattr(result.values[k], attr) == expected_val
+    result = dist_results
+    expected = {
+        0: ('total', 'crps', '0', 0.0067),
+        1: ('year', 'crps', '2019', 0.0067),
+        2: ('month', 'crps', 'Aug', 0.0067),
+        3: ('hour', 'crps', '0', 0.0001),
+        4: ('hour', 'crps', '1', 0.0005)
+    }
+    attr_order = ('category', 'metric', 'index', 'value')
+    for k, expected_attrs in expected.items():
+        for attr, expected_val in zip(attr_order, expected_attrs):
+            assert getattr(result.values[k], attr) == expected_val
 
 
 @pytest.mark.filterwarnings('ignore::RuntimeWarning')

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -221,6 +221,31 @@ def test_calculate_metrics_single_uncert(single_forecast_observation_uncert,
     assert result[0].values[0].value == expected
 
 
+def test_calculate_deterministic_metrics_sorting(single_forecast_observation,
+                                                 create_processed_fxobs,
+                                                 create_dt_index):
+    inp = create_processed_fxobs(
+        single_forecast_observation,
+        pd.Series([2, 1, 0], index=create_dt_index(3)),
+        pd.Series([1, 1, 1], index=create_dt_index(3)))
+    categories = ('hour', 'total', 'date')
+    metrics = ('rmse', 'ksi', 'mbe', 'mae')
+    proc_fx_obs
+    result = calculator.calculate_deterministic_metrics(
+        inp, categories, metrics)
+    expected = {
+        0: ('total', 'mae', '0', 2/3),
+        1: ('total', 'mbe', '0', 0.),
+        4: ('hour', 'mae', '0', 1.),
+        6: ('hour', 'mae', '2', 1.),
+        10: ('hour', 'rmse', '0', 1.)
+    }
+    attr_order = ('category', 'metric', 'index', 'value')
+    for k, expected_attrs in expected.items():
+        for attr, expected_val in zip(attr_order, expected_attrs):
+            assert getattr(result.values[k], attr) == expected_val
+
+
 @pytest.mark.filterwarnings('ignore::RuntimeWarning')
 def test_calculate_metrics_with_probablistic(single_observation,
                                              prob_forecasts,


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #352  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
