### PR TITLE
pyupgrade --py38-plus

### DIFF
--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Data classes and acceptable variables as defined by the SolarForecastArbiter
 Data Model document. Python 3.7 is required.
@@ -1845,7 +1844,7 @@ class ReportParameters(BaseModel):
     def __post_init__(self):
         # ensure that all forecast and observation units are the same
         __check_units__(*itertools.chain.from_iterable(
-            ((k.forecast, k.data_object) for k in self.object_pairs)))
+            (k.forecast, k.data_object) for k in self.object_pairs))
         # ensure the metrics can be applied to the forecasts and observations
         for k in self.object_pairs:
             __check_metrics__(k.forecast, self.metrics)

--- a/solarforecastarbiter/io/fetch/tests/test_arm.py
+++ b/solarforecastarbiter/io/fetch/tests/test_arm.py
@@ -44,7 +44,7 @@ def test_format_date():
 
 
 def mocked_request_get_files(*args, **kwargs):
-    class Object(object):
+    class Object:
         pass
     response = Object()
     response.text = '{"files": ["filename1", "filename2"]}'

--- a/solarforecastarbiter/io/fetch/tests/test_eia.py
+++ b/solarforecastarbiter/io/fetch/tests/test_eia.py
@@ -11,7 +11,7 @@ BAD_FILE = os.path.join(TEST_DATA_DIR, 'data', 'eia_caiso_bad.json')
 
 
 def test_get_eia_data(requests_mock):
-    with open(GOOD_FILE, "r") as f:
+    with open(GOOD_FILE) as f:
         content = f.read()
 
     requests_mock.register_uri(
@@ -32,7 +32,7 @@ def test_get_eia_data(requests_mock):
 
 
 def test_get_eia_data_bad(requests_mock):
-    with open(BAD_FILE, "r") as f:
+    with open(BAD_FILE) as f:
         content = f.read()
 
     requests_mock.register_uri(

--- a/solarforecastarbiter/io/fetch/tests/test_pvdaq.py
+++ b/solarforecastarbiter/io/fetch/tests/test_pvdaq.py
@@ -15,7 +15,7 @@ DATA_FILE_2019 = os.path.join(TEST_DATA_DIR, 'data', 'pvdaq_2019_data.csv')
 
 
 def test_get_pvdaq_metadata(requests_mock):
-    with open(SYSTEM_FILE, 'r') as f:
+    with open(SYSTEM_FILE) as f:
         content = f.read()
 
     requests_mock.register_uri(
@@ -56,7 +56,7 @@ def test_get_pvdaq_metadata(requests_mock):
 
 
 def test_get_pvdaq_data(requests_mock):
-    with open(DATA_FILE, 'r') as f:
+    with open(DATA_FILE) as f:
         content = f.read()
 
     requests_mock.register_uri(
@@ -74,7 +74,7 @@ def test_get_pvdaq_data(requests_mock):
 
 def test_get_pvdaq_data_2years(requests_mock):
 
-    with open(DATA_FILE, 'r') as f:
+    with open(DATA_FILE) as f:
         content = f.read()
 
     requests_mock.register_uri(
@@ -83,7 +83,7 @@ def test_get_pvdaq_data_2years(requests_mock):
         content=content.encode()
     )
 
-    with open(DATA_FILE_2019, 'r') as f:
+    with open(DATA_FILE_2019) as f:
         content_2019 = f.read()
 
     requests_mock.register_uri(

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -1401,7 +1401,7 @@ def test_real_apisession_get_observation_values(real_session):
         '123e4567-e89b-12d3-a456-426655440000',
         start, end)
     assert isinstance(obs, pd.DataFrame)
-    assert set(obs.columns) == set(['value', 'quality_flag'])
+    assert set(obs.columns) == {'value', 'quality_flag'}
     assert len(obs.index) > 0
     pdt.assert_frame_equal(obs.loc[start:end], obs)
 
@@ -1414,7 +1414,7 @@ def test_real_apisession_get_observation_values_tz(real_session):
         '123e4567-e89b-12d3-a456-426655440000',
         start, end)
     assert isinstance(obs, pd.DataFrame)
-    assert set(obs.columns) == set(['value', 'quality_flag'])
+    assert set(obs.columns) == {'value', 'quality_flag'}
     assert len(obs.index) > 0
     end = end.tz_convert(start.tzinfo)
     pdt.assert_frame_equal(obs.loc[start:end], obs)
@@ -1536,7 +1536,7 @@ def test_real_apisession_get_aggregate_values(real_session):
         '458ffc27-df0b-11e9-b622-62adb5fd6af0',
         start, end)
     assert isinstance(agg, pd.DataFrame)
-    assert set(agg.columns) == set(['value', 'quality_flag'])
+    assert set(agg.columns) == {'value', 'quality_flag'}
     assert len(agg.index) > 0
     pdt.assert_frame_equal(agg.loc[start:end], agg)
 

--- a/solarforecastarbiter/io/utils.py
+++ b/solarforecastarbiter/io/utils.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """Collection of Functions to convert API responses into python objects
 and vice versa.
 """

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -93,10 +93,10 @@ def quantile_score(obs, fx, fx_prob):
 
     .. math::
 
-        \\text{QS} = \\frac{1}{n} \\sum_{i=1}^n (fx_i - obs_i) * (p - 1\{obs_i > fx_i\})
+        \\text{QS} = \\frac{1}{n} \\sum_{i=1}^n (fx_i - obs_i) * (p - 1\\{obs_i > fx_i\\})
 
     where :math:`n` is the number of forecasts, :math:`obs_i` is an
-    observation, :math:`fx_i` is a forecast, :math:`1\{obs_i > fx_i\}` is an
+    observation, :math:`fx_i` is a forecast, :math:`1\\{obs_i > fx_i\\}` is an
     indicator function (1 if :math:`obs_i > fx_i`, 0 otherwise) and :math:`p`
     is the probability that :math:`obs_i <= fx_i`. [1]_ [2]_
 
@@ -105,7 +105,7 @@ def quantile_score(obs, fx, fx_prob):
     .. math::
 
         (fx - obs) < 0 \\\\
-        (p - 1\{obs > fx\}) = (p - 1) <= 0 \\\\
+        (p - 1\\{obs > fx\\}) = (p - 1) <= 0 \\\\
         (fx - obs) * (p - 1) >= 0
 
     If instead :math:`obs < fx`, then we have:
@@ -113,7 +113,7 @@ def quantile_score(obs, fx, fx_prob):
     .. math::
 
         (fx - obs) > 0 \\\\
-        (p - 1\{obs > fx\}) = (p - 0) >= 0 \\\\
+        (p - 1\\{obs > fx\\}) = (p - 0) >= 0 \\\\
         (fx - obs) * p >= 0
 
     Therefore, the quantile score is non-negative regardless of the obs and fx.

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -765,7 +765,7 @@ def test_process_forecast_observations_same_name(
         costs=report.report_parameters.costs)
     assert len(processed_fxobs_list) == len(
         fxobs)
-    assert len(set(pfxobs.name for pfxobs in processed_fxobs_list)) == len(
+    assert len({pfxobs.name for pfxobs in processed_fxobs_list}) == len(
         fxobs)
 
 

--- a/solarforecastarbiter/reports/figures/tests/test_bokeh_figures.py
+++ b/solarforecastarbiter/reports/figures/tests/test_bokeh_figures.py
@@ -320,9 +320,9 @@ def no_stray_phantomjs():  # pragma: no cover
         for pid in os.listdir('/proc'):
             if pid.isdigit():
                 try:
-                    with open(f'/proc/{pid}/cmdline', 'r') as f:
+                    with open(f'/proc/{pid}/cmdline') as f:
                         cmd = f.read()
-                except IOError:
+                except OSError:
                     continue
                 else:
                     if 'phantomjs' in cmd:

--- a/solarforecastarbiter/validation/tests/test_validator.py
+++ b/solarforecastarbiter/validation/tests/test_validator.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Created on Wed Feb 27 15:12:14 2019
 

--- a/solarforecastarbiter/validation/validator.py
+++ b/solarforecastarbiter/validation/validator.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Created on Fri Feb 15 14:08:20 2019
 
@@ -649,7 +648,7 @@ def detect_stale_values(x, window=6, rtol=1e-5, atol=1e-8):
         ValueError if window < 2
     """
     if window < 2:
-        raise ValueError('window set to {}, must be at least 2'.format(window))
+        raise ValueError(f'window set to {window}, must be at least 2')
 
     flags = x.rolling(window=window).apply(
         _all_close_to_first, raw=True, kwargs={'rtol': rtol, 'atol': atol}
@@ -696,7 +695,7 @@ def detect_interpolation(x, window=6, rtol=1e-5, atol=1e-8):
         ValueError if window < 3
     """
     if window < 3:
-        raise ValueError('window set to {}, must be at least 3'.format(window))
+        raise ValueError(f'window set to {window}, must be at least 3')
 
     # reduce window by 1 because we're passing the first difference
     flags = detect_stale_values(x.diff(periods=1), window=window-1, rtol=rtol,


### PR DESCRIPTION
  - [ ] Closes #xxxx .
  - [ ] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

I recently learned about ``pyupgrade`` and thought I'd throw it at solarforecastarbiter to see what it catches. Mostly improvements, not sure about the doc formatting and the `IOError` vs. `OSError`.

```
pyupgrade --py38-plus solarforecastarbiter/**/[a-z]*.py
```