### PR TITLE
metrics/probabilities: add quantile score

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -569,6 +569,8 @@ Functions to compute forecast probabilistic performance metrics:
 
     metrics.probabilistic.brier_score
     metrics.probabilistic.brier_skill_score
+    metrics.probabilistic.quantile_score
+    metrics.probabilistic.quantile_skill_score
     metrics.probabilistic.brier_decomposition
     metrics.probabilistic.reliability
     metrics.probabilistic.resolution

--- a/docs/source/whatsnew/1.0.0rc3.rst
+++ b/docs/source/whatsnew/1.0.0rc3.rst
@@ -8,7 +8,9 @@ This is the third 1.0 release candidate.
 
 API Changes
 ~~~~~~~~~~~
-
+* Added quantile score and skill score metrics
+  :py:func:`solarforecastarbiter.metrics.probabilistic.quantile_score`
+  :py:func:`solarforecastarbiter.metrics.probabilistic.quantile_skill_score` (:issue:`520`) (:pull:`530`)
 
 
 Enhancements

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -98,7 +98,7 @@ def quantile_score(obs, fx, fx_prob):
     where :math:`n` is the number of forecasts, :math:`obs_i` is an
     observation, :math:`fx_i` is a forecast, :math:`1\{obs_i > fx_i\}` is an
     indicator function (1 if :math:`obs_i > fx_i`, 0 otherwise) and :math:`p`
-    is the probability that :math:`obs_i <= fx_i`. [1]_ [2]_
+    is the probability that :math:`obs_i <= fx_i`. [1]_ [2]_ [3]_
 
     If :math:`obs > fx`, then we have:
 
@@ -149,10 +149,12 @@ def quantile_score(obs, fx, fx_prob):
     References
     ----------
     .. [1] Koenker and Bassett, Jr. (1978) "Regression Quantiles", Econometrica
-           46 (1), pp. 33-50. doi: 10.2307/1913643
+       46 (1), pp. 33-50. doi: 10.2307/1913643
     .. [2] Bouallegue, Pinson and Friederichs (2015) "Quantile forecast
        discrimination ability and value", Quarterly Journal of the Royal
        Meteorological Society 141, pp. 3415-3424. doi: 10.1002/qj.2624
+    .. [3] Wilks (2020) "Forecast Verification". In "Statistical Methods in the
+       Atmospheric Sciences" (3rd edition). Academic Press. ISBN: 9780123850225
 
     """  # NOQA: E501,W605
 

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -94,7 +94,7 @@ def quantile_score(obs, fx, fx_prob):
         QS = 1/n sum_{i=1}^n (obs_i - fx_i) * (1{obs_i >= fx_i} - p_i)
 
     where n is the number of forecasts, obs_i is an observation, fx_i is a
-    forecast, 1{obs_i >= fx_i} is an indicator function (1 if obs_i >= fx_i, 0
+    forecast, 1{obs_i <= fx_i} is an indicator function (1 if obs_i <= fx_i, 0
     otherwise) and p_i is the probability.
 
     Parameters
@@ -114,17 +114,20 @@ def quantile_score(obs, fx, fx_prob):
 
     Examples
     --------
-    >>> obs = [5]  # observation [MW]
-    >>> fx = [4]   # forecast [MW]
+    >>> obs = [4]  # observation [MW]
+    >>> fx = [5]   # forecast [MW]
     >>> fx_prob = [50]  # probability [%]
     >>> quantile_score(obs, fx, fx_prob)
     0.5   # score [MW]
 
     """
 
-    indicator = np.where(obs <= fx, 1.0, 0.0)  # 1 if obs <= fx, 0 otherwise
+    # Prob(obs <= fx) = p
     p = fx_prob / 100.0
-    qs = np.mean((obs - fx) * (indicator - p))
+    idx = obs <= fx
+    qs_pos = p[idx] * np.abs(obs[idx] - fx[idx])
+    qs_neg = (1.0 - p[~idx]) * np.abs(obs[~idx] - fx[~idx])
+    qs = np.mean(np.concatenate([qs_pos, qs_neg]))
     return qs
 
 

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -478,6 +478,8 @@ _MAP = {
     'rel': (reliability, 'REL'),
     'res': (resolution, 'RES'),
     'unc': (uncertainty, 'UNC'),
+    'qs': (quantile_score, 'QS'),
+    'qss': (quantile_skill_score, 'QSS'),
     # 'sh': (sharpness, 'SH'),  # TODO
     'crps': (continuous_ranked_probability_score, 'CRPS'),
 }
@@ -485,7 +487,7 @@ _MAP = {
 __all__ = [m[0].__name__ for m in _MAP.values()]
 
 # Functions that require a reference forecast
-_REQ_REF_FX = ['bss']
+_REQ_REF_FX = ['bss', 'qss']
 
 # Functions that require normalized factor
 _REQ_NORM = []

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -93,34 +93,28 @@ def quantile_score(obs, fx, fx_prob):
 
     .. math::
 
-        QS = 1/n sum_{i=1}^n (fx_i - obs_i) * (p - 1{obs_i > fx_i})
+        \\text{QS} = 1/n \\sum_{i=1}^n (fx_i - obs_i) * (p - 1\{obs_i > fx_i\})
 
     where :math:`n` is the number of forecasts, :math:`obs_i` is an
-    observation, :math:`fx_i` is a forecast, :math:`1{obs_i > fx_i}` is an
+    observation, :math:`fx_i` is a forecast, :math:`1\{obs_i > fx_i\}` is an
     indicator function (1 if :math:`obs_i > fx_i`, 0 otherwise) and :math:`p`
     is the probability that :math:`obs_i <= fx_i`. [1]_ [2]_
 
     If :math:`obs > fx`, then we have:
 
     .. math::
-       :nowrap:
 
-        \begin{align}
-            (fx - obs) &< 0 \\
-            (p - 1{obs > fx}) &= (p - 1) <= 0 \\
-            (fx - obs) * (p - 1) &>= 0
-        \end{align}
+        (fx - obs) < 0 \\\\
+        (p - 1\{obs > fx\}) = (p - 1) <= 0 \\\\
+        (fx - obs) * (p - 1) >= 0
 
     If instead :math:`obs < fx`, then we have:
 
     .. math::
-       :nowrap:
 
-        \begin{eqnarray}
-            (fx - obs) &> 0 \\
-            (p - 1{obs > fx}) &= (p - 0) >= 0 \\
-            (fx - obs) * p &>= 0
-        \end{eqnarray}
+        (fx - obs) > 0 \\\\
+        (p - 1\{obs > fx\}) = (p - 0) >= 0 \\\\
+        (fx - obs) * p >= 0
 
     Therefore, the quantile score is non-negative regardless of the obs and fx.
 

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -103,18 +103,24 @@ def quantile_score(obs, fx, fx_prob):
     If :math:`obs > fx`, then we have:
 
     .. math::
+       :nowrap:
 
-        (fx - obs) &< 0 \\
-        (p - 1{obs > fx}) &= (p - 1) <= 0 \\
-        (fx - obs) * (p - 1) &>= 0
+        \begin{align}
+            (fx - obs) &< 0 \\
+            (p - 1{obs > fx}) &= (p - 1) <= 0 \\
+            (fx - obs) * (p - 1) &>= 0
+        \end{align}
 
     If instead :math:`obs < fx`, then we have:
 
     .. math::
+       :nowrap:
 
-        (fx - obs) &> 0 \\
-        (p - 1{obs &> fx}) = (p - 0) >= 0 \\
-        (fx - obs) * p & >= 0
+        \begin{eqnarray}
+            (fx - obs) &> 0 \\
+            (p - 1{obs > fx}) &= (p - 0) >= 0 \\
+            (fx - obs) * p &>= 0
+        \end{eqnarray}
 
     Therefore, the quantile score is non-negative regardless of the obs and fx.
 

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -198,6 +198,10 @@ def quantile_skill_score(obs, fx, fx_prob, ref, ref_prob):
        discrimination ability and value", Quarterly Journal of the Royal
        Meteorological Society 141, pp. 3415-3424. doi: 10.1002/qj.2624
 
+    Notes
+    -----
+    This function returns 0 if QS_fx and QS_ref are both 0.
+
     See Also
     --------
     :py:func:`solarforecastarbiter.metrics.probabilistic.quantile_score`
@@ -206,8 +210,16 @@ def quantile_skill_score(obs, fx, fx_prob, ref, ref_prob):
 
     qs_fx = quantile_score(obs, fx, fx_prob)
     qs_ref = quantile_score(obs, ref, ref_prob)
-    skill = 1.0 - qs_fx / qs_ref
-    return skill
+
+    # avoid 0 / 0 --> nan
+    if qs_fx == qs_ref:
+        return 0.0
+    elif qs_ref == 0.0:
+        # avoid divide by 0
+        # typically caused by deadbands and short time periods
+        return np.NINF
+    else:
+        return 1.0 - qs_fx / qs_ref
 
 
 def _unique_forecasts(f):

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -91,19 +91,26 @@ def brier_skill_score(obs, fx, fx_prob, ref, ref_prob):
 def quantile_score(obs, fx, fx_prob):
     """Quantile Score (QS).
 
-        QS = 1/n sum_{i=1}^n (fx_i - obs_i) * (p_i - 1{obs_i > fx_i})
+    .. math::
 
-    where n is the number of forecasts, obs_i is an observation, fx_i is a
-    forecast, 1{obs_i > fx_i} is an indicator function (1 if obs_i > fx_i, 0
-    otherwise) and p_i is the probability that obs_i <= fx_i.
+        QS = 1/n sum_{i=1}^n (fx_i - obs_i) * (p - 1{obs_i > fx_i})
 
-    If obs > fx, then we have:
+    where :math:`n` is the number of forecasts, :math:`obs_i` is an
+    observation, :math:`fx_i` is a forecast, :math:`1{obs_i > fx_i}` is an
+    indicator function (1 if :math:`obs_i > fx_i`, 0 otherwise) and :math:`p`
+    is the probability that :math:`obs_i <= fx_i`. [1]_ [2]_
+
+    If :math:`obs > fx`, then we have:
+
+    .. math::
 
         (fx - obs) < 0
         (p - 1{obs > fx}) = (p - 1) <= 0
         (fx - obs) * (p - 1) >= 0
 
-    If instead obs < fx, then we have:
+    If instead :math:`obs < fx`, then we have:
+
+    .. math::
 
         (fx - obs) > 0
         (p - 1{obs > fx}) = (p - 0) >= 0
@@ -126,6 +133,11 @@ def quantile_score(obs, fx, fx_prob):
     qs : float
         The Quantile Score, with the same units as the observations.
 
+    Notes
+    -----
+    Quantile score is meant to be computed for a single probability of
+    :math:`n` samples.
+
     Examples
     --------
     >>> obs = 100     # observation [MW]
@@ -133,6 +145,14 @@ def quantile_score(obs, fx, fx_prob):
     >>> fx_prob = 60  # probability [%]
     >>> quantile_score(obs, fx, fx_prob)   # score [MW]
     8.0
+
+    References
+    ----------
+    .. [1] Koenker and Bassett, Jr. (1978) "Regression Quantiles", Econometrica
+           46 (1), pp. 33-50. doi: 10.2307/1913643
+    .. [2] Bouallegue, Pinson and Friederichs (2015) "Quantile forecast
+       discrimination ability and value", Quarterly Journal of the Royal
+       Meteorological Society 141, pp. 3415-3424. doi: 10.1002/qj.2624
 
     """
 

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -98,7 +98,7 @@ def quantile_score(obs, fx, fx_prob):
     where :math:`n` is the number of forecasts, :math:`obs_i` is an
     observation, :math:`fx_i` is a forecast, :math:`1\{obs_i > fx_i\}` is an
     indicator function (1 if :math:`obs_i > fx_i`, 0 otherwise) and :math:`p`
-    is the probability that :math:`obs_i <= fx_i`. [1]_ [2]_ [3]_
+    is the probability that :math:`obs_i <= fx_i`. [1]_ [2]_
 
     If :math:`obs > fx`, then we have:
 
@@ -150,10 +150,7 @@ def quantile_score(obs, fx, fx_prob):
     ----------
     .. [1] Koenker and Bassett, Jr. (1978) "Regression Quantiles", Econometrica
        46 (1), pp. 33-50. doi: 10.2307/1913643
-    .. [2] Bouallegue, Pinson and Friederichs (2015) "Quantile forecast
-       discrimination ability and value", Quarterly Journal of the Royal
-       Meteorological Society 141, pp. 3415-3424. doi: 10.1002/qj.2624
-    .. [3] Wilks (2020) "Forecast Verification". In "Statistical Methods in the
+    .. [2] Wilks (2020) "Forecast Verification". In "Statistical Methods in the
        Atmospheric Sciences" (3rd edition). Academic Press. ISBN: 9780123850225
 
     """  # NOQA: E501,W605
@@ -173,7 +170,7 @@ def quantile_skill_score(obs, fx, fx_prob, ref, ref_prob):
 
     where :math:`\\text{QS}_{\\text{fx}}` is the Quantile Score of the
     evaluated forecast and :math:`\\text{QS}_{\\text{ref}}` is the Quantile
-    Score of a reference forecast.
+    Score of a reference forecast. [1]_
 
     Parameters
     ----------
@@ -194,6 +191,12 @@ def quantile_skill_score(obs, fx, fx_prob, ref, ref_prob):
     -------
     skill : float
         The Quantile Skill Score [unitless].
+
+    References
+    ----------
+    .. [1] Bouallegue, Pinson and Friederichs (2015) "Quantile forecast
+       discrimination ability and value", Quarterly Journal of the Royal
+       Meteorological Society 141, pp. 3415-3424. doi: 10.1002/qj.2624
 
     See Also
     --------

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -319,7 +319,7 @@ def reliability(obs, fx, fx_prob):
         forecast has value of 0.
 
     See Also
-    ---------
+    --------
     brier_decomposition : 3-component decomposition of the Brier Score
 
     """
@@ -356,7 +356,7 @@ def resolution(obs, fx, fx_prob):
         better.
 
     See Also
-    ---------
+    --------
     brier_decomposition : 3-component decomposition of the Brier Score
 
     """
@@ -389,7 +389,7 @@ def uncertainty(obs, fx, fx_prob):
         forecasted occurs rarely.
 
     See Also
-    ---------
+    --------
     brier_decomposition : 3-component decomposition of the Brier Score
 
     """

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -104,17 +104,17 @@ def quantile_score(obs, fx, fx_prob):
 
     .. math::
 
-        (fx - obs) < 0
-        (p - 1{obs > fx}) = (p - 1) <= 0
-        (fx - obs) * (p - 1) >= 0
+        (fx - obs) &< 0 \\
+        (p - 1{obs > fx}) &= (p - 1) <= 0 \\
+        (fx - obs) * (p - 1) &>= 0
 
     If instead :math:`obs < fx`, then we have:
 
     .. math::
 
-        (fx - obs) > 0
-        (p - 1{obs > fx}) = (p - 0) >= 0
-        (fx - obs) * p >= 0
+        (fx - obs) &> 0 \\
+        (p - 1{obs &> fx}) = (p - 0) >= 0 \\
+        (fx - obs) * p & >= 0
 
     Therefore, the quantile score is non-negative regardless of the obs and fx.
 

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -93,7 +93,7 @@ def quantile_score(obs, fx, fx_prob):
 
     .. math::
 
-        \\text{QS} = 1/n \\sum_{i=1}^n (fx_i - obs_i) * (p - 1\{obs_i > fx_i\})
+        \\text{QS} = \\frac{1}{n} \\sum_{i=1}^n (fx_i - obs_i) * (p - 1\{obs_i > fx_i\})
 
     where :math:`n` is the number of forecasts, :math:`obs_i` is an
     observation, :math:`fx_i` is a forecast, :math:`1\{obs_i > fx_i\}` is an
@@ -167,10 +167,11 @@ def quantile_skill_score(obs, fx, fx_prob, ref, ref_prob):
 
     .. math::
 
-        QSS = 1 - QS_fx / QS_ref
+        \\text{QSS} = 1 - \\text{QS}_{\\text{fx}} / \\text{QS}_{\\text{ref}}
 
-    where :math:`QS_fx` is the Quantile Score of the evaluated forecast and
-    :math:`QS_ref` is the Quantile Score of a reference forecast.
+    where :math:`\\text{QS}_{\\text{fx}}` is the Quantile Score of the
+    evaluated forecast and :math:`\\text{QS}_{\\text{ref}}` is the Quantile
+    Score of a reference forecast.
 
     Parameters
     ----------

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -165,10 +165,12 @@ def quantile_score(obs, fx, fx_prob):
 def quantile_skill_score(obs, fx, fx_prob, ref, ref_prob):
     """Quantile Skill Score (QSS).
 
+    .. math::
+
         QSS = 1 - QS_fx / QS_ref
 
-    where QS_fx is the Quantile Score of the evaluated forecast and QS_ref is
-    the Quantile Score of a reference forecast.
+    where :math:`QS_fx` is the Quantile Score of the evaluated forecast and
+    :math:`QS_ref` is the Quantile Score of a reference forecast.
 
     Parameters
     ----------

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -154,7 +154,7 @@ def quantile_score(obs, fx, fx_prob):
        discrimination ability and value", Quarterly Journal of the Royal
        Meteorological Society 141, pp. 3415-3424. doi: 10.1002/qj.2624
 
-    """
+    """  # NOQA: E501,W605
 
     # Prob(obs <= fx) = p
     p = fx_prob / 100.0

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -131,7 +131,7 @@ def quantile_score(obs, fx, fx_prob):
     >>> obs = 100     # observation [MW]
     >>> fx = 80       # forecast [MW]
     >>> fx_prob = 60  # probability [%]
-    >>> quantile_score(obs, fx, fx_prob)   # score [W/m^2]
+    >>> quantile_score(obs, fx, fx_prob)   # score [MW]
     8.0
 
     """

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -372,9 +372,9 @@ def test_calculate_metrics_with_probablistic(single_observation,
     expected = {
         0: ('total', 'bs', '0', 0.8308500000000001),
         1: ('total', 'bss', '0', -0.010366947374821578),
-        5: ('year', 'bs', '2019', 0.8308500000000001),
-        9: ('year', 'unc', '2019', 0.08999999999999998),
-        10: ('month', 'bs', 'Aug', 0.8308500000000001)
+        7: ('year', 'bs', '2019', 0.8308500000000001),
+        11: ('year', 'unc', '2019', 0.08999999999999998),
+        14: ('month', 'bs', 'Aug', 0.8308500000000001)
     }
     attr_order = ('category', 'metric', 'index', 'value')
     for k, expected_attrs in expected.items():

--- a/solarforecastarbiter/metrics/tests/test_probabilistic.py
+++ b/solarforecastarbiter/metrics/tests/test_probabilistic.py
@@ -47,6 +47,7 @@ def test_brier_skill_score(fx, fx_prob, ref, ref_prob, obs, value):
     (np.array([5]), np.array([4]), np.array([50]), 0.5),
     (np.array([4, 5]), np.array([5, 4]), np.array([50, 50]), 0.5),
     (np.array([2]), np.array([10]), np.array([80]), 6.4),
+    (np.array([100]), np.array([80]), np.array([60]), 8.0),
 ])
 def test_quantile_score(obs, fx, fx_prob, expected_value):
     assert prob.quantile_score(obs, fx, fx_prob) == expected_value

--- a/solarforecastarbiter/metrics/tests/test_probabilistic.py
+++ b/solarforecastarbiter/metrics/tests/test_probabilistic.py
@@ -46,6 +46,8 @@ def test_brier_skill_score(fx, fx_prob, ref, ref_prob, obs, value):
     (4, 5, 50, 0.5),
     (5, 4, 50, 0.5),
     (2, 10, 80, 6.4),
+    (2, 3, 80, 0.8),
+    (2, 100, 100, 98),
     (100, 80, 50, 10.0),
     (100, 80, 60, 8.0),
     (np.array([4, 5]), np.array([5, 4]), np.array([50, 50]), 0.5),
@@ -57,6 +59,10 @@ def test_quantile_score(obs, fx, fx_prob, value):
 @pytest.mark.parametrize("obs,fx,fx_prob,ref,ref_prob,value", [
     (4, 5, 50, 3, 50, 1 - 0.5 / 0.5),
     (100, 80, 60, 80, 50, 1 - 8 / 10),
+    (2, 1, 80, 10, 80, 1 - 0.2 / 6.4),
+    (2, 3, 80, 10, 80, 1 - 0.8 / 6.4),
+    (2, 3, 80, 100, 100, 1 - 0.8 / 98),
+    (4, 5, 50, 4, 100, np.NINF),
 ])
 def test_quantile_skill_score(obs, fx, fx_prob, ref, ref_prob, value):
     assert prob.quantile_skill_score(obs, fx, fx_prob, ref, ref_prob) == value

--- a/solarforecastarbiter/metrics/tests/test_probabilistic.py
+++ b/solarforecastarbiter/metrics/tests/test_probabilistic.py
@@ -42,15 +42,24 @@ def test_brier_skill_score(fx, fx_prob, ref, ref_prob, obs, value):
     assert prob.brier_skill_score(obs, fx, fx_prob, ref, ref_prob) == value
 
 
-@pytest.mark.parametrize("obs,fx,fx_prob,expected_value", [
-    (np.array([4]), np.array([5]), np.array([50]), 0.5),
-    (np.array([5]), np.array([4]), np.array([50]), 0.5),
+@pytest.mark.parametrize("obs,fx,fx_prob,value", [
+    (4, 5, 50, 0.5),
+    (5, 4, 50, 0.5),
+    (2, 10, 80, 6.4),
+    (100, 80, 50, 10.0),
+    (100, 80, 60, 8.0),
     (np.array([4, 5]), np.array([5, 4]), np.array([50, 50]), 0.5),
-    (np.array([2]), np.array([10]), np.array([80]), 6.4),
-    (np.array([100]), np.array([80]), np.array([60]), 8.0),
 ])
-def test_quantile_score(obs, fx, fx_prob, expected_value):
-    assert prob.quantile_score(obs, fx, fx_prob) == expected_value
+def test_quantile_score(obs, fx, fx_prob, value):
+    assert prob.quantile_score(obs, fx, fx_prob) == value
+
+
+@pytest.mark.parametrize("obs,fx,fx_prob,ref,ref_prob,value", [
+    (4, 5, 50, 3, 50, 1 - 0.5 / 0.5),
+    (100, 80, 60, 80, 50, 1 - 8 / 10),
+])
+def test_quantile_skill_score(obs, fx, fx_prob, ref, ref_prob, value):
+    assert prob.quantile_skill_score(obs, fx, fx_prob, ref, ref_prob) == value
 
 
 @pytest.mark.parametrize("f,value", [

--- a/solarforecastarbiter/metrics/tests/test_probabilistic.py
+++ b/solarforecastarbiter/metrics/tests/test_probabilistic.py
@@ -42,6 +42,16 @@ def test_brier_skill_score(fx, fx_prob, ref, ref_prob, obs, value):
     assert prob.brier_skill_score(obs, fx, fx_prob, ref, ref_prob) == value
 
 
+@pytest.mark.parametrize("obs,fx,fx_prob,expected_value", [
+    (np.array([4]), np.array([5]), np.array([50]), 0.5),
+    (np.array([5]), np.array([4]), np.array([50]), 0.5),
+    (np.array([4, 5]), np.array([5, 4]), np.array([50, 50]), 0.5),
+    (np.array([2]), np.array([10]), np.array([80]), 6.4),
+])
+def test_quantile_score(obs, fx, fx_prob, expected_value):
+    assert prob.quantile_score(obs, fx, fx_prob) == expected_value
+
+
 @pytest.mark.parametrize("f,value", [
     ([0.1234], [0.1]),
     ([0.1689], [0.2]),


### PR DESCRIPTION
Add Quantile Score and Quantile Skill Score for evaluating probabilistic
forecasts.

  - [X] Closes #520 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.