### PR TITLE
Fix report plotting for probabilistic forecasts with axis=x

### DIFF
--- a/docs/source/whatsnew/1.0.0rc3.rst
+++ b/docs/source/whatsnew/1.0.0rc3.rst
@@ -41,6 +41,9 @@ Bug fixes
   (:pull:`562`)
 * Render report preprocessing results with friendly names (e.g. Event Forecast)
   instead of class names (e.g. EventForecast). (:issue:`406`)
+* Correct incorrect timeseries plots used in reports for probabilistic
+  forecasts with axis y. This bug was introduced in Release Candidate 2.
+  (:issue: `568`) (:pull: `569`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -531,7 +531,10 @@ def timeseries(timeseries_value_df, timeseries_meta_df,
     # add forecast traces that have correct axis to fig
     # get indices of probabilistic forecasts with axis y to create special
     # shaded distribution plots
-    y_distribution_indices = timeseries_meta_df['axis'] == 'y'
+    y_distribution_indices = (
+        timeseries_meta_df['distribution'].notna()
+        & (timeseries_meta_df['axis'] == 'y')
+    )
     non_y_distribution_meta_df = timeseries_meta_df[~y_distribution_indices]
     distribution_meta_df = timeseries_meta_df[y_distribution_indices]
 

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -529,12 +529,14 @@ def timeseries(timeseries_value_df, timeseries_meta_df,
         _plot_obs_timeseries(fig, timeseries_value_df, timeseries_meta_df)
 
     # add forecast traces that have correct axis to fig
-    non_distribution_indices = timeseries_meta_df['distribution'].isna()
-    non_distribution_meta_df = timeseries_meta_df[non_distribution_indices]
-    distribution_meta_df = timeseries_meta_df[~non_distribution_indices]
+    # get indices of probabilistic forecasts with axis y to create special
+    # shaded distribution plots
+    y_distribution_indices = timeseries_meta_df['axis'] == 'y'
+    non_y_distribution_meta_df = timeseries_meta_df[~y_distribution_indices]
+    distribution_meta_df = timeseries_meta_df[y_distribution_indices]
 
     _plot_fx_timeseries(
-        fig, timeseries_value_df, non_distribution_meta_df, axis)
+        fig, timeseries_value_df, non_y_distribution_meta_df, axis)
     _plot_fx_distribution_timeseries(
         fig, timeseries_value_df, distribution_meta_df, axis)
 


### PR DESCRIPTION

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #568  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Here's a screenshot of the report included in #568 after adjustment. This should be in line with the plots pre- #519 
![corrected](https://user-images.githubusercontent.com/21206164/93122592-9df96900-f67b-11ea-987d-baf0d71e3f93.png)