### PR TITLE
Reference forecast value serialization

### DIFF
--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1913,7 +1913,8 @@ def report_metrics(metric_index):
 
 
 @pytest.fixture()
-def raw_report(report_objects, report_metrics, preprocessing_result_types):
+def raw_report(report_objects, report_metrics, preprocessing_result_types,
+               ref_forecast_id):
     report, obs, fx0, fx1, agg, fxagg = report_objects
 
     def gen(with_series):
@@ -1935,7 +1936,10 @@ def raw_report(report_objects, report_metrics, preprocessing_result_types):
         qflags = list(qflags[0])
         fxobs0 = datamodel.ProcessedForecastObservation(
             fx0.name,
-            datamodel.ForecastObservation(fx0, obs),
+            datamodel.ForecastObservation(
+                fx0,
+                obs,
+                uncertainty=obs.uncertainty),
             fx0.interval_value_type,
             il0,
             fx0.interval_label,
@@ -1945,12 +1949,18 @@ def raw_report(report_objects, report_metrics, preprocessing_result_types):
             preprocessing_results=tuple(datamodel.PreprocessingResult(
                 name=t, count=0) for t in preprocessing_result_types),
             forecast_values=ser(il0) if with_series else fx0.forecast_id,
-            observation_values=ser(il0) if with_series else obs.observation_id
+            observation_values=ser(il0) if with_series else obs.observation_id,
+            uncertainty=1.
         )
         il1 = fx1.interval_length
         fxobs1 = datamodel.ProcessedForecastObservation(
             fx1.name,
-            datamodel.ForecastObservation(fx1, obs),
+            datamodel.ForecastObservation(
+                fx1,
+                obs,
+                normalization=1000.,
+                uncertainty=15.,
+                reference_forecast=fx0.replace(forecast_id=ref_forecast_id)),
             fx1.interval_value_type,
             il1,
             fx1.interval_label,
@@ -1961,11 +1971,18 @@ def raw_report(report_objects, report_metrics, preprocessing_result_types):
                 name=t, count=0) for t in preprocessing_result_types),
             forecast_values=ser(il1) if with_series else fx1.forecast_id,
             observation_values=ser(il1) if with_series else obs.observation_id,
+            reference_forecast_values=(
+                ser(il0) if with_series else ref_forecast_id),
+            normalization_factor=1000.,
+            uncertainty=15.,
         )
         ilagg = fxagg.interval_length
         fxagg_ = datamodel.ProcessedForecastObservation(
             fxagg.name,
-            datamodel.ForecastAggregate(fxagg, agg),
+            datamodel.ForecastAggregate(
+                fxagg,
+                agg,
+                uncertainty=5.),
             fxagg.interval_value_type,
             ilagg,
             fxagg.interval_label,
@@ -1975,7 +1992,8 @@ def raw_report(report_objects, report_metrics, preprocessing_result_types):
             preprocessing_results=tuple(datamodel.PreprocessingResult(
                 name=t, count=0) for t in preprocessing_result_types),
             forecast_values=ser(ilagg) if with_series else fxagg.forecast_id,
-            observation_values=ser(ilagg) if with_series else agg.aggregate_id
+            observation_values=ser(ilagg) if with_series else agg.aggregate_id,
+            uncertainty=5.
         )
         figs = datamodel.RawReportPlots(
             (

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -927,10 +927,23 @@ class APISession(requests.Session):
             obs_post = self.post(
                 f'/reports/{report_id}/values',
                 json=obs_data, headers={'Content-Type': 'application/json'})
+            if fxobs.original.reference_forecast is not None:
+                ref_fx_data = {
+                    'object_id': fxobs.original.reference_forecast.forecast_id,
+                    'processed_values': serialize_timeseries(
+                        fxobs.reference_forecast_values)}
+                ref_fx_post = self.post(
+                    f'/reports/{report_id}/values',
+                    json=ref_fx_data)
+                processed_ref_fx_id = ref_fx_post.text
+            else:
+                processed_ref_fx_id = None
             processed_fx_id = fx_post.text
             processed_obs_id = obs_post.text
-            new_fxobs = fxobs.replace(forecast_values=processed_fx_id,
-                                      observation_values=processed_obs_id)
+            new_fxobs = fxobs.replace(
+                forecast_values=processed_fx_id,
+                observation_values=processed_obs_id,
+                reference_forecast_values=processed_ref_fx_id)
             posted_fxobs.append(new_fxobs)
         return tuple(posted_fxobs)
 

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -934,7 +934,8 @@ class APISession(requests.Session):
                         fxobs.reference_forecast_values)}
                 ref_fx_post = self.post(
                     f'/reports/{report_id}/values',
-                    json=ref_fx_data)
+                    json=ref_fx_data,
+                    headers={'Content-Type': 'application/json'})
                 processed_ref_fx_id = ref_fx_post.text
             else:
                 processed_ref_fx_id = None

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -814,11 +814,14 @@ def test_apisession_create_report(requests_mock, report_objects, mocker):
 
 
 def test_apisession_post_raw_report_processed_data(
-        requests_mock, raw_report, report_objects):
+        requests_mock, raw_report, report_objects, ref_forecast_id):
     _, obs, fx0, fx1, agg, fxagg = report_objects
     session = api.APISession('')
-    ids = [fx0.forecast_id, obs.observation_id, fx1.forecast_id,
-           obs.observation_id, fxagg.forecast_id, agg.aggregate_id]
+    ids = [
+        fx0.forecast_id, obs.observation_id, fx1.forecast_id,
+        obs.observation_id, ref_forecast_id, fxagg.forecast_id,
+        agg.aggregate_id,
+    ]
     mocked = requests_mock.register_uri(
         'POST', re.compile(f'{session.base_url}/reports/.*/values'),
         [{'text': id_} for id_ in ids])

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -835,7 +835,7 @@ def test_apisession_post_raw_report_processed_data(
 
 
 def test_apisession_get_raw_report_processed_data(
-        requests_mock, raw_report, report_objects):
+        requests_mock, raw_report, report_objects, ref_forecast_id):
     _, obs, fx0, fx1, agg, fxagg = report_objects
     session = api.APISession('')
     ser = pd.Series(name='value', index=pd.DatetimeIndex(
@@ -845,12 +845,14 @@ def test_apisession_get_raw_report_processed_data(
         'GET', re.compile(f'{session.base_url}/reports/.*/values'),
         json=[{'id': id_, 'processed_values': val} for id_ in
               (fx0.forecast_id, fx1.forecast_id, obs.observation_id,
-               agg.aggregate_id, fxagg.forecast_id)])
+               ref_forecast_id, agg.aggregate_id, fxagg.forecast_id)])
     inp = raw_report(False)
     out = session.get_raw_report_processed_data('', inp)
     for fxo in out:
         pdt.assert_series_equal(fxo.forecast_values, ser)
         pdt.assert_series_equal(fxo.observation_values, ser)
+        if fxo.reference_forecast_values is not None:
+            pdt.assert_series_equal(fxo.reference_forecast_values, ser)
 
 
 def test_apisession_post_raw_report(requests_mock, raw_report, mocker,

--- a/solarforecastarbiter/io/utils.py
+++ b/solarforecastarbiter/io/utils.py
@@ -444,7 +444,11 @@ def load_report_values(raw_report, values):
         obs_vals = val_dict.get(fxobs.observation_values, None)
         if obs_vals is not None:
             obs_vals = deserialize_timeseries(obs_vals)
+        ref_fx_vals = val_dict.get(fxobs.reference_forecast_values)
+        if ref_fx_vals is not None:
+            ref_fx_vals = deserialize_timeseries(ref_fx_vals)
         new_fxobs = fxobs.replace(forecast_values=fx_vals,
-                                  observation_values=obs_vals)
+                                  observation_values=obs_vals,
+                                  reference_forecast_values=ref_fx_vals)
         out.append(new_fxobs)
     return tuple(out)


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #409  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Serializes and Deserializes `reference_forecast_values` field of ProcessedForecastObservations. This was causing a TypeError when workers tried to post a raw report to the API.