### PR TITLE
clarify data validation section

### DIFF
--- a/docs/source/whatsnew/1.0.0b5.rst
+++ b/docs/source/whatsnew/1.0.0b5.rst
@@ -131,6 +131,8 @@ Bug fixes
 * Eliminate most warnings from test suite. (:issue:`385`) (:pull:`395`)
 * :py:func:`solarforecastarbiter.metrics.deterministic.forecast_skill` now
   returns 0 if both forecast and reference forecast errors are 0. (:pull:`395`)
+* Clarify report data validation section text and table. (:issue:`413`)
+  (:pull:`422`)
 
 
 Contributors

--- a/solarforecastarbiter/reports/templates/body.html
+++ b/solarforecastarbiter/reports/templates/body.html
@@ -90,9 +90,10 @@ Plotly.newPlot("scatter-div", scat_plot);
 
 {% block datavalidation %}
 <h3 id="data-validation">Data Validation</h3>
-<p>The Solar Forecast Arbiter’s data validation toolkit using the selected
-filters identified the following issues with the unprocessed observation
-data:</p>
+<p>The Solar Forecast Arbiter applied its data validation toolkit to the
+observation data. The table below shows the selected filters and the number
+of observations that were removed from each forecast/observation pair.
+</p>
 {% for filter in report.report_parameters.filters %}
   {% if filter.__class__.__name__ == 'QualityFlagFilter' %}
     {% set valtable = True %}
@@ -106,7 +107,8 @@ data:</p>
 <p>These intervals were removed from the raw time series before
 resampling and realignment. For more details on the data validation
 results for each observation, please see the observation page linked
-to in the table above. Data providers may elect to reupload data to
+to in the table above.</p>
+<p>Data providers may elect to reupload data to
 fix issues identified by the validation toolkit. The metrics computed
 in this report will remain unchanged, however, a user may generate a
 new report after the data provider submits new data. The online

--- a/solarforecastarbiter/reports/templates/macros.j2
+++ b/solarforecastarbiter/reports/templates/macros.j2
@@ -93,7 +93,7 @@
   </caption>
   <thead>
     <tr class="header">
-      <th style="text-align: left;"></th>
+      <th style="text-align: left;">Aligned Pair</th>
       {% for proc_fxobs in proc_fxobs_list %}
       <th style="text-align: center;">
         {{ proc_fxobs.name }}
@@ -101,14 +101,13 @@
       {% endfor %}
     </tr>
     <tr class="header">
-      <th style="text-align: left;"></th>
+      <th style="text-align: left;">Observation</th>
       {% for proc_fxobs in proc_fxobs_list %}
       <th style="text-align: center;">
         {{ proc_fxobs.original.data_object.name }}
       </th>
       {% endfor %}
     </tr>
-
   </thead>
   <tbody>
     {% for qfilter in quality_filters %}

--- a/solarforecastarbiter/reports/templates/macros.j2
+++ b/solarforecastarbiter/reports/templates/macros.j2
@@ -93,7 +93,7 @@
   </caption>
   <thead>
     <tr class="header">
-      <th style="text-align: left;">Aligned Pair</th>
+      <th style="text-align: left;"></th>
       {% for proc_fxobs in proc_fxobs_list %}
       <th style="text-align: center;">
         {{ proc_fxobs.name }}
@@ -101,16 +101,14 @@
       {% endfor %}
     </tr>
     <tr class="header">
-      <th style="text-align: left;">Observation</th>
+      <th style="text-align: left;"></th>
       {% for proc_fxobs in proc_fxobs_list %}
       <th style="text-align: center;">
         {{ proc_fxobs.original.data_object.name }}
       </th>
       {% endfor %}
     </tr>
-    <tr class="header">
-      <th style="text-align: left;">Filter</th>
-    </tr>
+
   </thead>
   <tbody>
     {% for qfilter in quality_filters %}

--- a/solarforecastarbiter/reports/templates/macros.j2
+++ b/solarforecastarbiter/reports/templates/macros.j2
@@ -108,6 +108,9 @@
       </th>
       {% endfor %}
     </tr>
+    <tr class="header">
+      <th style="text-align: left;">Filter</th>
+    </tr>
   </thead>
   <tbody>
     {% for qfilter in quality_filters %}

--- a/solarforecastarbiter/reports/templates/macros.j2
+++ b/solarforecastarbiter/reports/templates/macros.j2
@@ -93,10 +93,18 @@
   </caption>
   <thead>
     <tr class="header">
-      <th style="text-align: left;">Validation Flag</th>
+      <th style="text-align: left;">Aligned Pair</th>
       {% for proc_fxobs in proc_fxobs_list %}
       <th style="text-align: center;">
-        {{ proc_fxobs.name }} <br>Number of Points
+        {{ proc_fxobs.name }}
+      </th>
+      {% endfor %}
+    </tr>
+    <tr class="header">
+      <th style="text-align: left;">Observation</th>
+      {% for proc_fxobs in proc_fxobs_list %}
+      <th style="text-align: center;">
+        {{ proc_fxobs.original.data_object.name }}
       </th>
       {% endfor %}
     </tr>

--- a/solarforecastarbiter/reports/tests/test_macros.py
+++ b/solarforecastarbiter/reports/tests/test_macros.py
@@ -112,12 +112,21 @@ validation_table_format = """<table class="table table-striped validation-table"
   </caption>
   <thead>
     <tr class="header">
-      <th style="text-align: left;">Validation Flag</th>
+      <th style="text-align: left;">Aligned Pair</th>
       <th style="text-align: center;">
-        {} <br>Number of Points
+        {}
       </th>
       <th style="text-align: center;">
-        {} <br>Number of Points
+        {}
+      </th>
+    </tr>
+    <tr class="header">
+      <th style="text-align: left;">Observation</th>
+      <th style="text-align: center;">
+        {}
+      </th>
+      <th style="text-align: center;">
+        {}
       </th>
     </tr>
   </thead>
@@ -154,6 +163,8 @@ def test_validation_table(report_with_raw, macro_test_template):
     assert rendered_validation_table == validation_table_format.format(
         proc_fxobs_list[0].name,
         proc_fxobs_list[1].name,
+        proc_fxobs_list[0].original.observation.name,
+        proc_fxobs_list[1].original.observation.name,
         *qfilters)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [ ] Closes #413 .
  - [ ] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

I think the text is better but still not great. Trying to emphasize it's the observations that are analyzed.

Existing table:

<img width="848" alt="Screen Shot 2020-04-25 at 10 19 11 AM" src="https://user-images.githubusercontent.com/4383303/80286085-3ba8c780-86de-11ea-89f4-90b02cfd47e1.png">


Option A:

<img width="850" alt="Screen Shot 2020-04-25 at 10 14 30 AM" src="https://user-images.githubusercontent.com/4383303/80286089-42cfd580-86de-11ea-8571-41e3934edf0d.png">


Option B:

<img width="862" alt="Screen Shot 2020-04-25 at 10 13 22 AM" src="https://user-images.githubusercontent.com/4383303/80286093-482d2000-86de-11ea-81ca-882dcd321086.png">


Option C:

<img width="859" alt="Screen Shot 2020-04-25 at 10 21 40 AM" src="https://user-images.githubusercontent.com/4383303/80286149-9510f680-86de-11ea-82b5-c0816c72031a.png">

Option D: (not shown because it would take more effort to change) 
* Columns: Aligned Pair, Observation, Filter 1, Filter 2, Filter 3...
