### PR TITLE
fix reference forecast alignment

### DIFF
--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -243,9 +243,9 @@ def resample_and_align(fx_obs, fx_series, obs_series, ref_series, tz):
     # alignment using ['forecast', 'observation'] or
     # ['forecast', 'observation', 'reference'] selections
     if ref_series is not None:
-        obs_aligned, ref_fx_aligned = obs_resampled.align(
+        obs_aligned, ref_fx_aligned = obs_aligned.align(
             ref_series.dropna(how="any"), 'inner')
-        fx_aligned = fx_aligned.loc[obs_aligned.index]
+        fx_aligned = fx_aligned.reindex(obs_aligned.index)
         ref_values = ref_fx_aligned.tz_convert(tz)
     else:
         ref_values = None

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -237,6 +237,50 @@ def test_resample_and_align_timezone(site_metadata, interval_label, tz,
                                   check_categorical=False)
 
 
+def test_resample_and_align_with_ref(
+        single_forecast_observation_reffx):
+    tz = 'UTC'
+    fx_obs = single_forecast_observation_reffx
+    fx_series = THREE_HOUR_SERIES
+    ref_series = THIRTEEN_10MIN_SERIES
+    obs_series = THREE_HOUR_SERIES
+    fx_values, obs_values, ref_values, _ = preprocessing.resample_and_align(
+        fx_obs, fx_series, obs_series, ref_series, tz)
+    pd.testing.assert_index_equal(fx_values.index,
+                                  obs_values.index,
+                                  check_categorical=False)
+    pd.testing.assert_index_equal(fx_values.index,
+                                  ref_values.index,
+                                  check_categorical=False)
+    pd.testing.assert_index_equal(obs_values.index,
+                                  THREE_HOURS,
+                                  check_categorical=False)
+
+
+def test_resample_and_align_ref_less_fx(
+        single_forecast_observation_reffx):
+    tz = 'UTC'
+    fx_obs = single_forecast_observation_reffx
+    nine_hour_series = pd.concat([
+        THREE_HOUR_SERIES.shift(periods=3, freq='1h'),
+        THREE_HOUR_SERIES,
+        THREE_HOUR_SERIES.shift(periods=3, freq='-1h')])
+    fx_series = THREE_HOUR_SERIES
+    ref_series = nine_hour_series
+    obs_series = nine_hour_series
+    fx_values, obs_values, ref_values, _ = preprocessing.resample_and_align(
+        fx_obs, fx_series, obs_series, ref_series, tz)
+    pd.testing.assert_index_equal(fx_values.index,
+                                  obs_values.index,
+                                  check_categorical=False)
+    pd.testing.assert_index_equal(fx_values.index,
+                                  ref_values.index,
+                                  check_categorical=False)
+    pd.testing.assert_index_equal(obs_values.index,
+                                  THREE_HOURS,
+                                  check_categorical=False)
+
+
 def test_resample_and_align_ref_error_None(
         single_forecast_observation, single_forecast_observation_reffx):
     tz = 'UTC'

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -242,7 +242,7 @@ def test_resample_and_align_with_ref(
     tz = 'UTC'
     fx_obs = single_forecast_observation_reffx
     fx_series = THREE_HOUR_SERIES
-    ref_series = THIRTEEN_10MIN_SERIES
+    ref_series = THREE_HOUR_SERIES
     obs_series = THREE_HOUR_SERIES
     fx_values, obs_values, ref_values, _ = preprocessing.resample_and_align(
         fx_obs, fx_series, obs_series, ref_series, tz)


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #411  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
