### PR TITLE
fix scatter plot axis range sensitivity to legend width

### DIFF
--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -1167,14 +1167,18 @@ def timeseries_plots(report):
             margin=PLOT_MARGINS,
         )
     else:
+        margin = PLOT_MARGINS.copy()
+        margin.pop('pad', None)
         scat_fig = scatter(value_df, meta_df, units)
         scat_fig.update_layout(
             plot_bgcolor=PLOT_BGCOLOR,
             font=dict(size=14),
             width=700,
-            height=600,
+            height=500,
             autosize=False,
-            yaxis=dict(scaleanchor="x", scaleratio=1, constrain="domain"),
+            xaxis=dict(scaleanchor="y", scaleratio=1, constrain="domain"),
+            yaxis=dict(constrain="domain"),
+            margin=margin,
         )
     includes_distribution = any(
         (


### PR DESCRIPTION


  - [x] Closes #419  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

![newplot(35)](https://user-images.githubusercontent.com/4383303/92980323-8edfa480-f44a-11ea-8af9-947559f4dfb4.png)
![newplot(36)](https://user-images.githubusercontent.com/4383303/92980324-9141fe80-f44a-11ea-81d4-8786c13cd84d.png)
