### PR TITLE
Fix various persistence bugs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -775,3 +775,4 @@ Generic utility functions.
 
    utils.compute_aggregate
    utils.sha256_pandas_object_hash
+   utils.generate_continuous_chunks

--- a/docs/source/whatsnew/1.0.0rc2.rst
+++ b/docs/source/whatsnew/1.0.0rc2.rst
@@ -1,0 +1,39 @@
+.. _whatsnew_100rc2:
+
+1.0.0rc2 (???)
+--------------
+
+This is the second 1.0 release candidate.
+
+
+API Changes
+~~~~~~~~~~~
+* Added :py:func:`solarforecastarbiter.utils.generate_continuous_chunks` to
+  split data into chunks with equal frequency to support operations such as
+  uploading forecast values. (:pull:`529`)
+
+
+Enhancements
+~~~~~~~~~~~~
+
+
+Bug fixes
+~~~~~~~~~
+* Fix bugs related to missing data in persistence functions
+  (:issue:`517`, :issue:`518`, :issue:`528`) and a bug in calculating
+  the clearksky curve for GHI persistence at a solar power plant
+  (:issue:`524`). (:pull:`529`)
+
+
+
+Contributors
+~~~~~~~~~~~~
+
+* Will Holmgren (:ghuser:`wholmgren`)
+* Leland Boeman (:ghuser:`lboeman`)
+* Cliff Hansen (:ghuser:`cwhanse`)
+* Tony Lorenzo (:ghuser:`alorenzo175`)
+* Justin Sharp (:ghuser:`MrWindAndSolar`)
+* Aidan Tuohy
+* Adam Wigington (:ghuser:`awig`)
+* David Larson (:ghuser:`dplarson`)

--- a/docs/source/whatsnew/index.rst
+++ b/docs/source/whatsnew/index.rst
@@ -9,6 +9,7 @@ These are new features and improvements of note in each release.
 .. toctree::
    :maxdepth: 2
 
+   1.0.0rc2
    1.0.0rc1
    1.0.0b6
    1.0.0b5

--- a/solarforecastarbiter/reference_forecasts/main.py
+++ b/solarforecastarbiter/reference_forecasts/main.py
@@ -15,6 +15,7 @@ import pandas as pd
 
 
 from solarforecastarbiter import datamodel, pvmodel
+from solarforecastarbiter.utils import generate_continuous_chunks
 from solarforecastarbiter.io import api
 from solarforecastarbiter.io.fetch import nwp as fetch_nwp
 from solarforecastarbiter.io.utils import adjust_timeseries_for_interval_label
@@ -669,7 +670,8 @@ def make_latest_persistence_forecasts(token, max_run_time, base_url=None):
                 serlist.append(fx_ser)
         if len(serlist) > 0:
             ser = pd.concat(serlist)
-            session.post_forecast_values(fx.forecast_id, ser)
+            for cser in generate_continuous_chunks(ser, fx.interval_length):
+                session.post_forecast_values(fx.forecast_id, cser)
 
 
 def make_latest_probabilistic_persistence_forecasts(
@@ -713,5 +715,7 @@ def make_latest_probabilistic_persistence_forecasts(
         for id_, serlist in out.items():
             if len(serlist) > 0:
                 ser = pd.concat(serlist)
-                session.post_probabilistic_forecast_constant_value_values(
-                    id_, ser)
+                for cser in generate_continuous_chunks(
+                        ser, fx.interval_length):
+                    session.post_probabilistic_forecast_constant_value_values(
+                        id_, cser)

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -162,11 +162,15 @@ def persistence_interval(observation, data_start, data_end, forecast_start,
                            forecast_start, forecast_end,
                            observation.interval_length)
 
+    closed_obs = datamodel.CLOSED_MAPPING[observation.interval_label]
     # get the data
     obs = load_data(observation, data_start, data_end)
-
+    obs_index = pd.date_range(start=data_start, end=data_end,
+                              freq=observation.interval_length,
+                              closed=closed_obs)
+    # put in nans if appropriate
+    obs = obs.reindex(obs_index)
     # average data within bins of length interval_length
-    closed_obs = datamodel.CLOSED_MAPPING[observation.interval_label]
     persistence_quantity = obs.resample(interval_length,
                                         closed=closed_obs).mean()
 
@@ -178,7 +182,8 @@ def persistence_interval(observation, data_start, data_end, forecast_start,
     # Construct the returned series.
     # Use values to strip the time information from resampled obs.
     # Raises ValueError if len(persistence_quantity) != len(fx_index), but
-    # that should never happen given the way we're calculating things here.
+    # that should never happen given the way we're calculating things here
+    # now that nans are insterted into obs for missing data.
     fx = pd.Series(persistence_quantity.values, index=fx_index)
     return fx
 

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -280,7 +280,10 @@ def persistence_scalar_index(observation, data_start, data_end, forecast_start,
     # Consider putting the code within each if/else block below into its own
     # function with standard outputs clear_ref and clear_fx. But with only two
     # cases for now, it might be more clear to leave inline.
-    if isinstance(site, datamodel.SolarPowerPlant):
+    if (
+            isinstance(site, datamodel.SolarPowerPlant) and
+            observation.variable == 'ac_power'
+    ):
         # No temperature input is only OK so long as temperature effects
         # do not push the system above or below AC clip point.
         # It's only a reference forecast!

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -478,6 +478,10 @@ def persistence_probabilistic(observation, data_start, data_end,
     obs = load_data(observation, data_start, data_end)
     obs = obs.resample(interval_length, closed=closed).mean()
 
+    if obs.empty:
+        return [pd.Series(None, dtype=float, index=fx_index)
+                for _ in constant_values]
+
     if axis == "x":
         cdf = ECDF(obs)
         forecasts = []
@@ -584,6 +588,8 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
     # observation data resampled to match forecast sampling
     obs = load_data(observation, data_start, data_end)
     obs = obs.resample(interval_length, closed=closed).mean()
+    if obs.empty:
+        raise ValueError("Insufficient data to match by time of day")
 
     # time of day: minutes past midnight (e.g. 0=12:00am, 75=1:15am)
     if obs.index.tzinfo is not None:

--- a/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
@@ -127,26 +127,37 @@ def uniform_data():
 
 
 @pytest.mark.parametrize(
-    'interval_label,expected_index,expected_ghi,expected_ac', (
+    'interval_label,expected_index,expected_ghi,expected_ac,obsscale', (
         ('beginning',
          ['20190404 1300', '20190404 1330'],
          [96.41150694741889, 91.6991546408236],
-         [99.28349914087346, 98.28165269708589]),
+         [99.28349914087346, 98.28165269708589],
+         1),
         ('ending',
          ['20190404 1330', '20190404 1400'],
          [96.2818141290749, 91.5132934827808],
-         [99.25690632023922, 98.2405479197069]))
+         [99.25690632023922, 98.2405479197069],
+         1),
+        # test clipped at 2x clearsky
+        ('beginning',
+         ['20190404 1300', '20190404 1330'],
+         [1926.5828549018618, 1832.4163238767312],
+         [395.9216674046528, 391.9265149579709],
+         50)
+    )
 )
 def test_persistence_scalar_index(
-        site_metadata, powerplant_metadata, uniform_data, interval_label,
-        expected_index, expected_ghi, expected_ac):
+        powerplant_metadata, uniform_data, interval_label,
+        expected_index, expected_ghi, expected_ac, obsscale):
+    # ac_capacity is 200 from above
     observation = default_observation(
-        site_metadata, interval_length='5min', interval_label='beginning')
+        powerplant_metadata, interval_length='5min',
+        interval_label='beginning')
     observation_ac = default_observation(
         powerplant_metadata, interval_length='5min',
         interval_label='beginning', variable='ac_power')
 
-    data = uniform_data
+    data = uniform_data * obsscale
     tz = data.index.tzinfo
     data_start = pd.Timestamp('20190404 1200', tz=tz)
     data_end = pd.Timestamp('20190404 1300', tz=tz)


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #517, closes #518, closes #528, closes #524.
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Two questions: should day ahead persistence keep NaNs in the forecast or fail to make one? Should probabilistic forecast return empty series when there is no data or raise some error?