### PR TITLE
Fix power observations for SRML Portland PV site.

### DIFF
--- a/solarforecastarbiter/io/reference_observations/srml_reference_sites.json
+++ b/solarforecastarbiter/io/reference_observations/srml_reference_sites.json
@@ -94,11 +94,11 @@
             "variable": "dc_power"
         },
         {
-            "extra_parameters": "{\"network_data_label\": \"536B\", \"module\": \"Evergreen 190W/ Solectra PV1 1800\", \"network_api_id\": \"94808.0\", \"attribution\": \"Peterson, J., and Vignola, F., 2017: Structure of a Comprehensive Solar Radiation Dataset. Proceedings of the ASES National Solar Conference 2017. doi: 10.18086/solar.2017.07.02\", \"network\": \"UO SRML\", \"network_api_abbreviation\": \"PS\", \"observation_interval_length\": 1.0}",
+            "extra_parameters": "{\"network_data_label\": \"5362\", \"module\": \"Evergreen 190W/ Solectra PV1 1800\", \"network_api_id\": \"94808.0\", \"attribution\": \"Peterson, J., and Vignola, F., 2017: Structure of a Comprehensive Solar Radiation Dataset. Proceedings of the ASES National Solar Conference 2017. doi: 10.18086/solar.2017.07.02\", \"network\": \"UO SRML\", \"network_api_abbreviation\": \"PS\", \"observation_interval_length\": 1.0}",
             "interval_label": "beginning",
             "interval_length": 1.0,
             "interval_value_type": "interval_mean",
-            "name": "Portland OR PV 30 deg tilt dc_power Evergreen",
+            "name": "Portland OR PV 30 deg tilt ac_power Evergreen",
             "observation_id": "",
             "provider": "",
             "site": {
@@ -122,7 +122,7 @@
                 "timezone": "Etc/GMT+8"
             },
             "uncertainty": 0,
-            "variable": "dc_power"
+            "variable": "ac_power"
         },
         {
             "extra_parameters": "{\"network_data_label\": \"536C\", \"module\": \"Photowatt 105W/ PVP 1100\", \"network_api_id\": \"94808.0\", \"attribution\": \"Peterson, J., and Vignola, F., 2017: Structure of a Comprehensive Solar Radiation Dataset. Proceedings of the ASES National Solar Conference 2017. doi: 10.18086/solar.2017.07.02\", \"network\": \"UO SRML\", \"network_api_abbreviation\": \"PS\", \"observation_interval_length\": 1.0}",
@@ -156,11 +156,11 @@
             "variable": "dc_power"
         },
         {
-            "extra_parameters": "{\"network_data_label\": \"536C\", \"module\": \"Photowatt 105W/ PVP 1100\", \"network_api_id\": \"94808.0\", \"attribution\": \"Peterson, J., and Vignola, F., 2017: Structure of a Comprehensive Solar Radiation Dataset. Proceedings of the ASES National Solar Conference 2017. doi: 10.18086/solar.2017.07.02\", \"network\": \"UO SRML\", \"network_api_abbreviation\": \"PS\", \"observation_interval_length\": 1.0}",
+            "extra_parameters": "{\"network_data_label\": \"5363\", \"module\": \"Photowatt 105W/ PVP 1100\", \"network_api_id\": \"94808.0\", \"attribution\": \"Peterson, J., and Vignola, F., 2017: Structure of a Comprehensive Solar Radiation Dataset. Proceedings of the ASES National Solar Conference 2017. doi: 10.18086/solar.2017.07.02\", \"network\": \"UO SRML\", \"network_api_abbreviation\": \"PS\", \"observation_interval_length\": 1.0}",
             "interval_label": "beginning",
             "interval_length": 1.0,
             "interval_value_type": "interval_mean",
-            "name": "Portland OR PV 30 deg tilt dc_power Photowatt",
+            "name": "Portland OR PV 30 deg tilt ac_power Photowatt",
             "observation_id": "",
             "provider": "",
             "site": {
@@ -184,7 +184,7 @@
                 "timezone": "Etc/GMT+8"
             },
             "uncertainty": 0,
-            "variable": "dc_power"
+            "variable": "ac_power"
         },
         {
             "extra_parameters": "{\"network_data_label\": \"536D\", \"module\": \"Kaneka 60W/SMA 700\", \"network_api_id\": \"94808.0\", \"attribution\": \"Peterson, J., and Vignola, F., 2017: Structure of a Comprehensive Solar Radiation Dataset. Proceedings of the ASES National Solar Conference 2017. doi: 10.18086/solar.2017.07.02\", \"network\": \"UO SRML\", \"network_api_abbreviation\": \"PS\", \"observation_interval_length\": 1.0}",
@@ -218,11 +218,42 @@
             "variable": "dc_power"
         },
         {
-            "extra_parameters": "{\"network_data_label\": \"536D\", \"module\": \"Kaneka 60W/SMA 700\", \"network_api_id\": \"94808.0\", \"attribution\": \"Peterson, J., and Vignola, F., 2017: Structure of a Comprehensive Solar Radiation Dataset. Proceedings of the ASES National Solar Conference 2017. doi: 10.18086/solar.2017.07.02\", \"network\": \"UO SRML\", \"network_api_abbreviation\": \"PS\", \"observation_interval_length\": 1.0}",
+            "extra_parameters": "{\"network_data_label\": \"5364\", \"module\": \"Kaneka 60W/SMA 700\", \"network_api_id\": \"94808.0\", \"attribution\": \"Peterson, J., and Vignola, F., 2017: Structure of a Comprehensive Solar Radiation Dataset. Proceedings of the ASES National Solar Conference 2017. doi: 10.18086/solar.2017.07.02\", \"network\": \"UO SRML\", \"network_api_abbreviation\": \"PS\", \"observation_interval_length\": 1.0}",
             "interval_label": "beginning",
             "interval_length": 1.0,
             "interval_value_type": "interval_mean",
-            "name": "Portland OR PV 30 deg tilt dc_power Kaneka",
+            "name": "Portland OR PV 30 deg tilt ac_power Kaneka",
+            "observation_id": "",
+            "provider": "",
+            "site": {
+                "elevation": 70.0,
+                "extra_parameters": "{\"network_api_id\": \"94808.0\", \"attribution\": \"Peterson, J., and Vignola, F., 2017: Structure of a Comprehensive Solar Radiation Dataset. Proceedings of the ASES National Solar Conference 2017. doi: 10.18086/solar.2017.07.02\", \"network\": \"UO SRML\", \"network_api_abbreviation\": \"PS\", \"observation_interval_length\": 1.0, \"modules\": [\"Evergreen 190W/ Solectra PV1 1800\", \"Photowatt 105W/ PVP 1100\", \"Kaneka 60W/SMA 700\", \"Sanyo 195W/ SMA 3000\"]}",
+                "latitude": 45.51,
+                "longitude": -122.69,
+                "modeling_parameters": {
+                    "ac_capacity": 0.004755,
+                    "ac_loss_factor": 0.0,
+                    "dc_capacity": 0.004755,
+                    "dc_loss_factor": 0.0,
+                    "surface_azimuth": 180.0,
+                    "surface_tilt": 30.0,
+                    "temperature_coefficient": 0.3,
+                    "tracking_type": "fixed"
+                },
+                "name": "Portland OR PV 30 deg tilt",
+                "provider": "",
+                "site_id": "",
+                "timezone": "Etc/GMT+8"
+            },
+            "uncertainty": 0,
+            "variable": "ac_power"
+        },
+        {
+            "extra_parameters": "{\"network_data_label\": \"536F\", \"module\": \"Sanyo 195W/ SMA 3000\", \"network_api_id\": \"94808.0\", \"attribution\": \"Peterson, J., and Vignola, F., 2017: Structure of a Comprehensive Solar Radiation Dataset. Proceedings of the ASES National Solar Conference 2017. doi: 10.18086/solar.2017.07.02\", \"network\": \"UO SRML\", \"network_api_abbreviation\": \"PS\", \"observation_interval_length\": 1.0}",
+            "interval_label": "beginning",
+            "interval_length": 1.0,
+            "interval_value_type": "interval_mean",
+            "name": "Portland OR PV 30 deg tilt dc_power Sanyo",
             "observation_id": "",
             "provider": "",
             "site": {
@@ -247,6 +278,37 @@
             },
             "uncertainty": 0,
             "variable": "dc_power"
+        },
+        {
+            "extra_parameters": "{\"network_data_label\": \"5366\", \"module\": \"Sanyo 195W/ SMA 3000\", \"network_api_id\": \"94808.0\", \"attribution\": \"Peterson, J., and Vignola, F., 2017: Structure of a Comprehensive Solar Radiation Dataset. Proceedings of the ASES National Solar Conference 2017. doi: 10.18086/solar.2017.07.02\", \"network\": \"UO SRML\", \"network_api_abbreviation\": \"PS\", \"observation_interval_length\": 1.0}",
+            "interval_label": "beginning",
+            "interval_length": 1.0,
+            "interval_value_type": "interval_mean",
+            "name": "Portland OR PV 30 deg tilt ac_power Sanyo",
+            "observation_id": "",
+            "provider": "",
+            "site": {
+                "elevation": 70.0,
+                "extra_parameters": "{\"network_api_id\": \"94808.0\", \"attribution\": \"Peterson, J., and Vignola, F., 2017: Structure of a Comprehensive Solar Radiation Dataset. Proceedings of the ASES National Solar Conference 2017. doi: 10.18086/solar.2017.07.02\", \"network\": \"UO SRML\", \"network_api_abbreviation\": \"PS\", \"observation_interval_length\": 1.0, \"modules\": [\"Evergreen 190W/ Solectra PV1 1800\", \"Photowatt 105W/ PVP 1100\", \"Kaneka 60W/SMA 700\", \"Sanyo 195W/ SMA 3000\"]}",
+                "latitude": 45.51,
+                "longitude": -122.69,
+                "modeling_parameters": {
+                    "ac_capacity": 0.004755,
+                    "ac_loss_factor": 0.0,
+                    "dc_capacity": 0.004755,
+                    "dc_loss_factor": 0.0,
+                    "surface_azimuth": 180.0,
+                    "surface_tilt": 30.0,
+                    "temperature_coefficient": 0.3,
+                    "tracking_type": "fixed"
+                },
+                "name": "Portland OR PV 30 deg tilt",
+                "provider": "",
+                "site_id": "",
+                "timezone": "Etc/GMT+8"
+            },
+            "uncertainty": 0,
+            "variable": "ac_power"
         },
         {
             "extra_parameters": "{\"network_data_label\": \"5161\", \"module\": \"5kw unspecified\", \"network_api_id\": \"94040.0\", \"attribution\": \"Peterson, J., and Vignola, F., 2017: Structure of a Comprehensive Solar Radiation Dataset. Proceedings of the ASES National Solar Conference 2017. doi: 10.18086/solar.2017.07.02\", \"network\": \"UO SRML\", \"network_api_abbreviation\": \"AS\", \"observation_interval_length\": 1.0}",


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [ ] Closes #xxxx .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
I made an error in exporting json to set the correct parameters for power observations at the SRML Portland PV 30 deg site. The dc_power observations were duplicated instead of including both ac and dc measurements. The Sanyo module at that site was also left out, and is now included here. I've run this locally to initialize sites and checked that each one has the appropriate observations with the appropriate variable and extra parameters.
