### PR TITLE
Add reference probabilistic forecast

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -231,7 +231,15 @@ Persistence
    reference_forecasts.persistence.persistence_scalar
    reference_forecasts.persistence.persistence_interval
    reference_forecasts.persistence.persistence_scalar_index
+
+Probabilistic persistence
+-------------------------
+
+.. autosummary::
+   :toctree: generated/
+
    reference_forecasts.persistence.persistence_probabilistic
+   reference_forecasts.persistence.persistence_probabilistic_timeofday
 
 
 Fetching external data

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -231,6 +231,7 @@ Persistence
    reference_forecasts.persistence.persistence_scalar
    reference_forecasts.persistence.persistence_interval
    reference_forecasts.persistence.persistence_scalar_index
+   reference_forecasts.persistence.persistence_probabilistic
 
 
 Fetching external data

--- a/docs/source/whatsnew/1.0.0rc1.rst
+++ b/docs/source/whatsnew/1.0.0rc1.rst
@@ -28,6 +28,9 @@ API Changes
   and `validation.tasks.daily_observation_validation` in favor of
   :py:func:`solarforecastarbiter.validation.tasks.fetch_and_validate_observation`
   and :py:func:`solarforecastarbiter.validation.tasks.fetch_and_validate_all_observations` (:pull:`484`)
+* Added support for probabilistic persistence forecasts with
+  :py:func:`solarforecastarbiter.reference_forecasts.persistence.persistence_probabilistic` (:issue:`195`) (:pull:`434`)
+
 
 Enhancements
 ~~~~~~~~~~~~
@@ -42,6 +45,9 @@ Enhancements
   :py:func:`solarforecastarbiter.api.APISession.get_observation_values_not_flagged`
   in order to only validate periods that have not yet had daily validation applied
   (:issue:`377`) (:pull:`484`)
+* Reference probabilistic forecasts provided using the Persistence Ensemble
+  (PeEn) method. (:issue:`195`) (:pull:`434`)
+
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0rc1.rst
+++ b/docs/source/whatsnew/1.0.0rc1.rst
@@ -29,7 +29,8 @@ API Changes
   :py:func:`solarforecastarbiter.validation.tasks.fetch_and_validate_observation`
   and :py:func:`solarforecastarbiter.validation.tasks.fetch_and_validate_all_observations` (:pull:`484`)
 * Added support for probabilistic persistence forecasts with
-  :py:func:`solarforecastarbiter.reference_forecasts.persistence.persistence_probabilistic` (:issue:`195`) (:pull:`434`)
+  :py:func:`solarforecastarbiter.reference_forecasts.persistence.persistence_probabilistic` and
+  :py:func:`solarforecastarbiter.reference_forecasts.persistence.persistence_probabilistic_timeofday` (:issue:`195`) (:pull:`434`)
 
 
 Enhancements

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -437,10 +437,6 @@ def persistence_probabilistic(observation, data_start, data_end,
             fx_prob = cdf(constant_value) * 100.0
             forecasts.append(pd.Series(fx_prob, index=fx_index))
     elif axis == "y":   # constant_values=percentiles, fx=variable
-        for constant_value in constant_values:
-            assert 0 <= constant_value <= 100, ("Constant percentile values "
-                                                "must be between 0 and 100")
-
         forecasts = []
         for constant_value in constant_values:
             fx = np.percentile(obs, constant_value)
@@ -529,9 +525,8 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
     fx_timeofday = (fx_index.hour * 60 + fx_index.minute).astype(int)
 
     # confirm sufficient data for matching by time of day
-    assert data_end - data_start > pd.Timedelta('7D'), (
-        "Insufficient data to match by time of day."
-    )
+    if data_end - data_start < pd.Timedelta('7D'):
+        raise ValueError("Insufficient data to match by time of day")
 
     if axis == "x":
         forecasts = []
@@ -543,10 +538,6 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
                 fx[fx_timeofday == tod] = cdf(constant_value) * 100.0
             forecasts.append(pd.Series(fx, index=fx_index))
     elif axis == "y":
-        for constant_value in constant_values:
-            assert 0 <= constant_value <= 100, ("Constant percentile values "
-                                                "must be between 0 and 100")
-
         forecasts = []
         for constant_value in constant_values:
             fx = np.empty(len(fx_index))

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -579,6 +579,10 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
 
     # time of day: minutes past midnight (e.g. 0=12:00am, 75=1:15am)
     obs_timeofday = (obs.index.hour * 60 + obs.index.minute).astype(int)
+    if fx_index.tzinfo is None:
+        fx_index = fx_index.tz_localze(obs.index.tzinfo)
+    else:
+        fx_index = fx_index.tz_convert(obs.index.tzinfo)
     fx_timeofday = (fx_index.hour * 60 + fx_index.minute).astype(int)
 
     # confirm sufficient data for matching by time of day

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -423,7 +423,6 @@ def persistence_probabilistic(observation, data_start, data_end,
     doi: 10.1016/j.apenergy.2015.08.011
 
     """
-
     closed = datamodel.CLOSED_MAPPING[interval_label]
     fx_index = pd.date_range(start=forecast_start, end=forecast_end,
                              freq=interval_length, closed=closed)
@@ -513,12 +512,18 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
     :py:func:`solarforecastarbiter.reference_forecasts.persistence.persistence_probabilistic`
 
     """
+    # ensure that we're using times rounded to multiple of interval_length
+    _check_intervals_times(observation.interval_label, data_start, data_end,
+                           forecast_start, forecast_end,
+                           observation.interval_length)
 
     closed = datamodel.CLOSED_MAPPING[interval_label]
     fx_index = pd.date_range(start=forecast_start, end=forecast_end,
                              freq=interval_length, closed=closed)
 
+    # observation data resampled to match forecast sampling
     obs = load_data(observation, data_start, data_end)
+    obs = obs.resample(interval_length, closed=closed).mean()
 
     # time of day: minutes past midnight (e.g. 0=12:00am, 75=1:15am)
     obs_timeofday = (obs.index.hour * 60 + obs.index.minute).astype(int)

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -582,7 +582,7 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
     fx_timeofday = (fx_index.hour * 60 + fx_index.minute).astype(int)
 
     # confirm sufficient data for matching by time of day
-    if data_end - data_start < pd.Timedelta('7D'):
+    if data_end - data_start < pd.Timedelta('20D'):
         raise ValueError("Insufficient data to match by time of day")
 
     if axis == "x":

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -374,7 +374,7 @@ def persistence_probabilistic(observation, data_start, data_end,
     r"""
     Make a probabilistic persistence forecast using the *observation* from
     *data_start* to *data_end*. In the forecast literature, this method is
-    typically referred to as Persistence Ensemble (PeEn). [1]_
+    typically referred to as Persistence Ensemble (PeEn). [1]_ [2]_ [3]_
 
     The function handles forecasting either constant variable values or
     constant percentiles. In the examples below, we use GHI to be concrete but
@@ -454,6 +454,12 @@ def persistence_probabilistic(observation, data_start, data_end,
     .. [1] Allessandrini et al. (2015) "An analog ensemble for short-term
        probabilistic solar power forecast", Appl. Energy 157, pp. 95-110.
        doi: 10.1016/j.apenergy.2015.08.011
+    .. [2] Yang (2019) "A universal benchmarking method for probabilistic
+       solar irradiance forecasting", Solar Energy 184, pp. 410-416.
+       doi: 10.1016/j.solener.2019.04.018
+    .. [3] Doubleday, Van Scyoc Herndandez and Hodge (2020) "Benchmark
+       probabilistic solar forecasts: characteristics and recommendations",
+       Solar Energy 206, pp. 52-67. doi: 10.1016/j.solener.2020.05.051
 
     """
     closed = datamodel.CLOSED_MAPPING[interval_label]
@@ -490,7 +496,7 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
     *data_start* to *data_end*, matched by time of day (e.g. to forecast 9am,
     only use observations from 9am on days between *data_start* and
     *data_end*). This is a common variant of the Persistence Ensemble (PeEn)
-    method. [1]_
+    method. [1]_ [2]_ [3]_
 
     Parameters
     ----------
@@ -536,16 +542,22 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
         If there is insufficient data for matching by time of day or the
         **axis** parameter is invalid.
 
+    Notes
+    -----
+    Assumes that there is at least 20 days of *observation* data available
+    based on [1]_, [2]_, [3]_.
 
     References
     ----------
     .. [1] Allessandrini et al. (2015) "An analog ensemble for short-term
        probabilistic solar power forecast", Appl. Energy 157, pp. 95-110.
        doi: 10.1016/j.apenergy.2015.08.011
-
-    Notes
-    -----
-    Assumes that there is at least 7 days of *observation* data available.
+    .. [2] Yang (2019) "A universal benchmarking method for probabilistic
+       solar irradiance forecasting", Solar Energy 184, pp. 410-416.
+       doi: 10.1016/j.solener.2019.04.018
+    .. [3] Doubleday, Van Scyoc Herndandez and Hodge (2020) "Benchmark
+       probabilistic solar forecasts: characteristics and recommendations",
+       Solar Energy 206, pp. 52-67. doi: 10.1016/j.solener.2020.05.051
 
     See also
     --------

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -581,8 +581,6 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
     obs_timeofday = (obs.index.hour * 60 + obs.index.minute).astype(int)
     if fx_index.tzinfo is None:
         fx_index = fx_index.tz_localize(obs.index.tzinfo)
-    else:
-        fx_index = fx_index.tz_convert(obs.index.tzinfo)
     fx_timeofday = (fx_index.hour * 60 + fx_index.minute).astype(int)
 
     # confirm sufficient data for matching by time of day

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -582,7 +582,7 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
     fx_timeofday = (fx_index.hour * 60 + fx_index.minute).astype(int)
 
     # confirm sufficient data for matching by time of day
-    if data_end - data_start < pd.Timedelta('20D'):
+    if obs.last_valid_index() - obs.first_valid_index() < pd.Timedelta("20D"):
         raise ValueError("Insufficient data to match by time of day")
 
     if axis == "x":

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -427,7 +427,9 @@ def persistence_probabilistic(observation, data_start, data_end,
     fx_index = pd.date_range(start=forecast_start, end=forecast_end,
                              freq=interval_length, closed=closed)
 
+    # observation data resampled to match forecast sampling
     obs = load_data(observation, data_start, data_end)
+    obs = obs.resample(interval_length, closed=closed).mean()
 
     if axis == "x":
         cdf = ECDF(obs)

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -580,7 +580,7 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
     # time of day: minutes past midnight (e.g. 0=12:00am, 75=1:15am)
     obs_timeofday = (obs.index.hour * 60 + obs.index.minute).astype(int)
     if fx_index.tzinfo is None:
-        fx_index = fx_index.tz_localze(obs.index.tzinfo)
+        fx_index = fx_index.tz_localize(obs.index.tzinfo)
     else:
         fx_index = fx_index.tz_convert(obs.index.tzinfo)
     fx_timeofday = (fx_index.hour * 60 + fx_index.minute).astype(int)

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -444,6 +444,11 @@ def persistence_probabilistic(observation, data_start, data_end,
         percentiles (e.g. 25%). If instead *axis* is *y*, the forecasts values
         have the same units as the observation data (e.g. MW).
 
+    Raises
+    ------
+    ValueError
+        If the **axis** parameter is invalid.
+
     References
     ----------
     .. [1] Allessandrini et al. (2015) "An analog ensemble for short-term
@@ -524,6 +529,13 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
         *constant_values*. If *axis* is *x*, the forecast values are
         percentiles (e.g. 25%). If instead *axis* is *y*, the forecasts values
         have the same units as the observation data (e.g. MW).
+
+    Raises
+    ------
+    ValueError
+        If there is insufficient data for matching by time of day or the
+        **axis** parameter is invalid.
+
 
     References
     ----------

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -578,9 +578,16 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
     obs = obs.resample(interval_length, closed=closed).mean()
 
     # time of day: minutes past midnight (e.g. 0=12:00am, 75=1:15am)
+    if obs.index.tzinfo is not None:
+        if fx_index.tzinfo is not None:
+            obs = obs.tz_convert(fx_index.tzinfo)
+        else:
+            fx_index = fx_index.tz_localize(obs.index.tzinfo)
+    else:
+        if fx_index.tzinfo is not None:
+            obs = obs.tz_localize(fx_index.tzinfo)
+
     obs_timeofday = (obs.index.hour * 60 + obs.index.minute).astype(int)
-    if fx_index.tzinfo is None:
-        fx_index = fx_index.tz_localize(obs.index.tzinfo)
     fx_timeofday = (fx_index.hour * 60 + fx_index.minute).astype(int)
 
     # confirm sufficient data for matching by time of day

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -374,14 +374,14 @@ def persistence_probabilistic(observation, data_start, data_end,
     r"""
     Make a probabilistic persistence forecast using the *observation* from
     *data_start* to *data_end*. In the forecast literature, this method is
-    typically referred to as Persistence Ensemble (PeEn). [1]
+    typically referred to as Persistence Ensemble (PeEn). [1]_
 
     The function handles forecasting either constant variable values or
     constant percentiles. In the examples below, we use GHI to be concrete but
     the concepts also apply to other variables (AC power, net load, etc.).
 
-    If forecasting constant values (e.g. forecast the probability of GHI being
-    less than or equal to 500 W/m^2), the persistence forecast is:
+    If forecasting constant variable values (e.g. forecast the probability of
+    GHI being less than or equal to 500 W/m^2), the persistence forecast is:
 
     .. math::
 
@@ -446,9 +446,9 @@ def persistence_probabilistic(observation, data_start, data_end,
 
     References
     ----------
-    Allessandrini et al. (2015) "An analog ensemble for short-term
-    probabilistic solar power forecast", Appl. Energy 157, pp. 95-110.
-    doi: 10.1016/j.apenergy.2015.08.011
+    .. [1] Allessandrini et al. (2015) "An analog ensemble for short-term
+       probabilistic solar power forecast", Appl. Energy 157, pp. 95-110.
+       doi: 10.1016/j.apenergy.2015.08.011
 
     """
     closed = datamodel.CLOSED_MAPPING[interval_label]
@@ -485,7 +485,7 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
     *data_start* to *data_end*, matched by time of day (e.g. to forecast 9am,
     only use observations from 9am on days between *data_start* and
     *data_end*). This is a common variant of the Persistence Ensemble (PeEn)
-    method. [1]
+    method. [1]_
 
     Parameters
     ----------
@@ -527,9 +527,9 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
 
     References
     ----------
-    Allessandrini et al. (2015) "An analog ensemble for short-term
-    probabilistic solar power forecast", Appl. Energy 157, pp. 95-110.
-    doi: 10.1016/j.apenergy.2015.08.011
+    .. [1] Allessandrini et al. (2015) "An analog ensemble for short-term
+       probabilistic solar power forecast", Appl. Energy 157, pp. 95-110.
+       doi: 10.1016/j.apenergy.2015.08.011
 
     Notes
     -----

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -376,7 +376,35 @@ def persistence_probabilistic(observation, data_start, data_end,
     *data_start* to *data_end*. In the forecast literature, this method is
     typically referred to as Persistence Ensemble (PeEn). [1]
 
-    TODO: add examples of `axis='x'` and `axis='y'` usage
+    The function handles forecasting either constant variable values or
+    constant percentiles. In the examples below, we use GHI to be concrete but
+    the concepts also apply to other variables (AC power, net load, etc.).
+
+    If forecasting constant values (e.g. forecast the probability of GHI being
+    less than or equal to 500 W/m^2), the persistence forecast is:
+
+    .. math::
+
+       F_n(x) = ECDF(GHI_{t_{start}}, ..., GHI_{t_{end}})
+       Prob(GHI_{t_f} <= 100 W/m^2) = F_n(100 W/m^2)
+
+    where :math:`t_f` is a forecast time and :math:`F_n` is the empirical CDF
+    (ECDF) function computed from the *n* observations between
+    :math:`t_{start}` = *data_start* and :math:`t_{end}` = *data_end*, which
+    maps from variable values to probabilities.
+
+    If forecasting constant probabilities (e.g. forecast the GHI value that has
+    a 50% probability), the persistence forecast is:
+
+    .. math::
+
+       F_n(x) = ECDF(GHI_{t_{start}}, ..., GHI_{t_{end}})
+       Q_n(p) = \inf {x \in \mathrf{R} : p \leq F_n(x) }
+       p_{t_f} = Q_n(50%)
+
+    where :math:`Q_n` is the quantile function based on the *n* observations
+    between :math:`t_{start}` = *data_start* and :math:`t_{end}` = *data_end*,
+    which maps from probabilities to variable values.
 
     Parameters
     ----------
@@ -458,8 +486,6 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
     only use observations from 9am on days between *data_start* and
     *data_end*). This is a common variant of the Persistence Ensemble (PeEn)
     method. [1]
-
-    TODO: add examples of `axis='x'` and `axis='y'` usage
 
     Parameters
     ----------

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -362,3 +362,38 @@ def _check_intervals_times(interval_label, data_start, data_end,
                              'interval_length. ' + strvals)
     else:
         raise ValueError('invalid interval_label')
+
+
+def probabilistic_persistence(observation, data_start, data_end,
+                             forecast_start, forecast_end,
+                             interval_length, interval_label,
+                             load_data, prob_intervals=[0.25, 0.50, 0.75]):
+    """
+    Calculate a probabilistic persistence based on historical estimates of the
+    distribution.
+
+    Method: Persistence Ensemble (PeEn)
+        1. get lagged measurements
+        2. from lagged measurements, estimate CDF
+        3. propogate estimated CDF forward to the forecast interval
+           (possibly with clear-sky index or maybe just for each time of day)
+
+    Questions:
+    - user-specified prob intervals vs constant?
+    - multiple prob intervals or on at a time? or maybe require one or more
+      prob intervals (e.g. one interval = [0.5], multiple = [0.25, 0.50, 0.75])
+    - minimum number of samples?
+    - restrict to only day-ahead or allow for any horizon?
+    - single function or multiple (eg one by HOD and another using clear-sky
+      index)?
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    fx :
+    fx_prob :
+
+    """
+    pass

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -430,7 +430,7 @@ def persistence_probabilistic(observation, data_start, data_end,
         signature load_data(observation, data_start, data_end) and
         properly account for observation interval label.
     axis : {'x', 'y'}
-        The axis on whicht he constant values of the CDF is specified. The axis
+        The axis on which the constant values of the CDF is specified. The axis
         can be either *x* (constant variable values) or *y* (constant
         percentiles).
     constant_values : array_like
@@ -522,7 +522,7 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
         signature load_data(observation, data_start, data_end) and
         properly account for observation interval label.
     axis : {'x', 'y'}
-        The axis on whicht he constant values of the CDF is specified. The axis
+        The axis on which the constant values of the CDF is specified. The axis
         can be either *x* (constant variable values) or *y* (constant
         percentiles).
     constant_values : array_like

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -576,20 +576,20 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
     if axis == "x":
         forecasts = []
         for constant_value in constant_values:
-            fx = np.empty(len(fx_index))
+            fx = pd.Series(np.nan, index=fx_index)
             for tod in fx_timeofday:
                 data = obs[obs_timeofday == tod]
                 cdf = ECDF(data)
                 fx[fx_timeofday == tod] = cdf(constant_value) * 100.0
-            forecasts.append(pd.Series(fx, index=fx_index))
+            forecasts.append(fx)
     elif axis == "y":
         forecasts = []
         for constant_value in constant_values:
-            fx = np.empty(len(fx_index))
+            fx = pd.Series(np.nan, index=fx_index)
             for tod in fx_timeofday:
                 data = obs[obs_timeofday == tod]
                 fx[fx_timeofday == tod] = np.percentile(data, constant_value)
-            forecasts.append(pd.Series(fx, index=fx_index))
+            forecasts.append(fx)
     else:
         raise ValueError(f"Invalid axis parameter: {axis}")
 

--- a/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
@@ -464,3 +464,63 @@ def test_persistence_probabilistic_timeofday(site_metadata, obs_values, axis,
             fx,
             pd.Series(expected_values[i], index=expected_index, dtype=float)
         )
+
+
+@pytest.mark.parametrize("obs_values,axis,constant_values,expected_values", [
+    # constant_values = variable values
+    # forecasts = percentiles [%]
+    ([0] * 10 + [20] * 10, 'x', [10, 20], [50, 100]),
+
+    # constant_values = percentiles [%]
+    # forecasts = variable values
+    ([0] * 10 + [4] * 10, 'y', [50], [2]),
+])
+def test_persistence_probabilistic_timeofday_resample(
+    site_metadata,
+    obs_values,
+    axis,
+    constant_values,
+    expected_values
+):
+
+    tz = 'UTC'
+    interval_label = "beginning"
+    observation = default_observation(
+        site_metadata,
+        interval_length='30min',
+        interval_label=interval_label
+    )
+
+    # all observations at 9am each day
+    data_end = pd.Timestamp('20190513T0900', tz=tz)
+    data_start = data_end - pd.Timedelta("{}D".format(len(obs_values) / 2))
+    closed = datamodel.CLOSED_MAPPING[interval_label]
+    index = pd.date_range(start=data_start, end=data_end, freq='30min',
+                          closed=closed)
+    index = index[index.hour == 9]
+
+    data = pd.Series(obs_values, index=index, dtype=float)
+
+    # forecast 9am
+    forecast_start = pd.Timestamp('20190514T0900', tz=tz)
+    forecast_end = pd.Timestamp('20190514T1000', tz=tz)
+    interval_length = pd.Timedelta('1h')
+
+    load_data = partial(load_data_base, data)
+
+    expected_index = pd.date_range(start=forecast_start, end=forecast_end,
+                                   freq=interval_length, closed=closed)
+
+    forecasts = persistence.persistence_probabilistic_timeofday(
+        observation, data_start, data_end, forecast_start, forecast_end,
+        interval_length, interval_label, load_data, axis, constant_values
+    )
+    assert isinstance(forecasts, list)
+    for i, fx in enumerate(forecasts):
+        pd.testing.assert_index_equal(fx.index, expected_index,
+                                      check_categorical=False)
+
+        pd.testing.assert_series_equal(
+            fx,
+            pd.Series(expected_values[i], index=expected_index, dtype=float)
+        )

--- a/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
@@ -418,7 +418,7 @@ def test_persistence_probabilistic(site_metadata, interval_label, obs_values,
     ([0, 0, 0, 0, 0, 4, 4, 4, 4, 4], 'y', [50], [2]),
 
     # invalid constant_values
-    pytest.param([0, 0, 0, 0,0, 4, 4, 4, 4, 4], 'y', [101], None,
+    pytest.param([0, 0, 0, 0, 0, 4, 4, 4, 4, 4], 'y', [101], None,
                  marks=pytest.mark.xfail(raises=AssertionError, strict=True)),
     pytest.param([0, 0, 0, 0, 0, 4, 4, 4, 4, 4], 'y', [-1], None,
                  marks=pytest.mark.xfail(raises=AssertionError, strict=True)),

--- a/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
@@ -357,10 +357,13 @@ def test_persistence_scalar_index_low_solar_elevation(
     # forecasts = variable values
     ([0, 0, 0, 4, 4, 4], 'y', [50], [2]),
 
+    # invalid constant_values
     pytest.param([0, 0, 0, 4, 4, 4], 'y', [101], None,
                  marks=pytest.mark.xfail(raises=AssertionError, strict=True)),
     pytest.param([0, 0, 0, 4, 4, 4], 'y', [-1], None,
                  marks=pytest.mark.xfail(raises=AssertionError, strict=True)),
+
+    # invalid axis
     pytest.param([0, 0, 0, 4, 4, 4], 'percentile', [-1], None,
                  marks=pytest.mark.xfail(raises=ValueError, strict=True)),
 ])
@@ -391,6 +394,76 @@ def test_persistence_probabilistic(site_metadata, interval_label, obs_values,
                                    freq=interval_length, closed=closed)
 
     forecasts = persistence.persistence_probabilistic(
+        observation, data_start, data_end, forecast_start, forecast_end,
+        interval_length, interval_label, load_data, axis, constant_values
+    )
+    assert isinstance(forecasts, list)
+    for i, fx in enumerate(forecasts):
+        pd.testing.assert_index_equal(fx.index, expected_index,
+                                      check_categorical=False)
+
+        pd.testing.assert_series_equal(
+            fx,
+            pd.Series(expected_values[i], index=expected_index, dtype=float)
+        )
+
+
+@pytest.mark.parametrize("obs_values,axis,constant_values,expected_values", [
+    # constant_values = variable values
+    # forecasts = percentiles [%]
+    ([0, 0, 0, 0, 0, 20, 20, 20, 20, 20], 'x', [10, 20], [50, 100]),
+
+    # constant_values = percentiles [%]
+    # forecasts = variable values
+    ([0, 0, 0, 0, 0, 4, 4, 4, 4, 4], 'y', [50], [2]),
+
+    # invalid constant_values
+    pytest.param([0, 0, 0, 0,0, 4, 4, 4, 4, 4], 'y', [101], None,
+                 marks=pytest.mark.xfail(raises=AssertionError, strict=True)),
+    pytest.param([0, 0, 0, 0, 0, 4, 4, 4, 4, 4], 'y', [-1], None,
+                 marks=pytest.mark.xfail(raises=AssertionError, strict=True)),
+
+    # invalid axis
+    pytest.param([0, 0, 0, 0, 0, 4, 4, 4, 4, 4], 'percentile', [-1], None,
+                 marks=pytest.mark.xfail(raises=ValueError, strict=True)),
+
+    # insufficient observation data
+    pytest.param([1, 2, 3, 4], 'x', [50], None,
+                 marks=pytest.mark.xfail(raises=AssertionError, strict=True))
+])
+def test_persistence_probabilistic_timeofday(site_metadata, obs_values, axis,
+                                             constant_values, expected_values):
+
+    tz = 'UTC'
+    interval_label = "beginning"
+    interval_length = '1h'
+    observation = default_observation(
+        site_metadata,
+        interval_length=interval_length,
+        interval_label=interval_label
+    )
+
+    # all observations at 9am each day
+    data_end = pd.Timestamp('20190513T0900', tz=tz)
+    data_start = data_end - pd.Timedelta("{}D".format(len(obs_values)))
+    closed = datamodel.CLOSED_MAPPING[interval_label]
+    index = pd.date_range(start=data_start, end=data_end, freq='1h',
+                          closed=closed)
+    index = index[index.hour == 9]
+
+    data = pd.Series(obs_values, index=index, dtype=float)
+
+    # forecast 9am
+    forecast_start = pd.Timestamp('20190514T0900', tz=tz)
+    forecast_end = pd.Timestamp('20190514T1000', tz=tz)
+    interval_length = pd.Timedelta('1h')
+
+    load_data = partial(load_data_base, data)
+
+    expected_index = pd.date_range(start=forecast_start, end=forecast_end,
+                                   freq=interval_length, closed=closed)
+
+    forecasts = persistence.persistence_probabilistic_timeofday(
         observation, data_start, data_end, forecast_start, forecast_end,
         interval_length, interval_label, load_data, axis, constant_values
     )

--- a/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
@@ -405,15 +405,15 @@ def test_persistence_probabilistic(site_metadata, interval_label, obs_values,
 @pytest.mark.parametrize("obs_values,axis,constant_values,expected_values", [
     # constant_values = variable values
     # forecasts = percentiles [%]
-    ([0] * 10 + [20] * 10, 'x', [10, 20], [50, 100]),
-    ([0] * 10 + [20] * 10, 'x', [10, 20], [50, 100]),
+    ([0] * 11 + [20] * 11, 'x', [10, 20], [50, 100]),
+    ([0] * 11 + [20] * 11, 'x', [10, 20], [50, 100]),
 
     # constant_values = percentiles [%]
     # forecasts = variable values
-    ([0] * 10 + [4] * 10, 'y', [50], [2]),
+    ([0] * 11 + [4] * 11, 'y', [50], [2]),
 
     # invalid axis
-    pytest.param([0, 0, 0, 0, 0, 4, 4, 4, 4, 4], 'percentile', [-1], None,
+    pytest.param([0] * 5 + [4] * 5, 'percentile', [-1], None,
                  marks=pytest.mark.xfail(raises=ValueError, strict=True)),
 
     # insufficient observation data
@@ -528,11 +528,11 @@ def test_persistence_probabilistic_resampling(
 @pytest.mark.parametrize("obs_values,axis,constant_values,expected_values", [
     # constant_values = variable values
     # forecasts = percentiles [%]
-    ([0] * 20 + [20] * 20, 'x', [10, 20], [50, 100]),
+    ([0] * 22 + [20] * 22, 'x', [10, 20], [50, 100]),
 
     # constant_values = percentiles [%]
     # forecasts = variable values
-    ([0] * 20 + [4] * 20, 'y', [50], [2]),
+    ([0] * 22 + [4] * 22, 'y', [50], [2]),
 ])
 def test_persistence_probabilistic_timeofday_resample(
     site_metadata,

--- a/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
@@ -466,6 +466,64 @@ def test_persistence_probabilistic_timeofday(site_metadata, obs_values, axis,
         )
 
 
+@pytest.mark.parametrize("interval_label", [
+    'beginning', 'ending'
+])
+@pytest.mark.parametrize("obs_values,axis,constant_values,expected_values", [
+    # constant_values = variable values
+    # forecasts = percentiles [%]
+    ([0] * 15 + [20] * 15, 'x', [10, 20], [50, 100]),
+
+    # constant_values = percentiles [%]
+    # forecasts = variable values
+    ([0] * 15 + [4] * 15, 'y', [50], [2]),
+])
+def test_persistence_probabilistic_resampling(
+    site_metadata,
+    interval_label,
+    obs_values, axis,
+    constant_values,
+    expected_values
+):
+
+    tz = 'UTC'
+    interval_length = '1min'
+    observation = default_observation(
+        site_metadata,
+        interval_length=interval_length,
+        interval_label=interval_label
+    )
+
+    data_start = pd.Timestamp('20190513 1200', tz=tz)
+    data_end = pd.Timestamp('20190513 1230', tz=tz)
+    closed = datamodel.CLOSED_MAPPING[interval_label]
+    index = pd.date_range(start=data_start, end=data_end, freq='1min',
+                          closed=closed)
+
+    data = pd.Series(obs_values, index=index, dtype=float)
+    forecast_start = pd.Timestamp('20190513 1230', tz=tz)
+    forecast_end = pd.Timestamp('20190513 1300', tz=tz)
+    interval_length = pd.Timedelta('5min')
+    load_data = partial(load_data_base, data)
+
+    expected_index = pd.date_range(start=forecast_start, end=forecast_end,
+                                   freq=interval_length, closed=closed)
+
+    forecasts = persistence.persistence_probabilistic(
+        observation, data_start, data_end, forecast_start, forecast_end,
+        interval_length, interval_label, load_data, axis, constant_values
+    )
+    assert isinstance(forecasts, list)
+    for i, fx in enumerate(forecasts):
+        pd.testing.assert_index_equal(fx.index, expected_index,
+                                      check_categorical=False)
+
+        pd.testing.assert_series_equal(
+            fx,
+            pd.Series(expected_values[i], index=expected_index, dtype=float)
+        )
+
+
 @pytest.mark.parametrize("obs_values,axis,constant_values,expected_values", [
     # constant_values = variable values
     # forecasts = percentiles [%]

--- a/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
@@ -357,11 +357,12 @@ def test_persistence_scalar_index_low_solar_elevation(
     # forecasts = variable values
     ([0, 0, 0, 4, 4, 4], 'y', [50], [2]),
 
-    # invalid percentile constant_values
     pytest.param([0, 0, 0, 4, 4, 4], 'y', [101], None,
                  marks=pytest.mark.xfail(raises=AssertionError, strict=True)),
     pytest.param([0, 0, 0, 4, 4, 4], 'y', [-1], None,
                  marks=pytest.mark.xfail(raises=AssertionError, strict=True)),
+    pytest.param([0, 0, 0, 4, 4, 4], 'percentile', [-1], None,
+                 marks=pytest.mark.xfail(raises=ValueError, strict=True)),
 ])
 def test_persistence_probabilistic(site_metadata, interval_label, obs_values,
                                    axis, constant_values, expected_values):

--- a/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
@@ -357,12 +357,6 @@ def test_persistence_scalar_index_low_solar_elevation(
     # forecasts = variable values
     ([0, 0, 0, 4, 4, 4], 'y', [50], [2]),
 
-    # invalid constant_values
-    pytest.param([0, 0, 0, 4, 4, 4], 'y', [101], None,
-                 marks=pytest.mark.xfail(raises=AssertionError, strict=True)),
-    pytest.param([0, 0, 0, 4, 4, 4], 'y', [-1], None,
-                 marks=pytest.mark.xfail(raises=AssertionError, strict=True)),
-
     # invalid axis
     pytest.param([0, 0, 0, 4, 4, 4], 'percentile', [-1], None,
                  marks=pytest.mark.xfail(raises=ValueError, strict=True)),
@@ -417,19 +411,13 @@ def test_persistence_probabilistic(site_metadata, interval_label, obs_values,
     # forecasts = variable values
     ([0, 0, 0, 0, 0, 4, 4, 4, 4, 4], 'y', [50], [2]),
 
-    # invalid constant_values
-    pytest.param([0, 0, 0, 0, 0, 4, 4, 4, 4, 4], 'y', [101], None,
-                 marks=pytest.mark.xfail(raises=AssertionError, strict=True)),
-    pytest.param([0, 0, 0, 0, 0, 4, 4, 4, 4, 4], 'y', [-1], None,
-                 marks=pytest.mark.xfail(raises=AssertionError, strict=True)),
-
     # invalid axis
     pytest.param([0, 0, 0, 0, 0, 4, 4, 4, 4, 4], 'percentile', [-1], None,
                  marks=pytest.mark.xfail(raises=ValueError, strict=True)),
 
     # insufficient observation data
     pytest.param([1, 2, 3, 4], 'x', [50], None,
-                 marks=pytest.mark.xfail(raises=AssertionError, strict=True))
+                 marks=pytest.mark.xfail(raises=ValueError, strict=True))
 ])
 def test_persistence_probabilistic_timeofday(site_metadata, obs_values, axis,
                                              constant_values, expected_values):

--- a/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
@@ -405,18 +405,19 @@ def test_persistence_probabilistic(site_metadata, interval_label, obs_values,
 @pytest.mark.parametrize("obs_values,axis,constant_values,expected_values", [
     # constant_values = variable values
     # forecasts = percentiles [%]
-    ([0, 0, 0, 0, 0, 20, 20, 20, 20, 20], 'x', [10, 20], [50, 100]),
+    ([0] * 10 + [20] * 10, 'x', [10, 20], [50, 100]),
+    ([0] * 10 + [20] * 10, 'x', [10, 20], [50, 100]),
 
     # constant_values = percentiles [%]
     # forecasts = variable values
-    ([0, 0, 0, 0, 0, 4, 4, 4, 4, 4], 'y', [50], [2]),
+    ([0] * 10 + [4] * 10, 'y', [50], [2]),
 
     # invalid axis
     pytest.param([0, 0, 0, 0, 0, 4, 4, 4, 4, 4], 'percentile', [-1], None,
                  marks=pytest.mark.xfail(raises=ValueError, strict=True)),
 
     # insufficient observation data
-    pytest.param([1, 2, 3, 4], 'x', [50], None,
+    pytest.param([5.3, 7.3, 1.4] * 4, 'x', [50], None,
                  marks=pytest.mark.xfail(raises=ValueError, strict=True))
 ])
 def test_persistence_probabilistic_timeofday(site_metadata, obs_values, axis,
@@ -527,11 +528,11 @@ def test_persistence_probabilistic_resampling(
 @pytest.mark.parametrize("obs_values,axis,constant_values,expected_values", [
     # constant_values = variable values
     # forecasts = percentiles [%]
-    ([0] * 10 + [20] * 10, 'x', [10, 20], [50, 100]),
+    ([0] * 20 + [20] * 20, 'x', [10, 20], [50, 100]),
 
     # constant_values = percentiles [%]
     # forecasts = variable values
-    ([0] * 10 + [4] * 10, 'y', [50], [2]),
+    ([0] * 20 + [4] * 20, 'y', [50], [2]),
 ])
 def test_persistence_probabilistic_timeofday_resample(
     site_metadata,


### PR DESCRIPTION
  - [x] Closes #195 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

The goal of this PR is to add a reference probabilistic forecast method. My initial idea is to implement the Persistence Ensemble (PeEn) method [1], which is fairly commonly used as a baseline probabilistic forecast in the literature and relies solely on historical observations to estimate an empirical CDF, which is then propagated into future. Similar to (dull) persistence, this works well in short horizons and during non-changing conditions (e.g. extended periods of clear-sky or overcast weather). Also, we can implement variations of PeEn such as using clear-sky index observations (similar to "Smart Persistence") as well as matching the empirical CDF by hour of the day, which in turn would provide a similar effect as using clear-sky index but for data without clear-sky models (e.g. net load). [2]

Overall the method is:
1. estimate the empirical CDF from historical observations for `data_start` to `data_end`
2. for each probability interval (e.g. 25%, 50%, 75%), forecast the future probabilities for `forecast_start` to `forecast_end` as the empirical CDF (`ECDF`) (e.g `fx(25%) = ECDF(25%)`, `fx(50%) = ECDF(50%)`, etc.)


[1] Alessandrini et al. (2015) "An analog ensemble for short-term probabilistic solar power forecast", Applied Energy
[2] Dazhi Yang (2019) "A universal benchmarking method for probabilistic solar irradiance forecasting", Solar Energy