### PR TITLE
add __blurb__ to fx, obs dataclasses. use in preprocess results dict

### DIFF
--- a/docs/source/whatsnew/1.0.0rc3.rst
+++ b/docs/source/whatsnew/1.0.0rc3.rst
@@ -39,6 +39,8 @@ Bug fixes
   the x and y axes. (:issue:`419`) (:pull:`562`)
 * Render ``W/m^2`` with a superscript in time series and scatter plots.
   (:pull:`562`)
+* Render report preprocessing results with friendly names (e.g. Event Forecast)
+  instead of class names (e.g. EventForecast). (:issue:`406`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -9,7 +9,7 @@ import itertools
 import json
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
-from typing import Tuple, Union
+from typing import Tuple, Union, ClassVar
 
 
 import numpy as np
@@ -511,6 +511,7 @@ class Observation(BaseModel):
     --------
     :py:class:`solarforecastarbiter.datamodel.Site`
     """
+    __blurb__: ClassVar[str] = 'Observation'
     name: str
     variable: str
     interval_value_type: str
@@ -555,6 +556,7 @@ class AggregateObservation(BaseModel):
     :py:class:`solarforecastarbiter.datamodel.Observation`
     :py:class:`solarforecastarbiter.datamodel.Aggregate`
     """
+    __blurb__: ClassVar[str] = 'Aggregate Observation'
     observation: Observation
     effective_from: pd.Timestamp
     effective_until: Union[pd.Timestamp, None] = None
@@ -620,6 +622,7 @@ class Aggregate(BaseModel):
     --------
     :py:class:`solarforecastarbiter.datamodel.Observation`
     """
+    __blurb__: ClassVar[str] = 'Aggregate'
     name: str
     description: str
     variable: str
@@ -729,6 +732,8 @@ class Forecast(BaseModel, _ForecastDefaultsBase, _ForecastBase):
     :py:class:`solarforecastarbiter.datamodel.Site`
     :py:class:`solarforecastarbiter.datamodel.Aggregate`
     """
+    __blurb__: ClassVar[str] = 'Forecast'
+
     def __post_init__(self):
         __set_units__(self)
         __site_or_agg__(self)
@@ -793,6 +798,8 @@ class EventForecast(Forecast):
     --------
     :py:class:`solarforecastarbiter.datamodel.Forecast`
     """
+    __blurb__: ClassVar[str] = 'Event Forecast'
+
     def __post_init__(self):
         super().__post_init__()
 
@@ -865,6 +872,8 @@ class ProbabilisticForecastConstantValue(
     --------
     :py:class:`solarforecastarbiter.datamodel.ProbabilisticForecast`
     """
+    __blurb__: ClassVar[str] = 'Probabilistic Forecast Constant Value'
+
     def __post_init__(self):
         super().__post_init__()
         __check_axis__(self.axis)
@@ -936,6 +945,8 @@ class ProbabilisticForecast(
     ProbabilisticForecastConstantValue
     Forecast
     """
+    __blurb__: ClassVar[str] = 'Probabilistic Forecast'
+
     def __post_init__(self):
         super().__post_init__()
         __check_axis__(self.axis)

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -338,13 +338,13 @@ def resample_and_align(fx_obs, fx_data, obs_data, ref_data, tz):
 
     # Return dict summarizing results
     results = {
-        type(fx).__name__ + " " + DISCARD_DATA_STRING:
+        fx.__blurb__ + " " + DISCARD_DATA_STRING:
             len(fx_data.dropna(how="any")) - len(fx_aligned),
-        type(obs).__name__ + " " + DISCARD_DATA_STRING:
+        obs.__blurb__ + " " + DISCARD_DATA_STRING:
             len(obs_resampled) - len(observation_values),
-        type(fx).__name__ + " " + UNDEFINED_DATA_STRING:
+        fx.__blurb__ + " " + UNDEFINED_DATA_STRING:
             int(undefined_fx),
-        type(obs).__name__ + " " + UNDEFINED_DATA_STRING:
+        obs.__blurb__ + " " + UNDEFINED_DATA_STRING:
             int(obs_data.isna().sum())
     }
 


### PR DESCRIPTION

  - [x] Closes #406 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Adds new class variable `__blurb__` to the relevant datamodel objects. Then `preprocessing.resample_and_align` pulls this attribute instead of `type(fx).__name__`. I used the name "blurb" because it's similar to `datamodel.CATEGORY_BLURBS`, and I put it in dunderscores because 1. it's the same for all instances of the class, so should be a class variable and 2. I didn't want to clutter the primary object namespace.

I also considered:

* `isinstance` calls
* a dict with classes for the keys and friendly strings for the values. Would be accessed like `d[type(fx)]`

The class variable approach feels more robust to me, but maybe I'm missing something.

<img width="874" alt="Screen Shot 2020-09-12 at 12 42 50 PM" src="https://user-images.githubusercontent.com/4383303/93003848-05d27700-f4f7-11ea-8170-256c0318c3cf.png">
<img width="884" alt="Screen Shot 2020-09-12 at 12 44 33 PM" src="https://user-images.githubusercontent.com/4383303/93003849-0834d100-f4f7-11ea-99ce-e3bca98e05bb.png">
