### PR TITLE
adjust margin for long x axis names

### DIFF
--- a/docs/source/whatsnew/1.0.0rc1.rst
+++ b/docs/source/whatsnew/1.0.0rc1.rst
@@ -128,6 +128,8 @@ Bug fixes
   an object did not contain the relevant data, and ensure correct
   ordering in PDF tables. (:issue:`504`, :issue:`512`, :pull:`513`)
 
+* Fix bug where long forecast names were cut off when used as x axis labels on
+  total metrics plots. (:pull:`515)
 
 Contributors
 ~~~~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0rc1.rst
+++ b/docs/source/whatsnew/1.0.0rc1.rst
@@ -129,7 +129,7 @@ Bug fixes
   ordering in PDF tables. (:issue:`504`, :issue:`512`, :pull:`513`)
 
 * Fix bug where long forecast names were cut off when used as x axis labels on
-  total metrics plots. (:pull:`515)
+  total metrics plots. (:pull:`515`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -669,6 +669,7 @@ def bar(df, metric):
     """  # NOQA
     data = df[(df['category'] == 'total') & (df['metric'] == metric)]
     y_range = None
+    x_axis_kwargs = {}
     x_values = data['abbrev']
     palette = cycle(PALETTE)
     palette = [next(palette) for _ in x_values]
@@ -678,9 +679,10 @@ def bar(df, metric):
     # than 5 pairs to problems with labels being cutt off.
     plot_layout_args = deepcopy(PLOT_LAYOUT_DEFAULTS)
     if x_values.map(len).max() > 15 or x_values.size > 6:
-        plot_layout_args.pop('height')
+        #plot_layout_args.pop('height')
         # Adjust bottom margin so that long names are not cut off
-        plot_layout_args['margin']['b'] = 350
+        plot_layout_args['height'] = 600
+        x_axis_kwargs = {'automargin': True}
     fig = go.Figure()
     fig.add_trace(go.Bar(x=x_values, y=data['value'],
                          marker=go.bar.Marker(color=palette)))
@@ -688,7 +690,7 @@ def bar(df, metric):
         title=f'<b>{metric_name}</b>',
         xaxis_title=metric_name,
         **plot_layout_args)
-    configure_axes(fig, None, y_range)
+    configure_axes(fig, x_axis_kwargs, y_range)
     return fig
 
 

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -4,6 +4,7 @@ using Plotly.
 """
 import base64
 import calendar
+from copy import deepcopy
 import datetime as dt
 from itertools import cycle
 from pathlib import Path
@@ -673,14 +674,16 @@ def bar(df, metric):
     palette = [next(palette) for _ in x_values]
     metric_name = datamodel.ALLOWED_METRICS[metric]
 
+    # remove height limit when long abbreviations are used or there are more
+    # than 5 pairs to problems with labels being cutt off.
+    plot_layout_args = deepcopy(PLOT_LAYOUT_DEFAULTS)
+    if x_values.map(len).max() > 15 or x_values.size > 6:
+        plot_layout_args.pop('height')
+        # Adjust bottom margin so that long names are not cut off
+        plot_layout_args['margin']['b'] = 350
     fig = go.Figure()
     fig.add_trace(go.Bar(x=x_values, y=data['value'],
                          marker=go.bar.Marker(color=palette)))
-    # remove height limit when long abbreviations are used or there are more
-    # than 5 pairs to problems with labels being cutt off.
-    plot_layout_args = PLOT_LAYOUT_DEFAULTS.copy()
-    if x_values.map(len).max() > 15 or x_values.size > 6:
-        plot_layout_args.pop('height')
     fig.update_layout(
         title=f'<b>{metric_name}</b>',
         xaxis_title=metric_name,

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -679,8 +679,8 @@ def bar(df, metric):
     # than 5 pairs to problems with labels being cutt off.
     plot_layout_args = deepcopy(PLOT_LAYOUT_DEFAULTS)
     if x_values.map(len).max() > 15 or x_values.size > 6:
-        #plot_layout_args.pop('height')
-        # Adjust bottom margin so that long names are not cut off
+        # Set explicit height and set automargin on x axis to allow for dynamic
+        # sizing to accomodate long x axis labels
         plot_layout_args['height'] = 600
         x_axis_kwargs = {'automargin': True}
     fig = go.Figure()


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [ ] Closes #xxxx .
  - [ ] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Fixes issue where long probabilistic forecast names are cut off below the x axis. This sets a static height of 600 pixels and allows automargin to determine the space needed below the plot. This still has the downside of squeezing the plot to the top left to properly align with the axis labels. However, of the few solutions I tried this worked best across all of them. Screenshot below of the plot layout.
![Screenshot from 2020-07-06 13-39-41](https://user-images.githubusercontent.com/21206164/86640142-e36c2c80-bf8e-11ea-997b-e2e44f6f4dea.png)

I did try adding newlines in the labels, but with too many ticks, or too narrow a screen overlap occured. 
![Screenshot from 2020-07-06 12-45-15](https://user-images.githubusercontent.com/21206164/86640231-fa128380-bf8e-11ea-87e8-36e6d26ccde8.png)
