### PR TITLE
fix months and weekdays ordering

### DIFF
--- a/docs/source/whatsnew/1.0.0rc1.rst
+++ b/docs/source/whatsnew/1.0.0rc1.rst
@@ -20,6 +20,9 @@ Enhancements
 
 Bug fixes
 ~~~~~~~~~
+* Fix incorrect ordering of months and weekdays in metrics plots.
+  (:issue:`428`) (:pull:`430`)
+
 
 Contributors
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/metrics/calculator.py
+++ b/solarforecastarbiter/metrics/calculator.py
@@ -253,10 +253,17 @@ def _sort_metrics_vals(metrics_vals, mapping):
     category_ordering = list(datamodel.ALLOWED_CATEGORIES.keys())
 
     def sorter(metricval):
+        if metricval.category == 'month':
+            index_order = calendar.month_abbr[0:13].index(metricval.index)
+        elif metricval.category == 'weekday':
+            index_order = calendar.day_abbr[0:7].index(metricval.index)
+        else:
+            index_order = metricval.index
+
         return (
             category_ordering.index(metricval.category),
             metric_ordering.index(metricval.metric),
-            metricval.index,
+            index_order,
             metricval.value
             )
 

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -197,20 +197,28 @@ def test_calculate_metrics_single_uncert(single_forecast_observation_uncert,
 def test_calculate_deterministic_metrics_sorting(single_forecast_observation,
                                                  create_processed_fxobs,
                                                  create_dt_index):
+    index = pd.DatetimeIndex(
+        # sunday, monday, tuesday
+        ['20200531 1900Z', '20200601 2000Z', '20200602 2100Z'])
     inp = create_processed_fxobs(
         single_forecast_observation,
-        pd.Series([2, 1, 0], index=create_dt_index(3)),
-        pd.Series([1, 1, 1], index=create_dt_index(3)))
-    categories = ('hour', 'total', 'date')
+        pd.Series([2, 1, 0], index=index),
+        pd.Series([1, 1, 1], index=index))
+    categories = ('hour', 'total', 'date', 'month', 'weekday')
     metrics = ('rmse', 'ksi', 'mbe', 'mae')
     result = calculator.calculate_deterministic_metrics(
         inp, categories, metrics)
     expected = {
         0: ('total', 'mae', '0', 2/3),
         1: ('total', 'mbe', '0', 0.),
-        4: ('hour', 'mae', '0', 1.),
-        6: ('hour', 'mae', '2', 1.),
-        10: ('hour', 'rmse', '0', 1.)
+        4: ('month', 'mae', 'May', 1.),
+        5: ('month', 'mae', 'Jun', 0.5),
+        12: ('hour', 'mae', '19', 1.),
+        14: ('hour', 'mae', '21', 1.),
+        18: ('hour', 'rmse', '19', 1.),
+        39: ('weekday', 'mbe', 'Mon', 0.),
+        40: ('weekday', 'mbe', 'Tue', -1.),
+        41: ('weekday', 'mbe', 'Sun', 1.),
     }
     attr_order = ('category', 'metric', 'index', 'value')
     for k, expected_attrs in expected.items():


### PR DESCRIPTION


  - [x] Closes #428  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

