### PR TITLE
io/api: document use of proxy servers and SSL certificates

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -317,6 +317,10 @@ files with site and observation metadata.
 SFA API
 =======
 
+To pass API calls through a proxy server, set either the HTTP_PROXY or
+HTTPS_PROXY environment variable. If necessary, set a SSL certificate using the
+REQUESTS_CA_BUNDLE environment variable.
+
 Token
 -----
 

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -56,6 +56,21 @@ class APISession(requests.Session):
         server.
     base_url : string
         URL to use as the base for endpoints to APISession
+
+    Notes
+    -----
+    To pass the API calls through a proxy server, set either the HTTP_PROXY or
+    HTTPS_PROXY environment variable. If necessary, you can also specify a SSL
+    certificate using the REQUESTS_CA_BUNDLE environment variable. For example,
+    on a Linux machine:
+
+    >>> export HTTPS_PROXY=https://some_corporate_proxy.com:8080
+    >>> export REQUESTS_CA_BUNDLE=/path/to/certificates/cert.crt
+    >>> python script_that_calls_api.py
+
+    For more information, see the "Advanced Usage" documentation for the
+    requests package: https://requests.readthedocs.io/en/master/user/advanced/
+
     """
 
     def __init__(self, access_token, default_timeout=(10, 60),


### PR DESCRIPTION
  - [x] Closes #474 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This PR adds documentation of how to pass API calls through a proxy server and how to specify a SSL certificate. This documentation is targeted at the (possibly few) users who are running the Solar Arbiter inside a restricted network that requires passing all HTTP/HTTPS outbound requests via a proxy server. Depending on the specifics of the network and their machine, they may need to specify the proxy server and/or SSL certificate in order to, e.g., push forecast data to the Solar Arbiter dashboard for a forecast trial.
