### PR TITLE
Avoid creating invalid reference persistence forecasts

### DIFF
--- a/docs/source/whatsnew/1.0.0rc1.rst
+++ b/docs/source/whatsnew/1.0.0rc1.rst
@@ -8,7 +8,9 @@ This is the first 1.0 release candidate.
 
 API Changes
 ~~~~~~~~~~~
-
+* Added :py:func:`solarforecastarbiter.reference_forecasts.utils.check_persistence_compatibility`
+  to check if a pair of Forecast and Observation objects are compatible for
+  making a persistence forecast (:pull:`478`)
 
 Enhancements
 ~~~~~~~~~~~~
@@ -16,6 +18,9 @@ Enhancements
 
 Bug fixes
 ~~~~~~~~~
+* Check if a Forecast and Observation are compatible for generating a
+  persistence forecast before creating reference persistence forecasts
+  (:issue:`472`) (:pull:`478`)
 
 
 Contributors

--- a/solarforecastarbiter/io/reference_observations/common.py
+++ b/solarforecastarbiter/io/reference_observations/common.py
@@ -1,5 +1,5 @@
 import datetime as dt
-from functools import lru_cache
+from functools import lru_cache, partial
 import json
 import logging
 
@@ -11,6 +11,8 @@ from requests.exceptions import HTTPError
 from solarforecastarbiter.datamodel import Observation, ProbabilisticForecast
 from solarforecastarbiter.io.reference_observations.default_forecasts import (
     CURRENT_NWP_VARIABLES, is_in_nwp_domain)
+from solarforecastarbiter.reference_forecasts.utils import (
+    check_persistence_compatibility)
 
 
 logger = logging.getLogger('reference_data')
@@ -409,7 +411,7 @@ def site_name_no_network(site):
 
 
 def create_one_forecast(api, site, template_forecast, variable,
-                        **extra_params):
+                        creation_validation=lambda x: True, **extra_params):
     """Creates a new Forecast or ProbabilisticForecast for the variable
     and site based on the template forecast.
 
@@ -425,6 +427,10 @@ def create_one_forecast(api, site, template_forecast, variable,
         to extra parameters.
     variable : string
         Variable measured in the forecast.
+    creation_validation : function
+        Function that expects a Forecast or ProbabilisticForecast object
+        and raises a ValueError if the forecast is invalid just before it
+        is created.
     **extra_params : dict
         Other key, value pairs to add to the extra_parameters of the Forecast
         object.
@@ -473,6 +479,12 @@ def create_one_forecast(api, site, template_forecast, variable,
     else:
         create_func = api.create_forecast
 
+    try:
+        creation_validation(forecast)
+    except ValueError as exc:
+        logger.error('Validation failed on creation of %s forecast '
+                     'at Site %s with message %s', variable, site.name, exc)
+        return
     try:
         created = create_func(forecast)
     except HTTPError as e:
@@ -576,8 +588,11 @@ def create_persistence_forecasts(api, site, variables, templates):
                 template_fx.run_length < pd.Timedelta('1d') and
                 obs.variable in ('ghi', 'dni', 'dhi', 'ac_power')
             )
+            validation_func = partial(check_persistence_compatibility, obs,
+                                      index=use_index)
             # net_load might go here, although other changes might be required
             fx_id = create_one_forecast(api, site, template_fx, obs.variable,
+                                        creation_validation=validation_func,
                                         observation_id=obs.observation_id,
                                         index_persistence=use_index)
             created.append(fx_id)

--- a/solarforecastarbiter/io/reference_observations/srml.py
+++ b/solarforecastarbiter/io/reference_observations/srml.py
@@ -27,6 +27,8 @@ srml_variable_map = {
     'dhi_': 'dhi',
     'wind_speed_': 'wind_speed',
     'temp_air_': 'air_temperature',
+    'ac_power_': 'ac_power',
+    'dc_power_': 'dc_power'
 }
 
 

--- a/solarforecastarbiter/io/reference_observations/srml.py
+++ b/solarforecastarbiter/io/reference_observations/srml.py
@@ -9,7 +9,7 @@ from pvlib import iotools
 from requests.exceptions import HTTPError
 
 
-from solarforecastarbiter.datamodel import Observation
+from solarforecastarbiter.datamodel import Observation, SolarPowerPlant
 from solarforecastarbiter.io.reference_observations import (
     common, default_forecasts)
 
@@ -27,8 +27,6 @@ srml_variable_map = {
     'dhi_': 'dhi',
     'wind_speed_': 'wind_speed',
     'temp_air_': 'air_temperature',
-    'ac_power_': 'ac_power',
-    'dc_power_': 'dc_power'
 }
 
 
@@ -250,8 +248,11 @@ def initialize_site_forecasts(api, site):
     site : :py:class:`solarforecastarbiter.datamodel.Site`
         The site object for which to create Forecasts.
     """
+    variables = list(srml_variable_map.values())
+    if isinstance(site, SolarPowerPlant):
+        variables += ['ac_power', 'dc_power']
     common.create_forecasts(
-        api, site, srml_variable_map.values(),
+        api, site, variables,
         default_forecasts.TEMPLATE_FORECASTS)
 
 

--- a/solarforecastarbiter/io/reference_observations/srml_reference_sites.json
+++ b/solarforecastarbiter/io/reference_observations/srml_reference_sites.json
@@ -315,7 +315,7 @@
             "interval_label": "beginning",
             "interval_length": 1.0,
             "interval_value_type": "interval_mean",
-            "name": "Ashland OR dc_power 5kw",
+            "name": "Ashland OR PV dc_power 5kw",
             "observation_id": "",
             "provider": "",
             "site": {
@@ -333,7 +333,7 @@
                     "temperature_coefficient": 0.3,
                     "tracking_type": "fixed"
                 },
-                "name": "Ashland OR",
+                "name": "Ashland OR PV",
                 "provider": "",
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
@@ -346,7 +346,7 @@
             "interval_label": "beginning",
             "interval_length": 1.0,
             "interval_value_type": "interval_mean",
-            "name": "Ashland OR dc_power 15kw",
+            "name": "Ashland OR PV dc_power 15kw",
             "observation_id": "",
             "provider": "",
             "site": {
@@ -364,7 +364,7 @@
                     "temperature_coefficient": 0.3,
                     "tracking_type": "fixed"
                 },
-                "name": "Ashland OR",
+                "name": "Ashland OR PV",
                 "provider": "",
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
@@ -377,7 +377,7 @@
             "interval_label": "beginning",
             "interval_length": 1.0,
             "interval_value_type": "interval_mean",
-            "name": "Kalapuya High School OR dc_power Sharp",
+            "name": "Kalapuya High School OR PV dc_power Sharp",
             "observation_id": "",
             "provider": "",
             "site": {
@@ -395,7 +395,7 @@
                     "temperature_coefficient": 0.3,
                     "tracking_type": "fixed"
                 },
-                "name": "Kalapuya High School OR",
+                "name": "Kalapuya High School OR PV",
                 "provider": "",
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
@@ -408,7 +408,7 @@
             "interval_label": "beginning",
             "interval_length": 1.0,
             "interval_value_type": "interval_mean",
-            "name": "Kalapuya High School OR ac_power Sharp",
+            "name": "Kalapuya High School OR PV ac_power Sharp",
             "observation_id": "",
             "provider": "",
             "site": {
@@ -426,7 +426,7 @@
                     "temperature_coefficient": 0.3,
                     "tracking_type": "fixed"
                 },
-                "name": "Kalapuya High School OR",
+                "name": "Kalapuya High School OR PV",
                 "provider": "",
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
@@ -439,7 +439,7 @@
             "interval_label": "beginning",
             "interval_length": 1.0,
             "interval_value_type": "interval_mean",
-            "name": "Bend OR (PV) ac_power Sunpower",
+            "name": "Bend OR PV ac_power Sunpower",
             "observation_id": "",
             "provider": "",
             "site": {
@@ -457,7 +457,7 @@
                     "temperature_coefficient": 0.3,
                     "tracking_type": "fixed"
                 },
-                "name": "Bend OR (PV)",
+                "name": "Bend OR PV",
                 "provider": "",
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
@@ -470,7 +470,7 @@
             "interval_label": "beginning",
             "interval_length": 1.0,
             "interval_value_type": "interval_mean",
-            "name": "Bend OR (PV) dc_power Sunpower",
+            "name": "Bend OR PV dc_power Sunpower",
             "observation_id": "",
             "provider": "",
             "site": {
@@ -488,7 +488,7 @@
                     "temperature_coefficient": 0.3,
                     "tracking_type": "fixed"
                 },
-                "name": "Bend OR (PV)",
+                "name": "Bend OR PV",
                 "provider": "",
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
@@ -513,7 +513,7 @@
                 "temperature_coefficient": 0.3,
                 "tracking_type": "fixed"
             },
-            "name": "Ashland OR",
+            "name": "Ashland OR PV",
             "provider": "",
             "site_id": ""
         },
@@ -532,7 +532,7 @@
                 "temperature_coefficient": 0.3,
                 "tracking_type": "fixed"
             },
-            "name": "Kalapuya High School OR",
+            "name": "Kalapuya High School OR PV",
             "provider": "",
             "site_id": ""
         },
@@ -589,7 +589,7 @@
                 "temperature_coefficient": 0.3,
                 "tracking_type": "fixed"
             },
-            "name": "Bend OR (PV)",
+            "name": "Bend OR PV",
             "provider": "",
             "site_id": ""
         }

--- a/solarforecastarbiter/io/reference_observations/tests/test_common.py
+++ b/solarforecastarbiter/io/reference_observations/tests/test_common.py
@@ -640,6 +640,17 @@ def test_create_one_forecast(template_fx):
     assert 'piggyback_on' not in ep
 
 
+def test_create_one_forecast_invalid(template_fx):
+    api, template, site = template_fx
+
+    def fail(fx):
+        raise ValueError('failed')
+    fx = common.create_one_forecast(
+        api, site, template, 'ac_power',
+        creation_validation=fail)
+    assert fx is None
+
+
 @pytest.mark.parametrize('tz,expected', [
     ('Etc/GMT+8', dt.time(1)),
     ('MST', dt.time(0)),

--- a/solarforecastarbiter/io/reference_observations/tests/test_srml.py
+++ b/solarforecastarbiter/io/reference_observations/tests/test_srml.py
@@ -177,3 +177,20 @@ def test_request_data_warnings(mocker, exception, test_site):
     data = srml.request_data(test_site, 1, 1)
     assert logger.warning.call_count == 3
     assert data is None
+
+
+def test_initialize_site_forecasts(mocker, test_site):
+    mock_create_fx = mocker.patch(
+        'solarforecastarbiter.io.reference_observations.srml.common.'
+        'create_forecasts')
+    mock_api = mocker.MagicMock()
+    srml.initialize_site_forecasts(mock_api, test_site)
+    assert 'ac_power' in mock_create_fx.call_args[0][2]
+    assert 'dc_power' in mock_create_fx.call_args[0][2]
+
+    regular_site_dict = test_site_dict.copy()
+    regular_site_dict.pop('modeling_parameters')
+    reg_site = Site.from_dict(regular_site_dict)
+    srml.initialize_site_forecasts(mock_api, reg_site)
+    assert 'ac_power' not in mock_create_fx.call_args[0][2]
+    assert 'dc_power' not in mock_create_fx.call_args[0][2]

--- a/solarforecastarbiter/reference_forecasts/main.py
+++ b/solarforecastarbiter/reference_forecasts/main.py
@@ -231,6 +231,7 @@ def run_persistence(session, observation, forecast, run_time, issue_time,
     to look more similar to the previous Monday that it does to the previous
     day (Sunday).
     """
+    utils.check_persistence_compatibility(observation, forecast, index)
     forecast_start, forecast_end = utils.get_forecast_start_end(
         forecast, issue_time, False)
     intraday = utils._is_intraday(forecast)

--- a/solarforecastarbiter/reference_forecasts/main.py
+++ b/solarforecastarbiter/reference_forecasts/main.py
@@ -261,7 +261,7 @@ def run_persistence(session, observation, forecast, run_time, issue_time,
         fx = persistence.persistence_interval(
             observation, data_start, data_end, forecast_start,
             forecast.interval_length, forecast.interval_label, load_data)
-    else:
+    else:  # pragma: no cover
         raise ValueError(
             'index=True not supported for forecasts with run_length >= 1day')
 

--- a/solarforecastarbiter/reference_forecasts/main.py
+++ b/solarforecastarbiter/reference_forecasts/main.py
@@ -602,6 +602,10 @@ def make_latest_persistence_forecasts(token, max_run_time, base_url=None):
         run_time = issue_time
         logger.info('Making persistence forecast for %s:%s at %s',
                     fx.name, fx.forecast_id, issue_time)
-        fx_ser = run_persistence(session, obs, fx, run_time, issue_time,
-                                 index=index)
-        session.post_forecast_values(fx.forecast_id, fx_ser)
+        try:
+            fx_ser = run_persistence(session, obs, fx, run_time, issue_time,
+                                     index=index)
+        except ValueError as e:
+            logger.error('Unable to generate persistence forecast: %s', e)
+        else:
+            session.post_forecast_values(fx.forecast_id, fx_ser)

--- a/solarforecastarbiter/reference_forecasts/tests/test_fx_utils.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_fx_utils.py
@@ -433,3 +433,45 @@ def test_find_next_issue_time_from_last_forecast(fxargs, last_time, expected,
     fx = default_forecast(site_metadata, **fxargs)
     out = utils.find_next_issue_time_from_last_forecast(fx, last_time)
     assert out == expected
+
+
+@pytest.mark.parametrize('obs_kw,fx_kw,index', [
+    pytest.param(dict(), dict(), False,
+                 marks=pytest.mark.xfail(strict=True)),
+    pytest.param(dict(), dict(), True,
+                 marks=pytest.mark.xfail(strict=True)),
+    # obs too long
+    (dict(interval_length=pd.Timedelta('2h')), dict(), True),
+    (dict(interval_length=pd.Timedelta('2h')), dict(), False),
+    # short fx runs
+    (dict(), dict(run_length=pd.Timedelta('15min')), True),
+    (dict(), dict(run_length=pd.Timedelta('15min')), False),
+    # day forecast index
+    (dict(), dict(run_length=pd.Timedelta('24h')), True),
+    pytest.param(dict(), dict(run_length=pd.Timedelta('24h')), False,
+                 marks=pytest.mark.xfail(strict=True)),
+    # non-instant obs
+    (dict(), dict(interval_label='instantaneous'), True),
+    (dict(), dict(interval_label='instantaneous'), False),
+    # instant, but mismatch length
+    (dict(interval_label='instantaneous'),
+     dict(interval_label='instantaneous'),
+     True),
+    (dict(interval_label='instantaneous'),
+     dict(interval_label='instantaneous'),
+     False),
+])
+def test_check_persistence_compatibility(obs_kw, fx_kw, index, site_metadata):
+    obs_dict = {'interval_label': 'ending',
+                'interval_value_type': 'interval_mean',
+                'interval_length': pd.Timedelta('30min')}
+    fx_dict = {'interval_label': 'ending',
+               'interval_value_type': 'interval_mean',
+               'interval_length': pd.Timedelta('1h'),
+               'run_length': pd.Timedelta('12h')}
+    obs_dict.update(obs_kw)
+    fx_dict.update(fx_kw)
+    obs = default_observation(site_metadata, **obs_dict)
+    fx = default_forecast(site_metadata, **fx_dict)
+    with pytest.raises(ValueError):
+        utils.check_persistence_compatibility(obs, fx, index)

--- a/solarforecastarbiter/reference_forecasts/tests/test_fx_utils.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_fx_utils.py
@@ -440,10 +440,12 @@ def test_find_next_issue_time_from_last_forecast(fxargs, last_time, expected,
                  marks=pytest.mark.xfail(strict=True)),
     pytest.param(dict(), dict(), True,
                  marks=pytest.mark.xfail(strict=True)),
-    # obs too long
-    (dict(interval_length=pd.Timedelta('2h')), dict(), True),
-    (dict(interval_length=pd.Timedelta('2h')), dict(), False),
-    # short fx runs
+    # obs interval length > 1h too long
+    (dict(interval_length=pd.Timedelta('2h')),
+     dict(interval_length=pd.Timedelta('4h')), True),
+    (dict(interval_length=pd.Timedelta('2h')),
+     dict(interval_length=pd.Timedelta('4h')), False),
+    # fx run_length < obs interval length
     (dict(), dict(run_length=pd.Timedelta('15min')), True),
     (dict(), dict(run_length=pd.Timedelta('15min')), False),
     # day forecast index

--- a/solarforecastarbiter/reference_forecasts/tests/test_main.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_main.py
@@ -987,6 +987,9 @@ def test_make_latest_persistence_forecasts(mocker, perst_fx_obs):
 
 
 def test_make_latest_persistence_forecasts_some_errors(mocker, perst_fx_obs):
+    # test that some persistence forecast parameters are invalid for the
+    # observation and that no peristence values are posted
+    # and tests that the creation_validation works as expected
     forecasts, observations = perst_fx_obs
     forecasts += [forecasts[0].replace(
         extra_parameters=(forecasts[0].extra_parameters[:-1] +


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #472  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
adds a check_persistence_compatibility function to see if a persistence forecast can be made from a forecast observation pair and then uses this function before creating reference persistence forecasts