### PR TITLE
pvlib 0.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ numpy==1.18.2
 pandas==1.0.3
 plotly==4.5.3
 psutil==5.7.0
-pvlib==0.8.0b0
+pvlib==0.8.0
 python-dateutil==2.8.1
 requests==2.22.0
 scipy==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ numpy==1.18.2
 pandas==1.0.3
 plotly==4.5.3
 psutil==5.7.0
-pvlib==0.7.2
+pvlib==0.8.0b0
 python-dateutil==2.8.1
 requests==2.22.0
 scipy==1.4.1

--- a/solarforecastarbiter/pvmodel.py
+++ b/solarforecastarbiter/pvmodel.py
@@ -294,9 +294,8 @@ def calculate_power(dc_capacity, temperature_coefficient, dc_loss_factor,
     dc = pvlib.pvsystem.pvwatts_dc(poa_effective, pvtemps, dc_capacity,
                                    temperature_coefficient / 100)
     dc *= (1 - dc_loss_factor / 100)
-    # set eta values to turn off clipping in pvwatts_ac
-    ac = pvlib.pvsystem.pvwatts_ac(dc, dc_capacity, eta_inv_nom=1,
-                                   eta_inv_ref=1)
+    # set eta values to turn off clipping in pvwatts inverter model
+    ac = pvlib.inverter.pvwatts(dc, dc_capacity, eta_inv_nom=1, eta_inv_ref=1)
     ac = ac.clip(upper=ac_capacity)
     ac *= (1 - ac_loss_factor / 100)
     return ac


### PR DESCRIPTION


  - [ ] Closes #xxxx .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

pvlib 0.8.0 will be released later today (hopefully), so making sure that our CI is happy with the beta release.

It looks like there's only one API change to deal with this time. 

The big win for us is the `read_crn` fix https://github.com/pvlib/pvlib-python/issues/1025

fyi @cwhanse.