### PR TITLE
preprocessing documentation

### DIFF
--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -455,7 +455,29 @@ def process_forecast_observations(forecast_observations, filters,
     Returns
     -------
     list of ProcessedForecastObservation
-    """  # NOQA
+
+    Notes
+    -----
+    The logic is as follows.
+
+    For each forecast, observation pair in ``forecast_observations``:
+
+      1. Remove observation data points with ``quality_flag`` in filters.
+         Remaining observation series is discontinuous.
+      2. Fill missing forecast data points according to
+         ``forecast_fill_method``.
+      3. Fill missing reference forecast data points according to
+         ``forecast_fill_method``.
+      4. Resample observations to match forecast intervals. A minimum of 10% of
+         the observation intervals within a forecast interval must be valid
+         (not flagged or previously missing) else the resampled observation is
+         NaN.
+      5. Drop remaining NaN observation and forecast values.
+      6. Align observations to match forecast times. Observation times for
+         which there is not a matching forecast time are dropped.
+      7. Create :py:class:`~solarforecastarbiter.datamodel.ProcessedForecastObservation`
+         with resampled, aligned data and metadata.
+    """  # NOQA: E501
     if not all([isinstance(filter_, datamodel.QualityFlagFilter)
                 for filter_ in filters]):
         logger.warning(


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [ ] Closes #xxxx .
  - [ ] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.


I wanted to make sure I understand what preprocessing is currently doing with quality flags, resampling, and alignment before we change things, so I added a notes section to the `process_forecast_observations` docstring.