### PR TITLE
adjust how reference forecast names are truncated

### DIFF
--- a/docs/source/whatsnew/1.0.0rc3.rst
+++ b/docs/source/whatsnew/1.0.0rc3.rst
@@ -44,6 +44,9 @@ Bug fixes
 * Correct incorrect timeseries plots used in reports for probabilistic
   forecasts with axis y. This bug was introduced in Release Candidate 2.
   (:issue: `568`) (:pull: `569`)
+* Adjust abbreviation of long reference forecast names to first abbreviate
+  some words and then cut entire words from the site name (:issue:`521`)
+  (:pull:`571`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/io/reference_observations/common.py
+++ b/solarforecastarbiter/io/reference_observations/common.py
@@ -415,12 +415,22 @@ def _make_fx_name(site_name, template_name, variable):
     # Some site names are too long and exceed the API's limits,
     # in those cases. Use the abbreviated version.
     if len(fx_name) > 63:
-        for old, new in (('Persistence', 'Pers.'), ('persistence', 'pers.')):
+        for old, new in (
+            ('Persistence', 'Pers.'),
+            ('persistence', 'pers.'),
+            ('Fifteen-minute', '15 min.'),
+            ('Five-minute', '5 min.'),
+        ):
             template_name = template_name.replace(old, new)
         suffix = f'{template_name} {variable}'
+        # ensure suffix not more than 50 characters to allow
+        # for some site identification in the name
+        if len(suffix) > 50:
+            raise ValueError('Template forecast name is too long')
         while len(fx_name) > 63:
             # drop the last word
-            fx_name = f"{' '.join(site_name.split(' ')[:-1])} {suffix}"
+            site_name = ' '.join(site_name.split(' ')[:-1])
+            fx_name = f"{site_name} {suffix}"
         logger.warning("Forecast name truncated to %s", fx_name)
     return fx_name
 

--- a/solarforecastarbiter/io/reference_observations/common.py
+++ b/solarforecastarbiter/io/reference_observations/common.py
@@ -423,10 +423,10 @@ def _make_fx_name(site_name, template_name, variable):
         ):
             template_name = template_name.replace(old, new)
         suffix = f'{template_name} {variable}'
-        # ensure suffix not more than 50 characters to allow
-        # for some site identification in the name
-        if len(suffix) > 50:
-            raise ValueError('Template forecast name is too long')
+        # ensure name can containe at least first word of site
+        # name and the suffix
+        if (len(site_name.split(' ')[0]) + len(suffix)) > 62:
+            raise ValueError('Template/site name too long together')
         while len(fx_name) > 63:
             # drop the last word
             site_name = ' '.join(site_name.split(' ')[:-1])

--- a/solarforecastarbiter/io/reference_observations/common.py
+++ b/solarforecastarbiter/io/reference_observations/common.py
@@ -419,6 +419,7 @@ def _make_fx_name(site_name, template_name, variable):
             template_name = template_name.replace(old, new)
         suffix = f'{template_name} {variable}'
         while len(fx_name) > 63:
+            # drop the last word
             fx_name = f"{' '.join(site_name.split(' ')[:-1])} {suffix}"
         logger.warning("Forecast name truncated to %s", fx_name)
     return fx_name

--- a/solarforecastarbiter/io/reference_observations/tests/test_common.py
+++ b/solarforecastarbiter/io/reference_observations/tests/test_common.py
@@ -669,16 +669,21 @@ def test_create_one_forecast_issue_time(template_fx, tz, expected):
 
 def test_create_one_forecast_long_name(template_fx):
     api, template, site = template_fx
-    nn = ''.join(['n'] * 64)
+    nn = 'a ' + ''.join(['n'] * 64)
     fx = common.create_one_forecast(api, site.replace(name=nn), template,
                                     'ac_power')
-    assert fx.name == 'nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn Test Template ac_power'  # NOQA
+    assert fx.name == 'a Test Template ac_power'
     assert fx.variable == 'ac_power'
     assert fx.issue_time_of_day == dt.time(8)
     ep = json.loads(fx.extra_parameters)
     assert ep['is_reference_forecast']
     assert ep['model'] == 'gfs_quarter_deg_hourly_to_hourly_mean'
     assert 'piggyback_on' not in ep
+
+
+def test_make_fx_name_replace():
+    out = common._make_fx_name('The Site is really really really really long', 'Persistence 1hour ahead', 'GHI')  # NOQA
+    assert out == 'The Site is really really really really Pers. 1hour ahead GHI'  # NOQA
 
 
 def test_create_one_forecast_piggy(template_fx):

--- a/solarforecastarbiter/io/reference_observations/tests/test_common.py
+++ b/solarforecastarbiter/io/reference_observations/tests/test_common.py
@@ -681,9 +681,18 @@ def test_create_one_forecast_long_name(template_fx):
     assert 'piggyback_on' not in ep
 
 
-def test_make_fx_name_replace():
-    out = common._make_fx_name('The Site is really really really really long', 'Persistence 1hour ahead', 'GHI')  # NOQA
-    assert out == 'The Site is really really really really Pers. 1hour ahead GHI'  # NOQA
+@pytest.mark.parametrize('tmpl,exp', [
+    ('Persistence 1hour ahead', 'The Site is really really really really Pers. 1hour ahead GHI'),  # NOQA
+    ('Persistence Fifteen-minute ahead', 'The Site is really really really really Pers. 15 min. ahead GHI'),  # NOQA
+    ('n' * 46, 'The Site is ' + 'n' * 46 + ' GHI'),
+    pytest.param(
+        'This is too long to be a template forecast name and will raise a value error',   # NOQA
+        '', marks=pytest.mark.xfail(strict=True, raises=ValueError))
+])
+def test_make_fx_name(tmpl, exp):
+    out = common._make_fx_name(
+        'The Site is really really really really long', tmpl, 'GHI')
+    assert out == exp
 
 
 def test_create_one_forecast_piggy(template_fx):

--- a/solarforecastarbiter/io/reference_observations/tests/test_common.py
+++ b/solarforecastarbiter/io/reference_observations/tests/test_common.py
@@ -695,6 +695,14 @@ def test_make_fx_name(tmpl, exp):
     assert out == exp
 
 
+def test_make_fx_name_long_site():
+    with pytest.raises(ValueError):
+        common._make_fx_name(
+            'a' * 14,
+            'r' * 49,
+            '')
+
+
 def test_create_one_forecast_piggy(template_fx):
     api, template, site = template_fx
     fx = common.create_one_forecast(api, site, template, 'ac_power',


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #521 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

First, abbreviate Persistence to Pers. then start cutting whole words out of the site name