### PR TITLE
shaded plots for probabilistic percentile forecasts (axis='y')

### DIFF
--- a/docs/source/whatsnew/1.0.0rc2.rst
+++ b/docs/source/whatsnew/1.0.0rc2.rst
@@ -15,7 +15,8 @@ API Changes
 
 Enhancements
 ~~~~~~~~~~~~
-
+* Report plots of Probabilistic Forecast timeseries now include shading for
+  each provided percentile. (:pull: `519`)
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0rc2.rst
+++ b/docs/source/whatsnew/1.0.0rc2.rst
@@ -16,7 +16,7 @@ API Changes
 Enhancements
 ~~~~~~~~~~~~
 * Report plots of Probabilistic Forecast timeseries now include shading for
-  each provided percentile. (:pull: `519`)
+  each provided percentile. (:issue:`516`) (:pull:`519`)
 
 Bug fixes
 ~~~~~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ statsmodels==0.11.0
 tables==3.6.1
 xarray==0.15.0
 selenium==3.141.0
+matplotlib==3.2.2

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'jsonschema',
         'plotly',
         'psutil',
+        'matplotlib',
     ],
     extras_require=EXTRAS_REQUIRE,
     project_urls={

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -428,7 +428,7 @@ def _plot_fx_timeseries(fig, timeseries_value_df, timeseries_meta_df, axis):
                 showlegend = False
 
             # Split name of the distribution from the current constant value
-            constant_label_index = cv['forecast_name'].find('Prob(')-1
+            constant_label_index = cv['forecast_name'].find('Prob(') - 1
             fx_name = cv['forecast_name'][:constant_label_index]
             cv_label = cv['forecast_name'][constant_label_index:]
 

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -441,7 +441,7 @@ def _plot_fx_timeseries(fig, timeseries_value_df, timeseries_meta_df, axis):
                 else:
                     fill_value = cv['constant_value']
 
-                # When constant values are symmetric, create credible intervals
+                # When constant values are symmetric, create intervals
                 # centered around the 50th percentile
                 fill_value = 2 * abs(fill_value - 50)
             else:

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -522,11 +522,7 @@ def timeseries(timeseries_value_df, timeseries_meta_df,
         _plot_obs_timeseries(fig, timeseries_value_df, timeseries_meta_df)
 
     # add forecast traces that have correct axis to fig
-    _plot_fx_timeseries(
-        fig,
-        timeseries_value_df,
-        timeseries_meta_df,
-        axis)
+    _plot_fx_timeseries(fig, timeseries_value_df, timeseries_meta_df, axis)
 
     fig.update_xaxes(title_text=f'Time ({timezone})', showgrid=True,
                      gridwidth=1, gridcolor='#CCC', showline=True,

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -445,7 +445,9 @@ def _plot_fx_timeseries(fig, timeseries_value_df, timeseries_meta_df, axis):
                 # centered around the 50th percentile
                 fill_value = 2 * abs(fill_value - 50)
             else:
-                fill_value = cv['constant_value']
+                # convert to complement percentile to invert shading, such that
+                # bright colors appear at 0 and dark at 100 when plotted.
+                fill_value = 100 - cv['constant_value']
 
             fill_color = _get_fill_color(fill_value)
 

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -354,10 +354,7 @@ def _plot_fx_timeseries(fig, timeseries_value_df, timeseries_meta_df, axis):
     gos = []
 
     # construct graph objects in random hash order
-    non_distribution_indices = timeseries_meta_df['distribution'].isna()
-    non_distribution_meta = timeseries_meta_df[non_distribution_indices]
-    distribution_meta = timeseries_meta_df[~non_distribution_indices]
-    for fx_hash in np.unique(non_distribution_meta['forecast_hash']):
+    for fx_hash in np.unique(timeseries_meta_df['forecast_hash']):
         metadata = _extract_metadata_from_df(
             timeseries_meta_df, fx_hash, 'forecast_hash')
         if metadata['axis'] not in axis:
@@ -385,8 +382,16 @@ def _plot_fx_timeseries(fig, timeseries_value_df, timeseries_meta_df, axis):
         # collect in list
         gos.append((metadata['pair_index'], go_))
 
+    for idx, go_ in sorted(gos, key=lambda x: x[0]):
+        fig.add_trace(go_)
+
+
+def _plot_fx_distribution_timeseries(
+        fig, timeseries_value_df, timeseries_meta_df, axis):
     palette = cycle(PROBABILISTIC_PALETTES)
-    for dist_hash in np.unique(distribution_meta['distribution']):
+    gos = []
+
+    for dist_hash in np.unique(timeseries_meta_df['distribution']):
         # indices to constant values in the metadata df
         cv_indices = timeseries_meta_df['distribution'] == dist_hash
 
@@ -522,7 +527,14 @@ def timeseries(timeseries_value_df, timeseries_meta_df,
         _plot_obs_timeseries(fig, timeseries_value_df, timeseries_meta_df)
 
     # add forecast traces that have correct axis to fig
-    _plot_fx_timeseries(fig, timeseries_value_df, timeseries_meta_df, axis)
+    non_distribution_indices = timeseries_meta_df['distribution'].isna()
+    non_distribution_meta_df = timeseries_meta_df[non_distribution_indices]
+    distribution_meta_df = timeseries_meta_df[~non_distribution_indices]
+
+    _plot_fx_timeseries(
+        fig, timeseries_value_df, non_distribution_meta_df, axis)
+    _plot_fx_distribution_timeseries(
+        fig, timeseries_value_df, distribution_meta_df, axis)
 
     fig.update_xaxes(title_text=f'Time ({timezone})', showgrid=True,
                      gridwidth=1, gridcolor='#CCC', showline=True,

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -456,6 +456,8 @@ def _plot_fx_distribution_timeseries(
 
             fill_color = _get_fill_color(fill_value)
 
+            plot_kwargs = line_or_step_plotly(cv['interval_label'])
+
             go_ = go.Scatter(
                 x=data.index,
                 y=data['forecast_values'],
@@ -473,6 +475,7 @@ def _plot_fx_distribution_timeseries(
                 line=dict(
                     color=fill_color,
                 ),
+                **plot_kwargs,
             )
 
             # Add traces in order of pair index

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -1089,6 +1089,9 @@ def timeseries_plots(report):
         If report contains a probabilistic forecast with axis='x',
         string json specification of the probability vs. time plot.
         Otherwise None.
+    includes_distribution: bool
+        True if the a plot was created for a pair containing a
+        ProbabilisticForecast.
     """
     value_df, meta_df = construct_timeseries_dataframe(report)
     pfxobs = report.raw_report.processed_forecasts_observations

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -434,7 +434,7 @@ def _plot_fx_timeseries(fig, timeseries_value_df, timeseries_meta_df, axis):
 
             if symmetric_percentiles:
                 # Since plotly always fills below the line, for constants below
-                # 50 %, use the previous value to mimic fill upward behavior.
+                # 50%, use the previous value to mimic fill upward behavior.
                 # E.g. fill downward from 5% to 0% with the 100% interval.
                 if cv['constant_value'] <= 50 and idx != 0:
                     fill_value = cv_metadata.iloc[idx - 1]['constant_value']

--- a/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
@@ -410,3 +410,37 @@ def test_timeseries_plots_xy(report_with_raw_xy):
     assert isinstance(scatter_spec, str)
     assert isinstance(ts_prob_spec, str)
     assert inc_dist
+
+
+@pytest.fixture
+def report_with_raw_xy_asymmetric_cv(report_dict, raw_report_xy):
+    raw = raw_report_xy(True)
+    pfxobs = raw.processed_forecasts_observations
+    fx_cvs = pfxobs[0].original.forecast.constant_values
+    cv_1 = pfxobs[0].replace(
+        original=pfxobs[0].original.replace(
+            forecast=pfxobs[0].original.forecast.replace(
+                constant_values=(
+                    fx_cvs[0],
+                    fx_cvs[1],
+                    fx_cvs[2].replace(constant_value=85.0))
+            ),
+        ),
+        forecast_values=pfxobs[0].forecast_values.rename(
+            columns={'75.0': '85.0'})
+    )
+    raw = raw.replace(
+        processed_forecasts_observations=(cv_1, pfxobs[1], pfxobs[2])
+    )
+    report_dict['raw_report'] = raw
+    return datamodel.Report.from_dict(report_dict)
+
+
+def test_probabilistic_plotting_asymmetric_cv(
+        report_with_raw_xy_asymmetric_cv):
+    ts_spec, scatter_spec, ts_prob_spec, inc_dist = figures.timeseries_plots(
+        report_with_raw_xy_asymmetric_cv)
+    assert isinstance(ts_spec, str)
+    assert isinstance(scatter_spec, str)
+    assert isinstance(ts_prob_spec, str)
+    assert inc_dist

--- a/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
@@ -395,16 +395,18 @@ def test_construct_timeseries_dataframe_timeseries(report_with_raw):
 
 
 def test_timeseries_plots(report_with_raw):
-    ts_spec, scatter_spec, ts_prob_spec = figures.timeseries_plots(
+    ts_spec, scatter_spec, ts_prob_spec, inc_dist = figures.timeseries_plots(
         report_with_raw)
     assert isinstance(ts_spec, str)
     assert isinstance(scatter_spec, str)
     assert ts_prob_spec is None
+    assert not inc_dist
 
 
 def test_timeseries_plots_xy(report_with_raw_xy):
-    ts_spec, scatter_spec, ts_prob_spec = figures.timeseries_plots(
+    ts_spec, scatter_spec, ts_prob_spec, inc_dist = figures.timeseries_plots(
         report_with_raw_xy)
     assert isinstance(ts_spec, str)
     assert isinstance(scatter_spec, str)
     assert isinstance(ts_prob_spec, str)
+    assert inc_dist

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -88,7 +88,7 @@ def _get_render_kwargs(report, dash_url, with_timeseries):
         except Exception:
             logger.exception(
                 'Failed to make Plotly items for timeseries and scatterplot')
-            timeseries_specs = ('{}', '{}', '{}')
+            timeseries_specs = ('{}', '{}', '{}', False)
         kwargs['timeseries_spec'] = timeseries_specs[0]
         kwargs['scatter_spec'] = timeseries_specs[1]
         if timeseries_specs[2] is not None:

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -94,6 +94,8 @@ def _get_render_kwargs(report, dash_url, with_timeseries):
         if timeseries_specs[2] is not None:
             kwargs['timeseries_prob_spec'] = timeseries_specs[2]
 
+        kwargs['includes_distribution'] = timeseries_specs[3]
+
     return kwargs
 
 

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -99,6 +99,11 @@ observation data.</p>
 right. Clicking on an item in the legend will hide/show it.</p>
 
 <div id="timeseries-div"></div>
+{% if includes_distribution %}
+<p>The timeseries plots above contain probabilistic forecast distributions.
+Confidence intervals are shaded in the color displayed in the legend. Brighter
+colors indicate larger intervals and converge to black at the median value.</p>
+{% endif %}
 <div id="scatter-div"></div>
 
 <script>

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -100,10 +100,12 @@ right. Clicking on an item in the legend will hide/show it.</p>
 
 <div id="timeseries-div"></div>
 {% if includes_distribution %}
-<p>The timeseries plots above contain probabilistic forecast distributions.
-Forecast percentiles are shaded in the color displayed in the legend. Brighter
-colors indicate percentiles closer to 0 or 100. Shading converges to black at
-the 50th percentile.</p>
+<p>For forecasts parameterized symmetrically around the 50th percentile,
+brighter colors indicate percentiles farther from the 50th percentile and
+darker colors indicate percentiles closer to the 50th percentile. For forecasts
+parameterized asymmetrically around the 50th percentile, brighter colors
+indicate smaller percentiles and darker colors indicate larger percentiles.
+Use the hover tool to determine the percentile.</p>
 {% endif %}
 <div id="scatter-div"></div>
 

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -101,8 +101,9 @@ right. Clicking on an item in the legend will hide/show it.</p>
 <div id="timeseries-div"></div>
 {% if includes_distribution %}
 <p>The timeseries plots above contain probabilistic forecast distributions.
-Confidence intervals are shaded in the color displayed in the legend. Brighter
-colors indicate larger intervals and converge to black at the median value.</p>
+Forecast percentiles are shaded in the color displayed in the legend. Brighter
+colors indicate percentiles closer to 0 or 100. Shading converges to black at
+the 50th percentile.</p>
 {% endif %}
 <div id="scatter-div"></div>
 

--- a/solarforecastarbiter/reports/tests/test_template.py
+++ b/solarforecastarbiter/reports/tests/test_template.py
@@ -21,7 +21,7 @@ expected_metrics_json = """[{"name":"0 Day GFS GHI","abbrev":"0 Day GFS GHI","ca
 def mocked_timeseries_plots(mocker):
     mocked = mocker.patch(
         'solarforecastarbiter.reports.figures.plotly_figures.timeseries_plots')
-    mocked.return_value = ('{}', '{}', '{}')
+    mocked.return_value = ('{}', '{}', '{}', False)
 
 
 @pytest.fixture
@@ -61,6 +61,7 @@ def expected_kwargs(dash_url):
             kwargs['timeseries_spec'] = '{}'
             kwargs['scatter_spec'] = '{}'
             kwargs['timeseries_prob_spec'] = '{}'
+            kwargs['includes_distribution'] = False
         return kwargs
     return fn
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #516 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Part of #516 aims to plot probabilistic forecast with axis = y. I've created confidence intervals from the available percentiles by taking `2 * | x -50 |` of each percentile, so we can plot a partial confidence interval e.g. if the probabilistic forecast only includes constant values 5, 25 50. we can shade the areas between the 5 and 25 point as if they are within the 90% confidence interval, and between 25 and 50 as if they're within the 50% confidence interval. This could be confusing to users, as plots would suggests that data should only exist in the lower portion of that interval. 

The screenshot below shows a plot with two distributions and two constant values, where one distrbution `asym thingy` is just a copy of the other missing some constant values.
![probabilistic_plot](https://user-images.githubusercontent.com/21206164/87361558-5b070200-c521-11ea-816a-b84e9b1e25de.png)


Needs a few more things before ready:

- [x] ~~Fix plotting order so we can accurately report confidence intervals on hover.~~
- [x] Better explanatory text when distributions are included in timeseries.