### PR TITLE
handle serialization/deserialization for prob fx dataframes

### DIFF
--- a/docs/source/whatsnew/1.0.0rc1.rst
+++ b/docs/source/whatsnew/1.0.0rc1.rst
@@ -55,6 +55,15 @@ API Changes
 * Removed :py:mod:`solarforecastarbiter.metrics.valuation` (:pull:`487`)
 * Add :py:func:`solarforecastarbiter.reference_forecasts.make_latest_probabilistic_persistence_forecasts`
   to generate reference probabilistic persistence forecasts (:pull:`490`)
+* :py:func:`solarforecastarbiter.io.api.get_probabilistic_forecast_values`
+  now returns a DataFrame with string column names. It previously returned a
+  DataFrame with floats for column names. For example, if the columns were
+  previously described by ``Float64Index([25.0, 50.0, 75.0], dtype='float64')``
+  they are now described by ``Index(['25.0', '50.0', '75.0'], dtype='object')``.
+  (:pull:`496`)
+* :py:func:`solarforecastarbiter.io.utils.serialize_timeseries` and
+  :py:func:`solarforecastarbiter.io.utils.deserialize_timeseries` can now
+  handle DataFrames in addition to Series. (:issue:`495`, :pull:`496`)
 
 
 Enhancements

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -266,9 +266,9 @@ b"""
 @pytest.fixture()
 def prob_forecast_values():
     return pd.DataFrame(
-        {'25': [0.0, 1, 2, 3, 4, 5],
-         '50': [1.0, 2, 3, 4, 5, 6],
-         '75': [2.0, 3, 4, 5, 6, 7]},
+        {'25.0': [0.0, 1, 2, 3, 4, 5],
+         '50.0': [1.0, 2, 3, 4, 5, 6],
+         '75.0': [2.0, 3, 4, 5, 6, 7]},
         index=pd.date_range(start='20190101T0600',
                             end='20190101T1100',
                             freq='1h',
@@ -2019,9 +2019,9 @@ def cdf_and_cv_report_data(cdf_and_cv_report_objects):
                                             freq='1min',
                                             tz='MST',
                                             name='timestamp'))
-    cdf_fx_df = pd.DataFrame({25.: np.arange(periods_1min/60),
-                              50.: np.arange(periods_1min/60)+1,
-                              75.: np.arange(periods_1min/60)+2},
+    cdf_fx_df = pd.DataFrame({'25.0': np.arange(periods_1min/60),
+                              '50.0': np.arange(periods_1min/60)+1,
+                              '75.0': np.arange(periods_1min/60)+2},
                              index=pd.date_range(start='2020-04-01T00:00:00',
                                                  periods=periods_1min/60,
                                                  freq='60min',
@@ -2039,10 +2039,10 @@ def cdf_and_cv_report_data(cdf_and_cv_report_objects):
         cdf_forecast_1: cdf_fx_df,
         cdf_forecast_agg: cdf_fx_df,
         cdf_forecast_ref: cdf_fx_df,
-        cv_forecast_0: cdf_fx_df[25.],
-        cv_forecast_1: cdf_fx_df[50.],
-        cv_forecast_agg: cdf_fx_df[75.],
-        cv_forecast_ref: cdf_fx_df[50.]
+        cv_forecast_0: cdf_fx_df['25.0'],
+        cv_forecast_1: cdf_fx_df['50.0'],
+        cv_forecast_agg: cdf_fx_df['75.0'],
+        cv_forecast_ref: cdf_fx_df['50.0']
     }
     return data
 
@@ -2260,14 +2260,14 @@ def cdf_and_cv_report_data_xy(cdf_and_cv_report_objects_xy):
         tz='MST',
         name='timestamp')
     cdf_fx_y_df = pd.DataFrame({
-        25.: np.arange(periods_1h),
-        50.: np.arange(periods_1h)+1,
-        75.: np.arange(periods_1h)+2},
+        '25.0': np.arange(periods_1h),
+        '50.0': np.arange(periods_1h)+1,
+        '75.0': np.arange(periods_1h)+2},
         index=hourly_index)
     cdf_fx_x_df = pd.DataFrame({
-        250.: np.arange(periods_1h),
-        500.: np.arange(periods_1h)+1,
-        750.: np.arange(periods_1h)+2},
+        '250.0': np.arange(periods_1h),
+        '500.0': np.arange(periods_1h)+1,
+        '750.0': np.arange(periods_1h)+2},
         index=hourly_index)
     obs_df = obs_ser.to_frame('value')
     obs_df['quality_flag'] = OK
@@ -2281,10 +2281,10 @@ def cdf_and_cv_report_data_xy(cdf_and_cv_report_objects_xy):
         cdf_forecast_1: cdf_fx_x_df,
         cdf_forecast_agg: cdf_fx_x_df,
         cdf_forecast_ref: cdf_fx_x_df,
-        cv_forecast_0: cdf_fx_y_df[25.],
-        cv_forecast_1: cdf_fx_y_df[50.],
-        cv_forecast_agg: cdf_fx_x_df[750.],
-        cv_forecast_ref: cdf_fx_x_df[500.]
+        cv_forecast_0: cdf_fx_y_df['25.0'],
+        cv_forecast_1: cdf_fx_y_df['50.0'],
+        cv_forecast_agg: cdf_fx_x_df['750.0'],
+        cv_forecast_ref: cdf_fx_x_df['500.0']
     }
     return data
 

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1728,6 +1728,25 @@ def report_objects(aggregate, ref_forecast_id):
     return report, observation, forecast_0, forecast_1, aggregate, forecast_agg
 
 
+@pytest.fixture
+def report_data(report_objects):
+    index = pd.date_range(
+        start="2019-04-01T00:00:00Z", end="2019-04-04T23:59:00Z",
+        freq='1h')
+    data = pd.Series(1., index=index)
+    obs = pd.DataFrame({'value': data, 'quality_flag': 2})
+    ref_fx = \
+        report_objects[0].report_parameters.object_pairs[1].reference_forecast
+    data = {
+        report_objects[2]: data,
+        report_objects[3]: data,
+        ref_fx: data,
+        report_objects[1]: obs,
+        report_objects[4]: obs,
+        report_objects[5]: data}
+    return data
+
+
 @pytest.fixture()
 def event_report_objects():
     tz = 'America/Phoenix'
@@ -2268,6 +2287,17 @@ def cdf_and_cv_report_data_xy(cdf_and_cv_report_objects_xy):
         cv_forecast_ref: cdf_fx_x_df[500.]
     }
     return data
+
+
+@pytest.fixture(params=['deterministic', 'prob_xy'])
+def various_report_objects_data(
+        report_objects, report_data,
+        cdf_and_cv_report_objects_xy, cdf_and_cv_report_data_xy,
+        request):
+    if request.param == 'deterministic':
+        return report_objects, report_data
+    elif request.param == 'prob_xy':
+        return cdf_and_cv_report_objects_xy, cdf_and_cv_report_data_xy
 
 
 @pytest.fixture()

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -782,9 +782,10 @@ class APISession(requests.Session):
         df_dict = {}
         prob_fx = self.get_probabilistic_forecast(forecast_id)
         for cv in prob_fx.constant_values:
-            df_dict[cv.constant_value] = self.get_probabilistic_forecast_constant_value_values(  # NOQA
-                forecast_id=cv.forecast_id, start=start, end=end,
-                interval_label=interval_label)
+            df_dict[str(cv.constant_value)] = \
+                self.get_probabilistic_forecast_constant_value_values(
+                    forecast_id=cv.forecast_id, start=start, end=end,
+                    interval_label=interval_label)
         return pd.DataFrame(df_dict)
 
     def post_observation_values(self, observation_id, observation_df,

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -567,12 +567,8 @@ def test_apisession_get_prob_forecast_constant_value_values(
     pdt.assert_series_equal(out, forecast_values)
 
 
-def _df_with_float64_columns(df):
-    df.columns = df.columns.astype(float)
-    return df
-
-
-@pytest.mark.parametrize('col_values', [['25', '50', '75'], [25., 50., 75.]])
+@pytest.mark.parametrize('col_values', [
+    ['25.0', '50.0', '75.0'], [25., 50., 75.]])
 def test_apisession_get_prob_forecast_values(
         requests_mock, mock_get_site, col_values,
         prob_forecast_values, prob_forecast_values_text_list,
@@ -588,7 +584,7 @@ def test_apisession_get_prob_forecast_values(
     for col in col_values:
         new_cv = copy.deepcopy(cvs_json)
         new_cv['constant_value'] = col
-        new_cv['forecast_id'] = 'CV' + str(int(col))
+        new_cv['forecast_id'] = 'CV' + str(int(float(col)))
         new_cv['axis'] = 'y'
         cvs.append(new_cv)
     probfx_json['constant_values'] = cvs
@@ -606,8 +602,6 @@ def test_apisession_get_prob_forecast_values(
         requests_mock.register_uri(
             'GET', f'/forecasts/cdf/single/{id}/values', content=cvv)
     out = session.get_probabilistic_forecast_values('', *fx_start_end)
-    if not isinstance(col_values[0], str):
-        prob_forecast_values = _df_with_float64_columns(prob_forecast_values)
     pdt.assert_frame_equal(out, prob_forecast_values)
 
 

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -584,6 +584,10 @@ def test_apisession_get_prob_forecast_values(
     for col in col_values:
         new_cv = copy.deepcopy(cvs_json)
         new_cv['constant_value'] = col
+        # fixture has keys like CV25
+        # we need to convert either float 25. or str '25.0' to int 25
+        # str(25.) == '25.0', int('25.0') raises ValueError, so we have
+        # to chain it all together
         new_cv['forecast_id'] = 'CV' + str(int(float(col)))
         new_cv['axis'] = 'y'
         cvs.append(new_cv)

--- a/solarforecastarbiter/io/tests/test_io_utils.py
+++ b/solarforecastarbiter/io/tests/test_io_utils.py
@@ -20,6 +20,19 @@ EMPTY_SERIES = pd.Series(dtype=float)
 EMPTY_TIMESERIES = pd.Series([], name='value', index=pd.DatetimeIndex(
     [], name='timestamp', tz='UTC'), dtype=float)
 
+EMPTY_DATAFRAME = pd.DataFrame(dtype=float)
+EMPTY_TIME_DATAFRAME = pd.DataFrame([], index=pd.DatetimeIndex(
+    [], name='timestamp', tz='UTC'), dtype=float)
+TEST_DATAFRAME = pd.DataFrame({
+    '25.0': [0.0, 1, 2, 3, 4, 5],
+    '50.0': [1.0, 2, 3, 4, 5, 6],
+    '75.0': [2.0, 3, 4, 5, 6, 7]},
+    index=pd.date_range(start='20190101T0600',
+                        end='20190101T1100',
+                        freq='1h',
+                        tz='America/Denver',
+                        name='timestamp')).tz_convert('UTC')
+
 
 @pytest.mark.parametrize('dump_quality,default_flag,flag_value', [
     (False, None, 1),
@@ -216,7 +229,9 @@ def test_adjust_timeseries_for_interval_label_series(label, exp):
         pytest.mark.xfail(strict=True, type=TypeError)]),
     pytest.param(pd.Series([], dtype=float, index=pd.DatetimeIndex([])),
                  marks=[pytest.mark.xfail(strict=True, type=TypeError)]),
-    pytest.param(TEST_DATA, marks=[
+    TEST_DATAFRAME,
+    EMPTY_TIME_DATAFRAME,
+    pytest.param(EMPTY_DATAFRAME, marks=[
         pytest.mark.xfail(strict=True, type=TypeError)]),
 ])
 def test_serialize_timeseries(ser):
@@ -263,16 +278,49 @@ def test_serialize_timeseries(ser):
         '{"schema": {"version": 0, "timezone": "UTC", "column": "value", "index": "timestamp", "dtype": "float64"}, "data": []}',  # NOQA
         EMPTY_SERIES,
         marks=[pytest.mark.xfail(strict=True, type=KeyError)]),
+    ('{"schema": {"version": 1, "objtype": "Series", "orient": "records", "timezone": "UTC", "column": "value", "index": "timestamp", "dtype": "float64"}, "data": []}',  # NOQA
+     EMPTY_TIMESERIES)
 ])
 def test_deserialize_timeseries(inp, exp):
     out = utils.deserialize_timeseries(inp)
     pdt.assert_series_equal(out, exp)
 
 
+@pytest.mark.parametrize('inp,exp', [
+    ('{"schema": {"version": 1, "objtype": "DataFrame", "orient": "records", "timezone": "UTC", "column": [], "index": "timestamp", "dtype": ["float64"]}, "data": []}',  # NOQA
+     EMPTY_TIME_DATAFRAME),
+    ('{"schema": {"version": 1, "objtype": "DataFrame", "orient": "records", "timezone": "UTC", "column": ["25.0"], "index": "timestamp", "dtype": ["float64"]}, "data": [{"timestamp": "2019-01-01T00:00:00", "25.0": 1.0}], "other_stuff": {}}',  # NOQA
+     pd.DataFrame({'25.0': 1.0}, index=pd.DatetimeIndex(
+         ["2019-01-01T00:00:00"], tz='UTC', name='timestamp'))),
+    ('{"schema": {"version": 1, "objtype": "DataFrame", "orient": "records", "timezone": "Etc/GMT+8", "column": ["25.0"], "index": "timestamp", "dtype": ["float64"]}, "data": [{"timestamp": "2019-01-01T00:00:00", "25.0": 1.0}], "other_stuff": {}}',  # NOQA
+     pd.DataFrame({'25.0': 1.0}, index=pd.DatetimeIndex(
+         ["2019-01-01T00:00:00"], tz='Etc/GMT+8', name='timestamp'))),
+])
+def test_deserialize_timeseries_frame(inp, exp):
+    out = utils.deserialize_timeseries(inp)
+    pdt.assert_frame_equal(out, exp)
+
+
 def test_serialize_roundtrip():
     ser = utils.serialize_timeseries(TEST_DATA['value'])
     out = utils.deserialize_timeseries(ser)
     pdt.assert_series_equal(out, TEST_DATA['value'])
+
+
+# use the conftest.py dataframe for security against refactoring
+def test_serialize_roundtrip_frame(prob_forecast_values):
+    ser = utils.serialize_timeseries(prob_forecast_values)
+    out = utils.deserialize_timeseries(ser)
+    pdt.assert_frame_equal(out, prob_forecast_values)
+
+
+def test_serialize_roundtrip_frame_floats(prob_forecast_values):
+    # check that roundtrip is not faithful if input columns is Float64Index
+    prob_forecast_floats = prob_forecast_values.copy()
+    prob_forecast_floats.columns = prob_forecast_floats.columns.astype(float)
+    ser = utils.serialize_timeseries(prob_forecast_floats)
+    out = utils.deserialize_timeseries(ser)
+    pdt.assert_frame_equal(out, prob_forecast_values)
 
 
 def test_hidden_token():

--- a/solarforecastarbiter/io/tests/test_io_utils.py
+++ b/solarforecastarbiter/io/tests/test_io_utils.py
@@ -222,23 +222,24 @@ def test_adjust_timeseries_for_interval_label_series(label, exp):
     pdt.assert_series_equal(exp, out)
 
 
-@pytest.mark.parametrize('ser', [
-    TEST_DATA['value'],
-    EMPTY_TIMESERIES,
-    pytest.param(EMPTY_SERIES, marks=[
+@pytest.mark.parametrize('inp,exp', [
+    (TEST_DATA['value'], '{"schema":{"version": 1, "orient": "records", "timezone": "UTC", "column": "value", "index": "timestamp", "dtype": "float64", "objtype": "Series"},"data":[{"timestamp":"2019-01-24T00:00:00Z","value":2.0},{"timestamp":"2019-01-24T00:01:00Z","value":43.9},{"timestamp":"2019-01-24T00:02:00Z","value":338.0},{"timestamp":"2019-01-24T00:03:00Z","value":-199.7},{"timestamp":"2019-01-24T00:04:00Z","value":0.32}]}'),  # NOQA: E501
+    (EMPTY_TIMESERIES, '{"schema":{"version": 1, "orient": "records", "timezone": "UTC", "column": "value", "index": "timestamp", "dtype": "float64", "objtype": "Series"},"data":[]}'),  # NOQA: E501
+    pytest.param(EMPTY_SERIES, '', marks=[
         pytest.mark.xfail(strict=True, type=TypeError)]),
-    pytest.param(pd.Series([], dtype=float, index=pd.DatetimeIndex([])),
+    pytest.param(pd.Series([], dtype=float, index=pd.DatetimeIndex([])), '',
                  marks=[pytest.mark.xfail(strict=True, type=TypeError)]),
-    TEST_DATAFRAME,
-    EMPTY_TIME_DATAFRAME,
-    pytest.param(EMPTY_DATAFRAME, marks=[
+    (TEST_DATAFRAME, '{"schema":{"version": 1, "orient": "records", "timezone": "UTC", "column": ["25.0", "50.0", "75.0"], "index": "timestamp", "dtype": ["float64", "float64", "float64"], "objtype": "DataFrame"},"data":[{"timestamp":"2019-01-01T13:00:00Z","25.0":0.0,"50.0":1.0,"75.0":2.0},{"timestamp":"2019-01-01T14:00:00Z","25.0":1.0,"50.0":2.0,"75.0":3.0},{"timestamp":"2019-01-01T15:00:00Z","25.0":2.0,"50.0":3.0,"75.0":4.0},{"timestamp":"2019-01-01T16:00:00Z","25.0":3.0,"50.0":4.0,"75.0":5.0},{"timestamp":"2019-01-01T17:00:00Z","25.0":4.0,"50.0":5.0,"75.0":6.0},{"timestamp":"2019-01-01T18:00:00Z","25.0":5.0,"50.0":6.0,"75.0":7.0}]}'),  # NOQA: E501
+    (EMPTY_TIME_DATAFRAME, '{"schema":{"version": 1, "orient": "records", "timezone": "UTC", "column": [], "index": "timestamp", "dtype": [], "objtype": "DataFrame"},"data":[]}'),  # NOQA: E501
+    pytest.param(EMPTY_DATAFRAME, '', marks=[
         pytest.mark.xfail(strict=True, type=TypeError)]),
 ])
-def test_serialize_timeseries(ser):
-    out = utils.serialize_timeseries(ser)
+def test_serialize_timeseries(inp, exp):
+    out = utils.serialize_timeseries(inp)
     outd = json.loads(out)
     assert 'schema' in outd
     assert 'data' in outd
+    assert out == exp
 
 
 @pytest.mark.parametrize('inp,exp', [
@@ -287,6 +288,8 @@ def test_deserialize_timeseries(inp, exp):
 
 
 @pytest.mark.parametrize('inp,exp', [
+    ('{"schema":{"version": 1, "orient": "records", "timezone": "UTC", "column": [], "index": "timestamp", "dtype": [], "objtype": "DataFrame"},"data":[]}',  # NOQA
+     EMPTY_TIME_DATAFRAME),
     ('{"schema": {"version": 1, "objtype": "DataFrame", "orient": "records", "timezone": "UTC", "column": [], "index": "timestamp", "dtype": ["float64"]}, "data": []}',  # NOQA
      EMPTY_TIME_DATAFRAME),
     ('{"schema": {"version": 1, "objtype": "DataFrame", "orient": "records", "timezone": "UTC", "column": ["25.0"], "index": "timestamp", "dtype": ["float64"]}, "data": [{"timestamp": "2019-01-01T00:00:00", "25.0": 1.0}], "other_stuff": {}}',  # NOQA

--- a/solarforecastarbiter/io/utils.py
+++ b/solarforecastarbiter/io/utils.py
@@ -299,8 +299,11 @@ def serialize_timeseries(ser):
             'is supported')
     v = ser.copy()
     v.index.name = 'timestamp'
-    jsonvals = v.tz_convert('UTC').reset_index(name='value').to_json(
-        orient='records', date_format='iso', date_unit='s')
+    if isinstance(v, pd.Series):
+        jsonvals = v.tz_convert('UTC').reset_index(name='value').to_json(
+            orient='records', date_format='iso', date_unit='s')
+    else:
+        jsonvals = _dataframe_to_json(v)
     schema = {
         'version': 0,
         'orient': 'records',

--- a/solarforecastarbiter/io/utils.py
+++ b/solarforecastarbiter/io/utils.py
@@ -309,7 +309,7 @@ def serialize_timeseries(ser):
         v.index.name = 'timestamp'
         jsonvals = v.tz_convert('UTC').reset_index().to_json(
             orient='records', date_format='iso', date_unit='s')
-        column = v.columns.to_list()
+        column = v.columns.astype(str).to_list()
         dtype = v.dtypes.astype(str).to_list()
         objtype = 'DataFrame'
     schema = {
@@ -378,9 +378,10 @@ def deserialize_timeseries(data):
         out = df.set_index(schema['index'])
         # pd.read_json will set all column names to strings, so
         # columns originally specified with float names need to be
-        # mapped back into the right name dtype
-        str_col_map = {str(col): col for col in schema['column']}
-        out = out.rename(columns=str_col_map)
+        # mapped back into the right name dtype. this code is not needed
+        # if columns are always strings.
+        # str_col_map = {str(col): col for col in schema['column']}
+        # out = out.rename(columns=str_col_map)
         out = out.astype(dict(zip(schema['column'], schema['dtype'])))
     if out.index.tzinfo is None:
         out = out.tz_localize(schema['timezone'])

--- a/solarforecastarbiter/io/utils.py
+++ b/solarforecastarbiter/io/utils.py
@@ -371,10 +371,13 @@ def deserialize_timeseries(data):
             schema['dtype'])
     elif objtype_str == 'DataFrame':
         if df.empty:
+            try:
+                dtype = schema['dtype'][0]
+            except IndexError:
+                dtype = float
             return pd.DataFrame(
                 [], columns=schema['column'], index=pd.DatetimeIndex(
-                    [], tz=schema['timezone'], name='timestamp'),
-                dtype=schema['dtype'][0])
+                    [], tz=schema['timezone'], name='timestamp'), dtype=dtype)
         out = df.set_index(schema['index'])
         # pd.read_json will set all column names to strings, so
         # columns originally specified with float names need to be

--- a/solarforecastarbiter/io/utils.py
+++ b/solarforecastarbiter/io/utils.py
@@ -276,7 +276,7 @@ def serialize_timeseries(ser):
 
     Parameters
     ----------
-    ser : (pandas.Series, pandas.DataFrame)
+    ser : {pandas.Series, pandas.DataFrame}
        Must have a tz-localized datetime index
 
     Returns
@@ -336,7 +336,7 @@ def deserialize_timeseries(data):
 
     Returns
     -------
-    pandas.Series
+    pandas.Series or pandas.DataFrame
         Deserialized timeseries
 
     Raises

--- a/solarforecastarbiter/io/utils.py
+++ b/solarforecastarbiter/io/utils.py
@@ -313,7 +313,7 @@ def serialize_timeseries(ser):
         dtype = v.dtypes.astype(str).to_list()
         objtype = 'DataFrame'
     schema = {
-        'version': 0,
+        'version': 1,
         'orient': 'records',
         'timezone': 'UTC',
         'column': column,
@@ -350,12 +350,12 @@ def deserialize_timeseries(data):
     if schema_str is None:
         raise ValueError('Could not locate schema in data string')
     schema = json.loads(schema_str.group(0))
-    try:
-        objtype_str = schema['objtype']
-    except KeyError:
-        # compatibility with data serialized and stored before this
-        # key was added and all data were Series
+    if schema['version'] == 0:
+        # compatibility with data serialized and stored before the
+        # objtype key was added to schema and DataFrames were suppored in v1
         objtype_str = 'Series'
+    else:
+        objtype_str = schema['objtype']
     # find between "data": and , or }, with only one set of []
     data_str = re.search('(?<="data":)\\s*\\[[^\\[\\]]*\\](?=\\s*(,|}))', data)
     if data_str is None:

--- a/solarforecastarbiter/io/utils.py
+++ b/solarforecastarbiter/io/utils.py
@@ -276,7 +276,7 @@ def serialize_timeseries(ser):
 
     Parameters
     ----------
-    ser : pandas.Series
+    ser : (pandas.Series, pandas.DataFrame)
        Must have a tz-localized datetime index
 
     Returns
@@ -290,12 +290,13 @@ def serialize_timeseries(ser):
         If the input is invalid
     """
     if not (
-            isinstance(ser, pd.Series) and
+            isinstance(ser, (pd.Series, pd.DataFrame)) and
             isinstance(ser.index, pd.DatetimeIndex) and
             ser.index.tzinfo is not None
     ):
         raise TypeError(
-            'Only pandas Series with a localized DatetimeIndex is supported')
+            'Only pandas Series or DataFrame with a localized DatetimeIndex '
+            'is supported')
     v = ser.copy()
     v.index.name = 'timestamp'
     jsonvals = v.tz_convert('UTC').reset_index(name='value').to_json(

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -154,7 +154,7 @@ def construct_timeseries_dataframe(report):
                       datamodel.ProbabilisticForecast):
             for cvfx in pfxobs.original.forecast.constant_values:
                 value_frame_dict = _value_frame_dict(
-                    idx, pfxobs, column=cvfx.constant_value)
+                    idx, pfxobs, column=str(cvfx.constant_value))
                 # specify fx type so we know the const value fx came from a
                 # ProbabilisticForecast
                 meta_row_dict = _meta_row_dict(

--- a/solarforecastarbiter/tests/test_cli.py
+++ b/solarforecastarbiter/tests/test_cli.py
@@ -259,7 +259,9 @@ def test_report(cli_token, mocker, report_objects):
     assert res.exit_code == 0
 
 
-def test_report_roundtrip(cli_token, mocker, report_objects, requests_mock):
+def test_report_roundtrip(cli_token, mocker, various_report_objects_data,
+                          requests_mock):
+    report_objects, report_data = various_report_objects_data
     # mock all endpoints
     base_url = 'http://baseurl'
     requests_mock.register_uri(['POST', 'GET'], re.compile(base_url + '/.*'))
@@ -270,20 +272,8 @@ def test_report_roundtrip(cli_token, mocker, report_objects, requests_mock):
         return_value=fail_pdf)
     mocker.patch('solarforecastarbiter.cli.APISession.process_report_dict',
                  return_value=report_objects[0].replace(status='complete'))
-    index = pd.date_range(
-        start="2019-04-01T00:00:00Z", end="2019-04-04T23:59:00Z",
-        freq='1h')
-    data = pd.Series(1., index=index)
-    obs = pd.DataFrame({'value': data, 'quality_flag': 2})
-    ref_fx = \
-        report_objects[0].report_parameters.object_pairs[1].reference_forecast
     mocker.patch('solarforecastarbiter.cli.reports.get_data_for_report',
-                 return_value={report_objects[2]: data,
-                               report_objects[3]: data,
-                               ref_fx: data,
-                               report_objects[1]: obs,
-                               report_objects[4]: obs,
-                               report_objects[5]: data})
+                 return_value=report_data)
     runner = CliRunner()
     with tempfile.TemporaryDirectory() as tmpdir:
         infile = tmpdir + '/report.json'


### PR DESCRIPTION
  - [x] Closes #495 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

So far I have a test that reproduces the failure.

@alorenzo175 I started trying to make `serialize_timeseries` work with DataFrames and it's turning out to be less straightforward than I thought it would be. The `schema` has `'column': 'value'` - do we want to change this to `'columns': [{df.columns}]` and then `deserialize_timeseries` has some conditional on this? Or do we want to let the calling functions serialize the DataFrame column by column, and the reverse for deserialize?

I can keep hacking at this but feel free to take over if you have a good idea of what to do.