### PR TITLE
fix ids for cost parameters when special characters are included

### DIFF
--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -12,6 +12,7 @@ import tempfile
 
 from bokeh import __version__ as bokeh_version
 from jinja2 import Environment, PackageLoader, select_autoescape, ChoiceLoader
+from jinja2.runtime import Undefined
 from plotly import __version__ as plotly_version
 
 
@@ -96,12 +97,16 @@ def _get_render_kwargs(report, dash_url, with_timeseries):
     return kwargs
 
 
-def _pretty_json(val):
-    return json.dumps(val, indent=4, separators=(',', ':'))
+def _pretty_json(value):
+    if isinstance(value, Undefined):  # pragma: no cover
+        return value
+    return json.dumps(value, indent=4, separators=(',', ':'))
 
 
 def _figure_name_filter(value):
     """replace characters that may cause problems for html/javascript ids"""
+    if isinstance(value, Undefined):
+        return value
     out = (value
            .replace('^', '-')
            .replace(' ', '-')
@@ -203,6 +208,8 @@ def render_html(report, dash_url=datamodel.DASH_URL,
 
 def _link_filter(value):
     """convert html href markup to tex href markup"""
+    if isinstance(value, Undefined):  # pragma: no cover
+        return value
     match = re.search(
         """<a\\s+(?:[^>]*?\\s+)?href=(["'])(.*?)(["'])>(.*?)<\\/a>""",
         value, re.DOTALL)
@@ -215,6 +222,8 @@ def _link_filter(value):
 
 
 def _html_to_tex(value):
+    if isinstance(value, Undefined):
+        return value
     value = (value
              .replace('<p>', '')
              .replace('</p>', '\n')

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -65,13 +65,13 @@
 {% if costs | length > 0 %}
 <h4 id="costparams">Cost Parameters</h4>
 {% for cost in costs %}
-<div id="cost-{{ cost.name }}" class="card">
+<div id="cost-{{ cost.name | figure_name_filter }}" class="card">
   <div class="card-header">
-    <a class="collapsed card-link" data-toggle="collapse" href="#collapse-{{ cost.name }}">
+    <a class="collapsed card-link" data-toggle="collapse" href="#collapse-{{ cost.name | figure_name_filter }}">
       <h5>{{ cost.name }}</h5>
     </a>
   </div>
-  <div id="collapse-{{ cost.name }}" class="collapse" data-parent="#cost-{{ cost.name }}">
+  <div id="collapse-{{ cost.name | figure_name_filter }}" class="collapse" data-parent="#cost-{{ cost.name | figure_name_filter }}">
     <div class="card-body">
       <pre>{{ cost.to_dict() | pretty_json }}</pre>
     </div>

--- a/solarforecastarbiter/reports/templates/html/metrics_meta_table.html
+++ b/solarforecastarbiter/reports/templates/html/metrics_meta_table.html
@@ -28,7 +28,7 @@
         {{ pfxobs.uncertainty }}
         </td>
         <td>
-        <a href="#cost-{{ pfxobs.cost.name }}">{{ pfxobs.cost.name }}</a>
+        <a href="#cost-{{ pfxobs.cost.name | figure_name_filter }}">{{ pfxobs.cost.name }}</a>
         </td>
     </tr>
     {% endfor %}

--- a/solarforecastarbiter/reports/templates/pdf/base.tex
+++ b/solarforecastarbiter/reports/templates/pdf/base.tex
@@ -60,8 +60,8 @@ with the reports or to create a new issue.
 %- if costs | length > 0
 \subsection{Cost Parameters}
 %- for cost in costs
-\subsubsection{\VAR{cost.name}}
-\label{cost:\VAR{cost.name}}
+\subsubsection{\VAR{cost.name | html_to_tex}}
+\label{cost:\VAR{cost.name | html_to_tex | replace('_', '+')}}
 \begin{verbatim}
   \VAR{cost.to_dict() | pretty_json }
 \end{verbatim}

--- a/solarforecastarbiter/reports/templates/pdf/macros.j2
+++ b/solarforecastarbiter/reports/templates/pdf/macros.j2
@@ -37,7 +37,7 @@
     Name & Normalization & Deadband(\%) & Cost Parameters\\
     \midrule
     %- for pfxobs in report.raw_report.processed_forecasts_observations
-    \VAR{pfxobs.name | html_to_tex} & \VAR{pfxobs.normalization_factor} & \VAR{pfxobs.uncertainty} & \hyperref[cost:\VAR{pfxobs.cost.name}]{\VAR{pfxobs.cost.name}} \\
+    \VAR{pfxobs.name | html_to_tex} & \VAR{pfxobs.normalization_factor} & \VAR{pfxobs.uncertainty} & \hyperref[cost:\VAR{pfxobs.cost.name | html_to_tex | replace('_', '+')}]{\VAR{pfxobs.cost.name | html_to_tex}} \\
     %- endfor
   \end{tabu}
 \end{table}


### PR DESCRIPTION
Otherwise linking and collaps won't work for costs with things like
a space in the name.

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #xxxx .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
