### PR TITLE
update SRML data to strip trailing nans

### DIFF
--- a/docs/source/whatsnew/1.0.0rc3.rst
+++ b/docs/source/whatsnew/1.0.0rc3.rst
@@ -49,7 +49,7 @@ Bug fixes
   (:pull:`571`)
 * Fixed issue with UO SRML reference data fetching that resulted in posting
   NaN values for data that had not yet been included in SRML files.
-  (:issue: `543`)(:pull: `` )
+  (:issue:`543`)(:pull:`572` )
 
 Contributors
 ~~~~~~~~~~~~

--- a/docs/source/whatsnew/1.0.0rc3.rst
+++ b/docs/source/whatsnew/1.0.0rc3.rst
@@ -47,6 +47,9 @@ Bug fixes
 * Adjust abbreviation of long reference forecast names to first abbreviate
   some words and then cut entire words from the site name (:issue:`521`)
   (:pull:`571`)
+* Fixed issue with UO SRML reference data fetching that resulted in posting
+  NaN values for data that had not yet been included in SRML files.
+  (:issue: `543`)(:pull: `` )
 
 Contributors
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/io/reference_observations/srml.py
+++ b/solarforecastarbiter/io/reference_observations/srml.py
@@ -130,8 +130,6 @@ def fetch(api, site, start, end):
     TypeError
         If start and end have different timezones, or if they do not include a
         timezone.
-    ValueError
-        If no data is available at the site between start and end.
     """
     month_dfs = []
     start_year = start.year

--- a/solarforecastarbiter/io/reference_observations/srml.py
+++ b/solarforecastarbiter/io/reference_observations/srml.py
@@ -130,6 +130,8 @@ def fetch(api, site, start, end):
     TypeError
         If start and end have different timezones, or if they do not include a
         timezone.
+    ValueError
+        If no data is available at the site between start and end.
     """
     month_dfs = []
     start_year = start.year

--- a/solarforecastarbiter/io/reference_observations/srml.py
+++ b/solarforecastarbiter/io/reference_observations/srml.py
@@ -116,14 +116,20 @@ def fetch(api, site, start, end):
     site : :py:class:`solarforecastarbiter.datamodel.Site`
         Site object with the appropriate metadata.
     start : datetime
-        The beginning of the period to request data for.
+        The beginning of the period to request data for. Must include timezone.
     end : datetime
-        The end of the period to request data for.
+        The end of the period to request data for. Must include timezone.
 
     Returns
     -------
     data : pandas.DataFrame
         All of the requested data concatenated into a single DataFrame.
+
+    Raises
+    ------
+    TypeError
+        If start and end have different timezones, or if they do not include a
+        timezone.
     """
     month_dfs = []
     start_year = start.year
@@ -155,6 +161,18 @@ def fetch(api, site, start, end):
     for column in power_columns:
         all_period_data[column] = all_period_data[column] / 1000000
     all_period_data = all_period_data[var_columns]
+
+    # slice to within timerange
+    all_period_data = all_period_data[start:end]
+
+    # remove possible trailing NaNs, it is necessary to do this after slicing
+    # because SRML data has nighttime data prefilled with 0s through the end of
+    # the month. This may not be effective if a given site has more than a 24
+    # hour lag, which will cause last_valid_index to return the latest
+    # timestamp just before sunrise, but will suffice for the typical lag on
+    # the order of hours.
+    all_period_data = all_period_data[:all_period_data.last_valid_index()]
+
     return all_period_data
 
 
@@ -183,7 +201,7 @@ def initialize_site_observations(api, site):
     different instruments.
     """
     # Request ~month old data at initialization to ensure we get a response.
-    start = pd.Timestamp.now() - pd.Timedelta('30 days')
+    start = pd.Timestamp.utcnow() - pd.Timedelta('30 days')
     end = start
     try:
         extra_params = common.decode_extra_parameters(site)

--- a/solarforecastarbiter/io/reference_observations/srml.py
+++ b/solarforecastarbiter/io/reference_observations/srml.py
@@ -160,10 +160,7 @@ def fetch(api, site, start, end):
     # adjust power from watts to megawatts
     for column in power_columns:
         all_period_data[column] = all_period_data[column] / 1000000
-    all_period_data = all_period_data[var_columns]
-
-    # slice to within timerange
-    all_period_data = all_period_data[start:end]
+    all_period_data = all_period_data.loc[start:end, var_columns]
 
     # remove possible trailing NaNs, it is necessary to do this after slicing
     # because SRML data has nighttime data prefilled with 0s through the end of

--- a/solarforecastarbiter/io/reference_observations/tests/test_srml.py
+++ b/solarforecastarbiter/io/reference_observations/tests/test_srml.py
@@ -69,19 +69,25 @@ def test_data():
 
 
 @pytest.mark.parametrize('start,end,exp', [
-    (dt.datetime(2019, 1, 10), dt.datetime(2019, 3, 11),
+    (dt.datetime(2019, 1, 10, tzinfo=dt.timezone.utc),
+     dt.datetime(2019, 3, 11, tzinfo=dt.timezone.utc),
      [(2019, 1), (2019, 2), (2019, 3)]),
-    (dt.datetime(2019, 11, 10), dt.datetime(2020, 2, 11),
+    (dt.datetime(2019, 11, 10, tzinfo=dt.timezone.utc),
+     dt.datetime(2020, 2, 11, tzinfo=dt.timezone.utc),
      [(2019, 11), (2019, 12), (2020, 1), (2020, 2)]),
-    (dt.datetime(2019, 11, 10), dt.datetime(2019, 11, 11),
+    (dt.datetime(2019, 11, 10, tzinfo=dt.timezone.utc),
+     dt.datetime(2019, 11, 11, tzinfo=dt.timezone.utc),
      [(2019, 11)]),
-    (dt.datetime(2019, 11, 10), dt.datetime(2021, 2, 11),
+    (dt.datetime(2019, 11, 10, tzinfo=dt.timezone.utc),
+     dt.datetime(2021, 2, 11, tzinfo=dt.timezone.utc),
      [(2019, 11), (2019, 12), (2020, 1), (2020, 2), (2020, 3),
       (2020, 4), (2020, 5), (2020, 6), (2020, 7), (2020, 8),
       (2020, 9), (2020, 10), (2020, 11), (2020, 12), (2021, 1),
       (2021, 2)]),
-    (dt.datetime(2019, 10, 1), dt.datetime(2019, 9, 1), []),
-    (dt.datetime(2019, 10, 1), dt.datetime(2018, 11, 1), [])
+    (dt.datetime(2019, 10, 1, tzinfo=dt.timezone.utc),
+     dt.datetime(2019, 9, 1, tzinfo=dt.timezone.utc), []),
+    (dt.datetime(2019, 10, 1, tzinfo=dt.timezone.utc),
+     dt.datetime(2018, 11, 1, tzinfo=dt.timezone.utc), [])
 ])
 def test_fetch(mocker, single_site, start, end, exp):
     rd = mocker.patch(
@@ -93,7 +99,8 @@ def test_fetch(mocker, single_site, start, end, exp):
 
 
 @pytest.mark.parametrize('start,end', [
-    (dt.datetime(2019, 1, 10), dt.datetime(2019, 3, 11)),
+    (dt.datetime(2019, 1, 10, tzinfo=dt.timezone.utc),
+     dt.datetime(2020, 3, 11, 8, 1, tzinfo=dt.timezone.utc)),
 ])
 def test_fetch_power_conversion(
         mocker, single_site, start, end, test_data):


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #543  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Gaps in SRML data have been caused by posting NaN when posting reference data. These NaN values exist because SRML files are prefilled through the given month with NaN values during the day and 0s at night. Posting the NaN values that occur between the last measurement and the end of the period we want to update causes the `/observations/{uuid}/values/latest` endpoint of the arbiter API to return the last timestamp filled with a NaN. The reference data update script then uses as the latest time as the start of the range to update. A simple call to `dropna` is insufficient because NaNs are also used to represent truly missing data.

This updates the `solarforecastarbiter.io.reference_observations.srml.fetch` function to slice data from start to end, and then slice again until the last valid index. This should handle dropping the trailing NaNs that cause the  gaps in data as can be seen at the [Hermiston OR site ](https://dashboard.solarforecastarbiter.org/observations/9d9d2780-7e49-11e9-a803-0a580a8003e9).

This should handle sites with a lag in data availability of less than 24 hours, which seems to be the most common case. One caveat is that it must run before sunset so as to not catch the prefilled nighttime 0s, I'm open to any other ideas on how to detect the true last valid value.