### PR TITLE
Add default daily validation and always re-validate observations in a report

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -662,9 +662,13 @@ Perform a sequence of validation steps. Used by the API to initiate validation.
    validation.tasks.validate_daily_ghi
    validation.tasks.validate_daily_dc_power
    validation.tasks.validate_daily_ac_power
+   validation.tasks.validate_daily_defaults
    validation.tasks.immediate_observation_validation
    validation.tasks.daily_single_observation_validation
    validation.tasks.daily_observation_validation
+   validation.tasks.apply_immediate_validation
+   validation.tasks.apply_daily_validation
+   validation.tasks.apply_validation
 
 
 Quality flag mapping

--- a/docs/source/whatsnew/1.0.0rc1.rst
+++ b/docs/source/whatsnew/1.0.0rc1.rst
@@ -11,10 +11,20 @@ API Changes
 * Added :py:func:`solarforecastarbiter.reference_forecasts.utils.check_persistence_compatibility`
   to check if a pair of Forecast and Observation objects are compatible for
   making a persistence forecast (:pull:`478`)
+* Added :py:func:`solarforecastarbiter.validation.tasks.validate_daily_defaults`
+  to validate all observations using the immediate validation function
+  along with stale and interpolated flags (:pull:`482`) (:issue:`453`)
+* Added :py:func:`solarforecastarbiter.validation.tasks.apply_immediate_validation`,
+  :py:func:`solarforecastarbiter.validation.tasks.apply_daily_validation`,
+  and :py:func:`solarforecastarbiter.validation.tasks.apply_validation`
+  convience functions (:pull:`482`)
+
 
 Enhancements
 ~~~~~~~~~~~~
 * Support parsing of Site climate zones from the API (:pull:`481`)
+* Reapply validation to Observation data when fetched for a Report
+  (:issue:`376`) (:pull:`482`)
 
 
 Bug fixes

--- a/solarforecastarbiter/reports/main.py
+++ b/solarforecastarbiter/reports/main.py
@@ -61,6 +61,7 @@ from solarforecastarbiter import datamodel
 from solarforecastarbiter.metrics import preprocessing, calculator
 from solarforecastarbiter.reports.figures import plotly_figures
 from solarforecastarbiter.utils import hijack_loggers
+from solarforecastarbiter.validation.tasks import apply_validation
 
 
 def get_data_for_report(session, report):
@@ -95,8 +96,15 @@ def get_data_for_report(session, report):
             data[fxobs.forecast] = session.get_values(
                 fxobs.forecast, start, end)
         if fxobs.data_object not in data:
-            data[fxobs.data_object] = session.get_values(
+            obs_data = session.get_values(
                 fxobs.data_object, start, end)
+            if isinstance(
+                    fxobs.data_object, datamodel.Aggregate):
+                data[fxobs.data_object] = obs_data
+            else:
+                validated_obs_data = apply_validation(
+                    fxobs.data_object, obs_data)
+                data[fxobs.data_object] = validated_obs_data
         if fxobs.reference_forecast is not None:
             if fxobs.reference_forecast not in data:
                 data[fxobs.reference_forecast] = session.get_values(

--- a/solarforecastarbiter/reports/main.py
+++ b/solarforecastarbiter/reports/main.py
@@ -98,13 +98,8 @@ def get_data_for_report(session, report):
         if fxobs.data_object not in data:
             obs_data = session.get_values(
                 fxobs.data_object, start, end)
-            if isinstance(
-                    fxobs.data_object, datamodel.Aggregate):
-                data[fxobs.data_object] = obs_data
-            else:
-                validated_obs_data = apply_validation(
-                    fxobs.data_object, obs_data)
-                data[fxobs.data_object] = validated_obs_data
+            data[fxobs.data_object] = apply_validation(
+                fxobs.data_object, obs_data)
         if fxobs.reference_forecast is not None:
             if fxobs.reference_forecast not in data:
                 data[fxobs.reference_forecast] = session.get_values(

--- a/solarforecastarbiter/reports/tests/test_reports_main.py
+++ b/solarforecastarbiter/reports/tests/test_reports_main.py
@@ -61,11 +61,13 @@ def mock_data(mocker, _test_data):
     return get_forecast_values, get_observation_values, get_aggregate_values
 
 
-def test_get_data_for_report(mock_data, report_objects):
+def test_get_data_for_report(mock_data, report_objects, mocker):
     report, observation, forecast_0, forecast_1, aggregate, forecast_agg = \
         report_objects
     session = api.APISession('nope')
+    apply_obs = mocker.spy(main, 'apply_validation')
     data = main.get_data_for_report(session, report)
+    assert apply_obs.call_count == 1  # only for observation
     assert isinstance(data[observation], pd.DataFrame)
     assert isinstance(data[forecast_0], pd.Series)
     assert isinstance(data[forecast_1], pd.Series)

--- a/solarforecastarbiter/reports/tests/test_reports_main.py
+++ b/solarforecastarbiter/reports/tests/test_reports_main.py
@@ -67,7 +67,7 @@ def test_get_data_for_report(mock_data, report_objects, mocker):
     session = api.APISession('nope')
     apply_obs = mocker.spy(main, 'apply_validation')
     data = main.get_data_for_report(session, report)
-    assert apply_obs.call_count == 1  # only for observation
+    assert apply_obs.call_count == 2
     assert isinstance(data[observation], pd.DataFrame)
     assert isinstance(data[forecast_0], pd.Series)
     assert isinstance(data[forecast_1], pd.Series)

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -413,9 +413,9 @@ def validate_daily_defaults(observation, values):
     """
     Run default daily validation checks on an observation.
     Applies the validation for the observation's variable and then
-    the stale and interpolated validation. If the variable does
-    not have a defined validation function :py:func:`validate_defaults`
-    is used.
+    the stale and interpolated validation. :py:func:`validate_defaults`
+    is used if the Observation variable does not have a defined validation
+    function.
 
     Parameters
     ----------

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -5,7 +5,7 @@ import pandas as pd
 from pvlib.irradiance import get_extra_radiation
 
 
-from solarforecastarbiter import pvmodel
+from solarforecastarbiter import pvmodel, datamodel
 from solarforecastarbiter.io.api import APISession
 from solarforecastarbiter.validation import validator, quality_mapping
 
@@ -618,7 +618,9 @@ def daily_observation_validation(access_token, start, end, base_url=None):
 def apply_validation(observation, observation_values):
     """
     Applies the appropriate daily or immediate validation functions to the
-    observation_values depending on the length of the data.
+    observation_values depending on the length of the data. If an Aggregate
+    object is passed, a warning is logged and the observation_values are
+    returned.
 
     Parameters
     ----------
@@ -638,6 +640,9 @@ def apply_validation(observation, observation_values):
         If the supplied observations_values is not a DataFrame with a
         DatetimeIndex
     """
+    if isinstance(observation, datamodel.Aggregate):
+        logger.warning('Cannot apply validation to an Aggregate')
+        return observation_values
     data = observation_values.sort_index()
     if (
             not isinstance(data, pd.DataFrame) or

--- a/solarforecastarbiter/validation/tests/test_validation_tasks.py
+++ b/solarforecastarbiter/validation/tests/test_validation_tasks.py
@@ -1329,3 +1329,11 @@ def test_apply_validation_bad_df(make_observation, mocker):
         tasks.apply_validation(obs, pd.Series(
             index=pd.DatetimeIndex([]),
             dtype=float))
+
+
+def test_apply_validation_agg(aggregate, mocker):
+    data = pd.DataFrame({'value': [1], 'quality_flag': [0]},
+                        index=pd.DatetimeIndex(
+                            ['2020-01-01T00:00Z'], name='timestamp'))
+    out = tasks.apply_validation(aggregate, data)
+    assert_frame_equal(data, out)

--- a/solarforecastarbiter/validation/tests/test_validation_tasks.py
+++ b/solarforecastarbiter/validation/tests/test_validation_tasks.py
@@ -104,6 +104,29 @@ def test_validate_mostly_clear(mocker, make_observation):
                             check_names=False)
 
 
+def test_apply_immediate_validation(
+        mocker, make_observation, default_index):
+    obs = make_observation('ghi')
+    data = pd.DataFrame(
+        [(0, 0), (100, 0), (200, 0), (-1, 1), (1500, 0)],
+        index=default_index,
+        columns=['value', 'quality_flag'])
+
+    val = tasks.apply_immediate_validation(obs, data)
+
+    out = data.copy()
+    out['quality_flag'] = [
+        DESCRIPTION_MASK_MAPPING['NIGHTTIME'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['OK'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['USER FLAGGED'] | LATEST_VERSION_FLAG,
+        DESCRIPTION_MASK_MAPPING['UNEVEN FREQUENCY'] | LATEST_VERSION_FLAG |
+        DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'] |
+        DESCRIPTION_MASK_MAPPING['CLEARSKY EXCEEDED']
+    ]
+    assert_frame_equal(val, out)
+
+
 def test_immediate_observation_validation_ghi(mocker, make_observation,
                                               default_index):
     obs = make_observation('ghi')
@@ -1022,6 +1045,54 @@ def test_daily_observation_validation_other(var, mocker, make_observation,
     assert validate_mock.called
 
 
+def test_apply_daily_validation(mocker, make_observation, daily_index):
+    obs = make_observation('ac_power')
+    data = pd.DataFrame({
+        'value': [
+            # 8     9     10   11   12  13    14   15  16  17  18  19  23
+            0, 100, -100, 100, 300, 300, 300, 300, 100, 0, 100, 0, 0],
+        'quality_flag': 0},
+        index=daily_index)
+
+    out = tasks.apply_daily_validation(obs, data)
+    qf = (pd.Series(LATEST_VERSION_FLAG, index=data.index),
+          pd.Series([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+                    index=data.index) *
+          DESCRIPTION_MASK_MAPPING['UNEVEN FREQUENCY'],
+          pd.Series([1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
+                    index=data.index) *
+          DESCRIPTION_MASK_MAPPING['NIGHTTIME'],
+          pd.Series([0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0],
+                    index=data.index) *
+          DESCRIPTION_MASK_MAPPING['LIMITS EXCEEDED'],
+          pd.Series([0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0],
+                    index=data.index) *
+          DESCRIPTION_MASK_MAPPING['STALE VALUES'],
+          pd.Series([0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0],
+                    index=data.index) *
+          DESCRIPTION_MASK_MAPPING['INTERPOLATED VALUES'],
+          pd.Series([0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0],
+                    index=data.index) *
+          DESCRIPTION_MASK_MAPPING['CLIPPED VALUES']
+          )
+    exp = data.copy()
+    exp['quality_flag'] = sum(qf)
+    assert_frame_equal(exp, out)
+
+
+def test_apply_daily_validation_not_enough(mocker, make_observation):
+    obs = make_observation('ghi')
+    data = pd.DataFrame(
+        [(0, 0)],
+        index=pd.date_range(start='2019-01-01T0000Z',
+                            end='2019-01-01T0100Z',
+                            tz='UTC',
+                            freq='1h'),
+        columns=['value', 'quality_flag'])
+    with pytest.raises(IndexError):
+        tasks.apply_daily_validation(obs, data)
+
+
 def test_daily_observation_validation_many(mocker, make_observation,
                                            daily_index):
     obs = [make_observation('dhi'), make_observation('dni')]
@@ -1143,3 +1214,47 @@ def test__group_continuous_week_post(mocker, make_observation):
     assert len(call_list) == 4
     for i, cal in enumerate(call_list):
         assert_frame_equal(split_dfs[i], cal[0][1])
+
+
+@pytest.mark.parametrize('vals,func', [
+    (pd.DataFrame({'value': 0, 'quality_flag': 4}, index=pd.DatetimeIndex(
+        [pd.Timestamp.utcnow()], name='timestamp')),
+     'apply_immediate_validation'),
+    (pd.DataFrame({'value': [0.0] * 5 + [None] * 10, 'quality_flag': 4},
+                  index=pd.date_range('now', name='timestamp', freq='2h',
+                                      periods=15)),
+     'apply_immediate_validation'),
+    (pd.DataFrame({'value': [0.0] * 15 + [None] * 11, 'quality_flag': 4},
+                  index=pd.date_range('now', name='timestamp', freq='1h',
+                                      periods=26)),
+     'apply_daily_validation'),
+])
+def test_apply_validation(make_observation, mocker, vals, func):
+    obs = make_observation('ac_power')
+    fmock = mocker.patch.object(tasks, func, autospec=True)
+    tasks.apply_validation(obs, vals)
+    assert fmock.called
+
+
+def test_apply_validation_empty(make_observation, mocker):
+    obs = make_observation('dhi')
+    daily = mocker.patch.object(tasks, 'apply_daily_validation')
+    immediate = mocker.patch.object(tasks, 'apply_immediate_validation')
+    data = pd.DataFrame({'value': [], 'quality_flag': []},
+                        index=pd.DatetimeIndex([], name='timestamp'))
+    out = tasks.apply_validation(obs, data)
+    assert_frame_equal(out, data)
+    assert not daily.called
+    assert not immediate.called
+
+
+def test_apply_validation_bad_df(make_observation, mocker):
+    obs = make_observation('dhi')
+    data = pd.DataFrame()
+    with pytest.raises(TypeError):
+        tasks.apply_validation(obs, data)
+
+    with pytest.raises(TypeError):
+        tasks.apply_validation(obs, pd.Series(
+            index=pd.DatetimeIndex([]),
+            dtype=float))


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #453 closes #376 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
This does not add the various `validate_daily_{variable}` functions, but instead relies on using whatever immediat function is available and adding the stale and interpolated flags.