### PR TITLE
Generate PDF figures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
   - task: Npm@1
     inputs:
       command: 'custom'
-      customCommand: 'install -g electron@6.1.4 orca'
+      customCommand: 'install electron@6.1.4 orca'
     displayName: 'Install orca'
 
   - script: python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,15 +23,6 @@ jobs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
 
-  - script: sudo apt-get update && sudo apt-get install -y xvfb
-    displayName: 'Install xvfb'
-
-  - task: Npm@1
-    inputs:
-      command: 'custom'
-      customCommand: 'install electron orca'
-    displayName: 'Install orca'
-
   - script: python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt
     displayName: 'Install dependencies'
 
@@ -39,7 +30,7 @@ jobs:
     displayName: 'Install solarforecastarbiter with extras'
 
   - script: |
-      PATH=/home/vsts/work/node_modules/.bin:$PATH pytest solarforecastarbiter --junitxml=junit/test-results.xml --cov --cov-report=xml --cov-report=html
+      pytest solarforecastarbiter --junitxml=junit/test-results.xml --cov --cov-report=xml --cov-report=html
     displayName: 'pytest'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
   - task: Npm@1
     inputs:
       command: 'custom'
-      customCommand: 'install electron@6.1.4 orca'
+      customCommand: 'install electron orca'
     displayName: 'Install orca'
 
   - script: python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,11 +23,14 @@ jobs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
 
+  - script: apt-get update && apt-get install -y xvfb
+    displayName: 'Install xvfb'
+
   - task: Npm@1
     inputs:
       command: 'custom'
-      customCommand: 'install phantomjs-prebuilt'
-    displayName: 'Install phantomjs'
+      customCommand: 'install -g electron@6.1.4 orca'
+    displayName: 'Install orca'
 
   - script: python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt
     displayName: 'Install dependencies'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
 
-  - script: apt-get update && apt-get install -y xvfb
+  - script: sudo apt-get update && sudo apt-get install -y xvfb
     displayName: 'Install xvfb'
 
   - task: Npm@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
     displayName: 'Install solarforecastarbiter with extras'
 
   - script: |
-      pytest solarforecastarbiter --junitxml=junit/test-results.xml --cov --cov-report=xml --cov-report=html
+      PATH=/home/vsts/work/node_modules/.bin:$PATH pytest solarforecastarbiter --junitxml=junit/test-results.xml --cov --cov-report=xml --cov-report=html
     displayName: 'pytest'
 
   - script: |

--- a/docs/source/whatsnew/1.0.0rc1.rst
+++ b/docs/source/whatsnew/1.0.0rc1.rst
@@ -24,6 +24,7 @@ Enhancements
 * PDF report figures are generated instead of SVG for easy integration into PDF
   reports (:issue:`360`) (:pull:`437`)
 
+
 Bug fixes
 ~~~~~~~~~
 * Fix incorrect ordering of months and weekdays in metrics plots.

--- a/docs/source/whatsnew/1.0.0rc1.rst
+++ b/docs/source/whatsnew/1.0.0rc1.rst
@@ -21,7 +21,8 @@ Enhancements
 * Datamodel now supports ``'net_load'`` as an allowed variable. (:issue:`55`) (:pull:`392`)
 * Posting of daily validation now splits requests to avoid missing periods and
   limit each request to one week of data (:issue:`424`) (:pull:`435`)
-
+* PDF report figures are generated instead of SVG for easy integration into PDF
+  reports (:issue:`360`) (:pull:`437`)
 
 Bug fixes
 ~~~~~~~~~

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -2001,7 +2001,7 @@ def raw_report(report_objects, report_metrics, preprocessing_result_types,
                     {
                         'name': 'mae tucson ghi',
                         'spec': '{"data":[{"x":[1],"y":[1],"type":"bar"}]}',
-                        'svg': '<svg></svg>',
+                        'pdf': ',u@!!/MSk7$7-ue:IY',
                         'figure_type': 'bar',
                         'category': 'total',
                         'metric': 'mae',
@@ -2363,7 +2363,7 @@ def plotly_report_figure_dict():
     return {
         'name': 'mae tucson ghi',
         'spec': '{"data":[{"x":[1],"y":[1],"type":"bar"}]}',
-        'svg': '<svg></svg>',
+        'pdf': ',u@!!/MSk7$7-ue:IY',
         'figure_type': 'bar',
         'category': 'total',
         'metric': 'mae',
@@ -2435,7 +2435,7 @@ def raw_report_dict_with_event():
                 'metric': 'pod',
                 'name': 'all',
                 'spec': "{}",
-                'svg': '<svg></svg>'}],
+                'pdf': ',u@!!/MSk7$7-ue:IY'}],
             'plotly_version': '4.5.3',
             'script': None},
         'processed_forecasts_observations': [{

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1418,10 +1418,12 @@ class PlotlyReportFigure(ReportFigure):
         A descriptive name for the figure.
     spec: str
         JSON string representation of the plotly plot.
-    svg: str
-        A static svg copy of the plot, for including in the pdf version.
     figure_type: str
         The type of plot, e.g. bar or scatter.
+    pdf: str
+        A static PDF copy of the plot, for including in PDF reports.
+    svg: str
+        DEPRECATED for pdf. A static svg copy of the plot.
     category: str
         The metric category. One of ALLOWED_CATEGORIES keys.
     metric: str
@@ -1429,8 +1431,9 @@ class PlotlyReportFigure(ReportFigure):
     """
     name: str
     spec: str
-    svg: str
     figure_type: str
+    pdf: str
+    svg: str = ''
     category: str = ''
     metric: str = ''
     figure_class: str = 'plotly'

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1432,7 +1432,7 @@ class PlotlyReportFigure(ReportFigure):
     name: str
     spec: str
     figure_type: str
-    pdf: str
+    pdf: str = ''
     svg: str = ''
     category: str = ''
     metric: str = ''

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -2,6 +2,7 @@
 Functions to make all of the metrics figures for Solar Forecast Arbiter reports
 using Plotly.
 """
+import base64
 import calendar
 import datetime as dt
 from itertools import cycle
@@ -761,6 +762,39 @@ def output_svg(fig):
     return svg
 
 
+def output_pdf(fig):
+    """
+    Generates an PDF from the Plotly figure. Errors in the process are logged
+    and an PDF with error text is returned.
+
+    Parameters
+    ----------
+    fig : plotly.graph_objects.Figure
+
+    Returns
+    -------
+    pdf : str
+       An ASCII-85 encoded PDF
+
+    Notes
+    -----
+    Requires `Orca <https://plot.ly/python/orca-management/>`_ for generating
+    pdfs. If orca is not installed, an pdf with an error message will be
+    returned.
+    """
+    try:
+        pdf = base64.a85encode(fig.to_image(format='pdf')).decode('utf-8')
+    except Exception:
+        try:
+            name = fig.layout.title['text'][3:-4]
+        except Exception:
+            name = 'unnamed'
+        logger.error('Could not generate PDF for figure %s', name)
+        # should have same text as fail SVG
+        pdf = ',u@!!/MSk8$73+IY58P_+>=pV@VQ644<Q:NASu.&BHT/T0Ha7#+<Vd[7VQ[\\ATAnH7VlLTAOL*>De*Dd5!B<pFE1r$D$kNX1K6%.6<uqiV.X\\GOIXKoa;)c"!&3^A=pehYA92j5ARTE_ASu$s@VQ6-+>=pV@VQ5m+<WEu$>"*cDdmGg1E\\@oDdmGg4?Ns74pkk=A8bpl$8N_X+E(_($9UEn03!49AKWX&@:s-o,p4oL+<Vd[:gnBUDKI!U+>=p9$6UH6026"gBjj>HGT^350H`%l0J5:A+>>E,2\'?03+<Vd[6Z6jaASuU2+>b2p+ArOh+<W=-Ec6)>+?Van+<VdL+<W=:H#R=;01U&$F`7[1+<VdL+>6Y902ut#DKBc*Eb0,uGmYZ:+<VdL01d:.Eckq#+<VdL+<W=);]m_]AThctAPu#b$6UH65!B;r+<W=8ATMd4Ear[%+>Y,o+ArP14pkk=A8bpl$8EYW+E(_($9UEn03!49AKWX&@:s.m$6UH602$"iF!+[01*A7n;BT6P+<Vd[6Z7*bF<E:F5!B<bDIdZpC\'ljA0Hb:CC\'m\'c+>6Q3De+!#ATAnA@ps(lD]gbe0fCX<+=LoFFDu:^0/$gDBl\\-)Ea`p#Bk)3:DfTJ>.1.1?+>6*&ART[pDf.sOFCcRC6om(W1,(C>0K1^?0ebFC/MK+20JFp_5!B<bDIdZpC\'lmB0Hb:CC\'m\'c+>6]>E+L.F6Xb(FCi<qn+<Vd[:gn!JF!*1[0Ha7#5!B<bDIdZpC\'o3+AS)9\'+?0]^0JG170JG170H`822)@*4AfqF70JG170JG:B0d&/(0JG1\'DBK9?0JG170JG4>0d&/(0JG1\'DBK9?0JG170JG4<0H`&\'0JG1\'DBK9?0JG170JG182\'=S,0JG1\'DBK9?0JG170JG493?U"00JG1\'DBK9?0JG170JG=?2BX\\-0JG1\'DBK9?0JG170JG@B1*A8)0JG1\'DBK:.Ea`ZuATA,?4<Q:UBmO>53!pcN+>6W2Dfd*\\+>=p9$6UH601g%nD]gq\\0Ha7#5!B<pFCB33G]IA-$8sUq$7-ue:IYZ'  # NOQA
+    return pdf
+
+
 def raw_report_plots(report, metrics):
     """Create a RawReportPlots object from the metrics of a report.
 
@@ -791,10 +825,10 @@ def raw_report_plots(report, metrics):
     for k, v in figure_dict.items():
         cat, met, name = k.split('::', 2)
         figure_spec = v.to_json()
-        svg = output_svg(v)
+        pdf = output_pdf(v)
         mplots.append(datamodel.PlotlyReportFigure(
             name=name, category=cat, metric=met, spec=figure_spec,
-            svg=svg, figure_type='bar'))
+            pdf=pdf, figure_type='bar'))
 
     out = datamodel.RawReportPlots(tuple(mplots), plotly_version)
     return out

--- a/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
@@ -1,3 +1,4 @@
+import base64
 import shutil
 
 
@@ -164,11 +165,29 @@ def test_output_svg_with_plotly_figure(mocker):
         'solarforecastarbiter.reports.figures.plotly_figures.logger')
     if shutil.which('orca') is None:  # pragma: no cover
         pytest.skip('orca must be on PATH to make SVGs')
+    if shutil.which('xvfb-run') is None:  # pragma: no cover
+        pytest.skip('xvfb-run must be on PATH to make SVGs')
     values = list(range(5))
     fig = graph_objects.Figure(data=graph_objects.Scatter(x=values, y=values))
     svg = figures.output_svg(fig)
     assert svg.startswith('<svg')
     assert svg.endswith('</svg>')
+    assert not logger.error.called
+
+
+def test_output_pdf_with_plotly_figure(mocker):
+    logger = mocker.patch(
+        'solarforecastarbiter.reports.figures.plotly_figures.logger')
+    if shutil.which('orca') is None:  # pragma: no cover
+        pytest.skip('orca must be on PATH to make PDFs')
+    if shutil.which('xvfb-run') is None:  # pragma: no cover
+        pytest.skip('xvfb-run must be on PATH to make PDFs')
+    values = list(range(5))
+    fig = graph_objects.Figure(data=graph_objects.Scatter(x=values, y=values))
+    pdf = figures.output_pdf(fig)
+    pdf_bytes = base64.a85decode(pdf)
+    assert pdf_bytes.startswith(b'%PDF-')
+    assert pdf_bytes.rstrip(b'\n').endswith(b'%%EOF')
     assert not logger.error.called
 
 
@@ -187,6 +206,18 @@ def test_output_svg_with_plotly_figure_no_orca(mocker, remove_orca):
     assert svg.startswith('<svg')
     assert 'Unable' in svg
     assert svg.endswith('</svg>')
+    assert logger.error.called
+
+
+def test_output_pdf_with_plotly_figure_no_orca(mocker, remove_orca):
+    logger = mocker.patch(
+        'solarforecastarbiter.reports.figures.plotly_figures.logger')
+    values = list(range(5))
+    fig = graph_objects.Figure(data=graph_objects.Scatter(x=values, y=values))
+    pdf = figures.output_pdf(fig)
+    pdf_bytes = base64.a85decode(pdf)
+    assert pdf_bytes.startswith(b'%PDF-')
+    assert pdf_bytes.rstrip(b'\n').endswith(b'%%EOF')
     assert logger.error.called
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #360  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

I want to explore how long this takes for a standard report. Full PDF generation via Latex will likely take some time to begin with (and require backend generation with some temporary storage to be retrieved by the client in another request) so might make sense to generate PDFs from the spec on a PDF report request.