### PR TITLE
nighttime validation task that accounts for interval length

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -679,7 +679,8 @@ Functions to perform validation.
    validation.validator.check_dc_power_limits
    validation.validator.check_ghi_clearsky
    validation.validator.check_poa_clearsky
-   validation.validator.check_irradiance_day_night
+   validation.validator.check_day_night
+   validation.validator.check_day_night_interval
    validation.validator.check_timestamp_spacing
    validation.validator.detect_stale_values
    validation.validator.detect_interpolation

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1626,7 +1626,7 @@ def report_objects(aggregate, ref_forecast_id):
         name="University of Arizona OASIS ghi",
         variable="ghi",
         interval_value_type="interval_mean",
-        interval_length=pd.Timedelta("15min"),
+        interval_length=pd.Timedelta("1min"),
         interval_label="ending",
         site=site,
         uncertainty=1.0,

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -75,10 +75,11 @@ def _solpos_night_resample(observation, values):
         observation.site.latitude, observation.site.longitude,
         observation.site.elevation, obs_range
     )
-    night_flag = validator.check_irradiance_day_night(
+    # get the night flag as bitmask
+    night_flag = validator.check_irradiance_day_night_interval(
         solar_position['zenith'],
-        closed=closed,
-        interval_length=interval_length,
+        closed,
+        interval_length,
         solar_zenith_interval_length=freq,
         _return_mask=True
     )
@@ -88,7 +89,8 @@ def _solpos_night_resample(observation, values):
     solar_position = solar_position.resample(
         interval_length, closed=closed, label=closed
     ).mean()
-    # put gaps back in the data
+    # return series with same index as input values
+    # i.e. put any gaps back in the data
     night_flag = night_flag.loc[values.index]
     solar_position = solar_position.loc[values.index]
     return solar_position, night_flag

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -125,8 +125,8 @@ def validate_ghi(observation, values):
     timestamp_flag : pandas.Series
         Bitmask from :py:func:`.validator.check_timestamp_spacing`
     night_flag : pandas.Series
-        Bitmask from :py:func:`.validator.check_irradiance_day_night` or
-        :py:func:`.validator.check_irradiance_day_night_interval`
+        Bitmask from :py:func:`.validator.check_day_night` or
+        :py:func:`.validator.check_day_night_interval`
     ghi_limit_flag : pandas.Series
         Bitmask from :py:func:`.validator.check_ghi_limits_QCRad`
     ghi_clearsky_flag : pandas.Series
@@ -164,11 +164,13 @@ def validate_dni(observation, values):
 
     Returns
     -------
-    timestamp_flag, night_flag, dni_limit_flag : pandas.Series
-        Integer bitmask series from
-        :py:func:`.validator.check_timestamp_spacing`,
-        :py:func:`.validator.check_irradiance_day_night`,
-        :py:func:`.validator.check_dni_limits_QCRad` respectively
+    timestamp_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_timestamp_spacing`
+    night_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_day_night` or
+        :py:func:`.validator.check_day_night_interval`
+    dni_limit_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_dni_limits_QCRad`
     """
     solar_position, dni_extra, timestamp_flag, night_flag = _solpos_dni_extra(
         observation, values)
@@ -192,11 +194,13 @@ def validate_dhi(observation, values):
 
     Returns
     -------
-    timestamp_flag, night_flag, dhi_limit_flag : pandas.Series
-        Integer bitmask series from
-        :py:func:`.validator.check_timestamp_spacing`,
-        :py:func:`.validator.check_irradiance_day_night`,
-        :py:func:`.validator.check_dhi_limits_QCRad` respectively
+    timestamp_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_timestamp_spacing`
+    night_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_day_night` or
+        :py:func:`.validator.check_day_night_interval`
+    dhi_limit_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_dhi_limits_QCRad`
     """
     solar_position, dni_extra, timestamp_flag, night_flag = _solpos_dni_extra(
         observation, values)
@@ -220,11 +224,13 @@ def validate_poa_global(observation, values):
 
     Returns
     -------
-    timestamp_flag, night_flag, poa_clearsky_flag : pandas.Series
-        Integer bitmask series from
-        :py:func:`.validator.check_timestamp_spacing`,
-        :py:func:`.validator.check_irradiance_day_night`,
-        :py:func:`.validator.check_poa_clearsky` respectively
+    timestamp_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_timestamp_spacing`
+    night_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_day_night` or
+        :py:func:`.validator.check_day_night_interval`
+    poa_clearsky_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_poa_clearsky`
     """
     solar_position, dni_extra, timestamp_flag, night_flag = _solpos_dni_extra(
         observation, values)
@@ -254,16 +260,18 @@ def validate_air_temperature(observation, values):
 
     Returns
     -------
-    timestamp_flag, night_flag, temp_limit_flag : pandas.Series
-        Integer bitmask series from
-        :py:func:`.validator.check_timestamp_spacing`,
-        :py:func:`.validator.check_irradiance_day_night`,
-        :py:func:`.validator.check_temperature_limits` respectively
+    timestamp_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_timestamp_spacing`
+    night_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_day_night` or
+        :py:func:`.validator.check_day_night_interval`
+    limit_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_temperature_limits`
     """
     timestamp_flag, night_flag = validate_defaults(observation, values)
-    temp_limit_flag = validator.check_temperature_limits(
+    limit_flag = validator.check_temperature_limits(
         values, _return_mask=True)
-    return timestamp_flag, night_flag, temp_limit_flag
+    return timestamp_flag, night_flag, limit_flag
 
 
 def validate_wind_speed(observation, values):
@@ -279,16 +287,17 @@ def validate_wind_speed(observation, values):
 
     Returns
     -------
-    timestamp_flag, night_flag, wind_limit_flag : pandas.Series
-        Integer bitmask series from
-        :py:func:`.validator.check_timestamp_spacing`,
-        :py:func:`.validator.check_irradiance_day_night`,
-        :py:func:`.validator.check_wind_limits` respectively
+    timestamp_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_timestamp_spacing`
+    night_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_day_night` or
+        :py:func:`.validator.check_day_night_interval`
+    limit_flag : pandas.Series
+        Bitmask from :py:func:`.validator.wind_limit_flag`
     """
     timestamp_flag, night_flag = validate_defaults(observation, values)
-    wind_limit_flag = validator.check_wind_limits(values,
-                                                  _return_mask=True)
-    return timestamp_flag, night_flag, wind_limit_flag
+    limit_flag = validator.check_wind_limits(values, _return_mask=True)
+    return timestamp_flag, night_flag, limit_flag
 
 
 def validate_relative_humidity(observation, values):
@@ -304,15 +313,17 @@ def validate_relative_humidity(observation, values):
 
     Returns
     -------
-    timestamp_flag, night_flag, rh_limit_flag : pandas.Series
-        Integer bitmask series from
-        :py:func:`.validator.check_timestamp_spacing`,
-        :py:func:`.validator.check_irradiance_day_night`,
-        :py:func:`.validator.check_rh_limits` respectively
+    timestamp_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_timestamp_spacing`
+    night_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_day_night` or
+        :py:func:`.validator.check_day_night_interval`
+    limit_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_rh_limits`
     """
     timestamp_flag, night_flag = validate_defaults(observation, values)
-    rh_limit_flag = validator.check_rh_limits(values, _return_mask=True)
-    return timestamp_flag, night_flag, rh_limit_flag
+    limit_flag = validator.check_rh_limits(values, _return_mask=True)
+    return timestamp_flag, night_flag, limit_flag
 
 
 def validate_ac_power(observation, values):
@@ -328,20 +339,22 @@ def validate_ac_power(observation, values):
 
     Returns
     -------
-    timestamp_flag, night_flag, limit_flag : pandas.Series
-        Integer bitmask series from
-        :py:func:`.validator.check_timestamp_spacing`,
-        :py:func:`.validator.check_irradiance_day_night`,
-        :py:func:`.validator.check_power_limits`
+    timestamp_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_timestamp_spacing`
+    night_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_day_night` or
+        :py:func:`.validator.check_day_night_interval`
+    limit_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_ac_power_limits`
     """
     solar_position, dni_extra, timestamp_flag, night_flag = _solpos_dni_extra(
         observation, values)
     day_night = \
         ~quality_mapping.convert_mask_into_dataframe(night_flag)['NIGHTTIME']
-    ac_limit_flag = validator.check_ac_power_limits(
+    limit_flag = validator.check_ac_power_limits(
         values, day_night,
         observation.site.modeling_parameters.ac_capacity, _return_mask=True)
-    return timestamp_flag, night_flag, ac_limit_flag
+    return timestamp_flag, night_flag, limit_flag
 
 
 def validate_dc_power(observation, values):
@@ -357,11 +370,13 @@ def validate_dc_power(observation, values):
 
     Returns
     -------
-    timestamp_flag, night_flag, limit_flag : pandas.Series
-        Integer bitmask series from
-        :py:func:`.validator.check_timestamp_spacing`,
-        :py:func:`.validator.check_irradiance_day_night`,
-        :py:func:`.validator.check_power_limits`
+    timestamp_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_timestamp_spacing`
+    night_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_day_night` or
+        :py:func:`.validator.check_day_night_interval`
+    limit_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_dc_power_limits`
     """
     solar_position, dni_extra, timestamp_flag, night_flag = _solpos_dni_extra(
         observation, values)
@@ -386,10 +401,11 @@ def validate_defaults(observation, values):
 
     Returns
     -------
-    timestamp_flag, night_flag : pandas.Series
-        Integer bitmask series from
-        :py:func:`.validator.check_timestamp_spacing`,
-        :py:func:`.validator.check_irradiance_day_night` respectively
+    timestamp_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_timestamp_spacing`
+    night_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_day_night` or
+        :py:func:`.validator.check_day_night_interval`
     """
     timestamp_flag = _validate_timestamp(observation, values)
     _, night_flag = _solpos_night(observation, values)
@@ -411,11 +427,12 @@ def validate_daily_ghi(observation, values):
 
     Returns
     -------
-    *ghi_flags, stale_flag, interpolation_flag : pandas.Series
-        Integer bitmask series from
-        :py:func:`.validate_ghi`,
-        :py:func:`.validator.detect_stale_values`,
-        :py:func:`.validator.detect_interpolation`
+    *ghi_flags
+        Bitmasks from :py:func:`.tasks.validate_ghi`
+    stale_flag : pandas.Series
+        Bitmask from :py:func:`.validator.detect_stale_values`
+    interpolation_flag : pandas.Series
+        Bitmask from :py:func:`.validator.detect_interpolation`
     """
     ghi_flags = validate_ghi(observation, values)
     stale_flag, interpolation_flag = _validate_stale_interpolated(observation,
@@ -436,14 +453,18 @@ def validate_daily_dc_power(observation, values):
 
     Returns
     -------
-    timestamp_flag, night_flag, limit_flag, stale_flag, interpolation_flag : pandas.Series
-        Integer bitmask series from
-        :py:func:`.validator.check_timestamp_spacing`,
-        :py:func:`.validator.check_irradiance_day_night`,
-        :py:func:`.validator.check_power_limits`,
-        :py:func:`.validator.detect_stale_values`,
-        :py:func:`.validator.detect_interpolation`
-    """  # NOQA: E501
+    timestamp_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_timestamp_spacing`
+    night_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_day_night` or
+        :py:func:`.validator.check_day_night_interval`
+    limit_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_dc_power_limits`
+    stale_flag : pandas.Series
+        Bitmask from :py:func:`.validator.detect_stale_values`
+    interpolation_flag : pandas.Series
+        Bitmask from :py:func:`.validator.detect_interpolation`
+    """
     timestamp_flag, night_flag, dc_limit_flag = validate_dc_power(observation,
                                                                   values)
     stale_flag, interpolation_flag = _validate_stale_interpolated(observation,
@@ -465,15 +486,18 @@ def validate_daily_ac_power(observation, values):
 
     Returns
     -------
-    timestamp_flag, night_flag, limit_flag, stale_flag, interpolation_flag, clipping_flag : pandas.Series
-        Integer bitmask series from
-        :py:func:`.validator.check_timestamp_spacing`,
-        :py:func:`.validator.check_irradiance_day_night`,
-        :py:func:`.validator.check_power_limits`,
-        :py:func:`.validator.detect_stale_values`,
-        :py:func:`.validator.detect_interpolation`,
-        :py:func:`.validator.detect_clipping`
-    """  # NOQA: E501
+    timestamp_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_timestamp_spacing`
+    night_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_day_night` or
+        :py:func:`.validator.check_day_night_interval`
+    limit_flag : pandas.Series
+        Bitmask from :py:func:`.validator.check_ac_power_limits`
+    stale_flag : pandas.Series
+        Bitmask from :py:func:`.validator.detect_stale_values`
+    interpolation_flag : pandas.Series
+        Bitmask from :py:func:`.validator.detect_interpolation`
+    """
     timestamp_flag, night_flag, ac_limit_flag = validate_ac_power(observation,
                                                                   values)
     stale_flag, interpolation_flag = _validate_stale_interpolated(observation,
@@ -500,11 +524,12 @@ def validate_daily_defaults(observation, values):
 
     Returns
     -------
-    *variable_immediate_flags, stale_flag, interpolation_flag : pandas.Series
-        Integer bitmask series from
-        :py:func:`.tasks.validate_{variable}`,
-        :py:func:`.validator.detect_stale_values`,
-        :py:func:`.validator.detect_interpolation`
+    *variable_immediate_flags
+        Bitmasks from :py:func:`.tasks.validate_{variable}`
+    stale_flag : pandas.Series
+        Bitmask from :py:func:`.validator.detect_stale_values`
+    interpolation_flag : pandas.Series
+        Bitmask from :py:func:`.validator.detect_interpolation`
     """
     immediate_func = IMMEDIATE_VALIDATION_FUNCS.get(
         observation.variable, validate_defaults)
@@ -538,7 +563,8 @@ DAILY_VALIDATION_FUNCS = {
 
 def apply_immediate_validation(observation, observation_values):
     """
-    Applies the appropriate validation functions to the observation_values.
+    Apply the appropriate validation functions to the observation_values.
+
     Only the USER_FLAGGED flag is propagated if the series has been
     previously validated.
 
@@ -571,9 +597,11 @@ def apply_immediate_validation(observation, observation_values):
 
 
 def apply_daily_validation(observation, observation_values):
-    """Applies the appropriate daily validation functions to the
-    observation_values.  Only the USER_FLAGGED flag is propagated if
-    the series has been previously validated.
+    """
+    Apply the appropriate daily validation functions to the observation_values.
+
+    Only the USER_FLAGGED flag is propagated if the series has been previously
+    validated.
 
     Parameters
     ----------

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -336,8 +336,10 @@ def validate_ac_power(observation, values):
     """
     solar_position, dni_extra, timestamp_flag, night_flag = _solpos_dni_extra(
         observation, values)
+    day_night = \
+        ~quality_mapping.convert_mask_into_dataframe(night_flag)['NIGHTTIME']
     ac_limit_flag = validator.check_ac_power_limits(
-        values, solar_position['apparent_zenith'],
+        values, day_night,
         observation.site.modeling_parameters.ac_capacity, _return_mask=True)
     return timestamp_flag, night_flag, ac_limit_flag
 
@@ -363,8 +365,10 @@ def validate_dc_power(observation, values):
     """
     solar_position, dni_extra, timestamp_flag, night_flag = _solpos_dni_extra(
         observation, values)
+    day_night = \
+        ~quality_mapping.convert_mask_into_dataframe(night_flag)['NIGHTTIME']
     dc_limit_flag = validator.check_dc_power_limits(
-        values, solar_position['apparent_zenith'],
+        values, day_night,
         observation.site.modeling_parameters.dc_capacity, _return_mask=True)
     return timestamp_flag, night_flag, dc_limit_flag
 

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -97,8 +97,8 @@ def _solpos_night_resample(observation, values):
     ).mean()
     # return series with same index as input values
     # i.e. put any gaps back in the data
-    night_flag = night_flag.loc[values.index]
-    solar_position = solar_position.loc[values.index]
+    night_flag = night_flag.reindex(values.index)
+    solar_position = solar_position.reindex(values.index)
     return solar_position, night_flag
 
 

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -45,8 +45,8 @@ def _solpos_night_instantaneous(observation, values):
     solar_position = pvmodel.calculate_solar_position(
         observation.site.latitude, observation.site.longitude,
         observation.site.elevation, values.index)
-    night_flag = validator.check_irradiance_day_night(solar_position['zenith'],
-                                                      _return_mask=True)
+    night_flag = validator.check_day_night(solar_position['zenith'],
+                                           _return_mask=True)
     return solar_position, night_flag
 
 
@@ -82,7 +82,7 @@ def _solpos_night_resample(observation, values):
         observation.site.elevation, obs_range
     )
     # get the night flag as bitmask
-    night_flag = validator.check_irradiance_day_night_interval(
+    night_flag = validator.check_day_night_interval(
         solar_position['zenith'],
         closed,
         interval_length,

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -29,6 +29,14 @@ def _validate_stale_interpolated(observation, values):
 
 
 def _solpos_night(observation, values):
+    closed = datamodel.CLOSED_MAPPING[observation.interval_label]
+    if closed is None:
+        return _solpos_night_instantaneous(observation, values)
+    else:
+        return _solpos_night_resample(observation, values)
+
+
+def _solpos_night_instantaneous(observation, values):
     solar_position = pvmodel.calculate_solar_position(
         observation.site.latitude, observation.site.longitude,
         observation.site.elevation, values.index)
@@ -88,8 +96,8 @@ def _solpos_night_resample(observation, values):
         observation.interval_length, closed=closed, label=closed
     ).mean()
     # put gaps back in the data
-    night_flag.loc[values.index]
-    solar_position.loc[values.index]
+    night_flag = night_flag.loc[values.index]
+    solar_position = solar_position.loc[values.index]
     return solar_position, night_flag
 
 

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -46,12 +46,10 @@ def _solpos_night_instantaneous(observation, values):
 
 
 def _solpos_night_resample(observation, values):
-    # copied from persistence.py...
-    # Calculate solar position and clearsky for obs time range.
-    # if data is instantaneous, calculate at the obs time.
-    # else (if data is interval average), calculate at 1 minute resolution to
+    # similar approach as in persistence_scalar_index.
+    # Calculate solar position and clearsky at 1 minute resolution to
     # reduce errors from changing solar position during interval.
-    # Later, nighttime be resampled over the interval
+    # Later, nighttime bools will be resampled over the interval
     closed = datamodel.CLOSED_MAPPING[observation.interval_label]
     data_start, data_end = values.index[0], values.index[-1]
     freq = pd.Timedelta('1min')
@@ -62,9 +60,9 @@ def _solpos_night_resample(observation, values):
     elif closed == 'right':
         data_start -= observation.interval_length
     else:
-        # instantaneous or event obs. maybe skip all this and call out
-        # to the function we currently call _solpos_night instead
-        freq = observation.interval_length
+        raise ValueError('Invalid observation.interval_length '
+                         f'{observation.interval_length}. Use '
+                         '_solpos_night_instantaneous')
     obs_range = pd.date_range(start=data_start, end=data_end, freq=freq,
                               closed=closed)
     # could add logic to remove points from obs_range where there are
@@ -73,21 +71,12 @@ def _solpos_night_resample(observation, values):
         observation.site.latitude, observation.site.longitude,
         observation.site.elevation, obs_range
     )
-    # True = daytime. False = nighttime.
-    daytime_1min = validator.check_irradiance_day_night(
-        solar_position['zenith'], _return_mask=False
-    )
-    # number of daytime minutes within the interval
-    daytime_sum = daytime_1min.resample(
-        observation.interval_length, closed=closed, label=closed
-    ).sum()
-    # If 10% of an interval is daytime, then the interval is daytime
-    count_threshold = int(observation.interval_length / freq * 0.1)
-    daytime = daytime_sum > count_threshold
-    # Convert the bools into a bitmask (need to do this manually because
-    # we set _return_mask=False in the call to the validator function).
-    night_flag = quality_mapping.convert_bool_flags_to_flag_mask(
-        daytime, 'NIGHTTIME', True
+    night_flag = validator.check_irradiance_day_night(
+        solar_position['zenith'],
+        closed=closed,
+        interval_length=observation.interval_length,
+        solar_zenith_interval_length=freq,
+        _return_mask=True
     )
     # Better to use average solar position in downstream functions
     # Best to return high res solar position and adapt downstream functions

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -58,7 +58,7 @@ def _resample_date_range(interval_length, closed, freq, values):
     elif closed == 'right':
         data_start -= interval_length
     else:
-        raise ValueError("closed must be 'left' or 'right'")
+        raise ValueError("closed must be left or right")  # pragma: no cover
     obs_range = pd.date_range(start=data_start, end=data_end, freq=freq,
                               closed=closed)
     return obs_range

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -97,8 +97,14 @@ def _solpos_night_resample(observation, values):
     ).mean()
     # return series with same index as input values
     # i.e. put any gaps back in the data
-    night_flag = night_flag.reindex(values.index)
-    solar_position = solar_position.reindex(values.index)
+    try:
+        night_flag = night_flag.loc[values.index]
+        solar_position = solar_position.loc[values.index]
+    except KeyError:
+        raise KeyError(
+            'Missing times when reindexing averaged flag or solar position to '
+            'original data. Check that observation.interval_length is '
+            'consistent with observation_values.index.')
     return solar_position, night_flag
 
 

--- a/solarforecastarbiter/validation/tests/test_validation_tasks.py
+++ b/solarforecastarbiter/validation/tests/test_validation_tasks.py
@@ -1437,6 +1437,17 @@ def test_apply_validation_bad_df(make_observation, mocker):
             dtype=float))
 
 
+def test_apply_validation_inconsistent_interval(make_observation):
+    obs = make_observation('ghi')
+    index = pd.date_range(start='20200924', end='20200925', freq='1min')
+    data = pd.DataFrame({'value': 1, 'quality_flag': 2}, index=index)
+    if obs.interval_label == 'instant':
+        pass
+    else:
+        with pytest.raises(KeyError, match='Missing times'):
+            tasks.apply_validation(obs, data)
+
+
 def test_apply_validation_agg(aggregate, mocker):
     data = pd.DataFrame({'value': [1], 'quality_flag': [0]},
                         index=pd.DatetimeIndex(

--- a/solarforecastarbiter/validation/tests/test_validation_tasks.py
+++ b/solarforecastarbiter/validation/tests/test_validation_tasks.py
@@ -17,7 +17,7 @@ def make_observation(single_site):
     def f(variable):
         return Observation(
             name='test', variable=variable, interval_value_type='mean',
-            interval_length=pd.Timedelta('1hr'), interval_label='beginning',
+            interval_length=pd.Timedelta('1hr'), interval_label='ending',
             site=single_site, uncertainty=0.1, observation_id='OBSID',
             provider='Organization 1', extra_parameters='')
     return f

--- a/solarforecastarbiter/validation/tests/test_validation_tasks.py
+++ b/solarforecastarbiter/validation/tests/test_validation_tasks.py
@@ -46,13 +46,13 @@ def daily_index(single_site):
 def nighttime_func_mask(obs, index):
     if obs.interval_label == 'beginning':
         flag = [0, 0, 0, 0, 0]
-        func = 'check_irradiance_day_night_interval'
+        func = 'check_day_night_interval'
     elif obs.interval_label == 'ending':
         flag = [1, 0, 0, 0, 0]
-        func = 'check_irradiance_day_night_interval'
+        func = 'check_day_night_interval'
     else:
         flag = [1, 0, 0, 0, 0]
-        func = 'check_irradiance_day_night'
+        func = 'check_day_night'
     flag = pd.Series(flag, index=index, dtype='int')
     mask = flag * DESCRIPTION_MASK_MAPPING['NIGHTTIME']
     return func, mask
@@ -61,13 +61,13 @@ def nighttime_func_mask(obs, index):
 def nighttime_func_mask_daily(obs, index):
     if obs.interval_label == 'beginning':
         flag = [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0]
-        func = 'check_irradiance_day_night_interval'
+        func = 'check_day_night_interval'
     elif obs.interval_label == 'ending':
         flag = [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0]
-        func = 'check_irradiance_day_night_interval'
+        func = 'check_day_night_interval'
     else:
         flag = [1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0]
-        func = 'check_irradiance_day_night'
+        func = 'check_day_night'
     flag = pd.Series(flag, index=index)
     mask = flag * DESCRIPTION_MASK_MAPPING['NIGHTTIME']
     return func, mask

--- a/solarforecastarbiter/validation/tests/test_validator.py
+++ b/solarforecastarbiter/validation/tests/test_validator.py
@@ -235,18 +235,26 @@ def test_check_day_night():
     assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize('closed,expected', (
-    ('left', pd.Series([False, True], index=pd.DatetimeIndex(
-        ['20200917 0000', '20200917 0100']))),
-    ('right', pd.Series([False, True], index=pd.DatetimeIndex(
+@pytest.mark.parametrize('closed,solar_zenith,expected', (
+    ('left', [89]*11 + [80]*13,
+     pd.Series([False, True], index=pd.DatetimeIndex(
+            ['20200917 0000', '20200917 0100']))),
+    ('right', [89]*11 + [80]*13,
+     pd.Series([False, True], index=pd.DatetimeIndex(
+        ['20200917 0100', '20200917 0200']))),
+    ('left', [89]*10 + [80]*14,
+     pd.Series([True, True], index=pd.DatetimeIndex(
+            ['20200917 0000', '20200917 0100']))),
+    ('right', [89]*10 + [80]*14,
+     pd.Series([True, True], index=pd.DatetimeIndex(
         ['20200917 0100', '20200917 0200'])))
 ))
-def test_check_day_night_interval(closed, expected):
+def test_check_day_night_interval(closed, solar_zenith, expected):
     interval_length = pd.Timedelta('1h')
     index = pd.date_range(
         start='20200917 0000', end='20200917 0200', closed=closed,
         freq='5min')
-    solar_zenith = pd.Series([89]*11 + [80]*13, index=index)
+    solar_zenith = pd.Series(solar_zenith, index=index)
     result = validator.check_day_night_interval(
         solar_zenith, closed, interval_length
     )

--- a/solarforecastarbiter/validation/tests/test_validator.py
+++ b/solarforecastarbiter/validation/tests/test_validator.py
@@ -142,11 +142,10 @@ def test_check_ac_power_limits():
     index = pd.date_range(
         start='20200401 0700', freq='2h', periods=6, tz='UTC')
     power = pd.Series([0, -0.1, 0.1, 1, 1.1, -0.1], index=index)
-    # not precise zenith - just for day/night flagging
-    solar_zenith = pd.Series([180, 150, 120, 80, 50, 30], index=index)
+    day_night = pd.Series([0, 0, 0, 1, 1, 1], index=index, dtype='bool')
     capacity = 1.
     expected = pd.Series([1, 0, 0, 1, 0, 0], index=index).astype(bool)
-    out = validator.check_ac_power_limits(power, solar_zenith, capacity)
+    out = validator.check_ac_power_limits(power, day_night, capacity)
     assert_series_equal(out, expected)
 
 
@@ -154,11 +153,10 @@ def test_check_dc_power_limits():
     index = pd.date_range(
         start='20200401 0700', freq='2h', periods=6, tz='UTC')
     power = pd.Series([0, -0.1, 0.1, 1, 1.3, -0.1], index=index)
-    # not precise zenith - just for day/night flagging
-    solar_zenith = pd.Series([180, 150, 120, 80, 50, 30], index=index)
+    day_night = pd.Series([0, 0, 0, 1, 1, 1], index=index, dtype='bool')
     capacity = 1.
     expected = pd.Series([1, 0, 0, 1, 0, 0], index=index).astype(bool)
-    out = validator.check_dc_power_limits(power, solar_zenith, capacity)
+    out = validator.check_dc_power_limits(power, day_night, capacity)
     assert_series_equal(out, expected)
 
 

--- a/solarforecastarbiter/validation/tests/test_validator.py
+++ b/solarforecastarbiter/validation/tests/test_validator.py
@@ -261,7 +261,7 @@ def test_check_irradiance_day_night_interval_no_infer():
     index = pd.DatetimeIndex(
         ['20200917 0100', '20200917 0200', '20200917 0400'])
     solar_zenith = pd.Series([0]*3, index=index)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='contains gaps'):
         validator.check_irradiance_day_night_interval(
             solar_zenith, closed, interval_length
         )

--- a/solarforecastarbiter/validation/tests/test_validator.py
+++ b/solarforecastarbiter/validation/tests/test_validator.py
@@ -227,13 +227,13 @@ def test_check_poa_clearsky(mocker, times):
     assert_series_equal(result, expected)
 
 
-def test_check_irradiance_day_night():
+def test_check_day_night():
     MST = pytz.timezone('MST')
     times = [datetime(2018, 6, 15, 12, 0, 0, tzinfo=MST),
              datetime(2018, 6, 15, 22, 0, 0, tzinfo=MST)]
     expected = pd.Series(data=[True, False], index=times)
     solar_zenith = pd.Series(data=[11.8, 114.3], index=times)
-    result = validator.check_irradiance_day_night(solar_zenith)
+    result = validator.check_day_night(solar_zenith)
     assert_series_equal(result, expected)
 
 
@@ -243,31 +243,31 @@ def test_check_irradiance_day_night():
     ('right', pd.Series([False, True], index=pd.DatetimeIndex(
         ['20200917 0100', '20200917 0200'])))
 ))
-def test_check_irradiance_day_night_interval(closed, expected):
+def test_check_day_night_interval(closed, expected):
     interval_length = pd.Timedelta('1h')
     index = pd.date_range(
         start='20200917 0000', end='20200917 0200', closed=closed,
         freq='5min')
     solar_zenith = pd.Series([89]*11 + [80]*13, index=index)
-    result = validator.check_irradiance_day_night_interval(
+    result = validator.check_day_night_interval(
         solar_zenith, closed, interval_length
     )
     assert_series_equal(result, expected)
 
 
-def test_check_irradiance_day_night_interval_no_infer():
+def test_check_day_night_interval_no_infer():
     interval_length = pd.Timedelta('1h')
     closed = 'left'
     index = pd.DatetimeIndex(
         ['20200917 0100', '20200917 0200', '20200917 0400'])
     solar_zenith = pd.Series([0]*3, index=index)
     with pytest.raises(ValueError, match='contains gaps'):
-        validator.check_irradiance_day_night_interval(
+        validator.check_day_night_interval(
             solar_zenith, closed, interval_length
         )
 
 
-def test_check_irradiance_day_night_interval_irregular():
+def test_check_day_night_interval_irregular():
     interval_length = pd.Timedelta('1h')
     solar_zenith_interval_length = pd.Timedelta('5min')
     closed = 'left'
@@ -279,7 +279,7 @@ def test_check_irradiance_day_night_interval_irregular():
         freq=solar_zenith_interval_length)
     index = index1.union(index2)
     solar_zenith = pd.Series([89]*11 + [80]*13, index=index)
-    result = validator.check_irradiance_day_night_interval(
+    result = validator.check_day_night_interval(
         solar_zenith, closed, interval_length,
         solar_zenith_interval_length=solar_zenith_interval_length
     )

--- a/solarforecastarbiter/validation/validator.py
+++ b/solarforecastarbiter/validation/validator.py
@@ -427,10 +427,6 @@ def check_ac_power_limits(power, day_night, capacity,
           * power > capacity * capacity_limit_low, AND
             * power < capacity * capacity_limit_high_day AND day_night, OR
             * power < capacity * capacity_limit_high_night AND NOT day_night
-
-    Notes
-    -----
-    Day time is defined as zenith < 93 degrees.
     """
     flags = _check_power_limits(
         power, day_night, capacity, capacity_limit_low,
@@ -549,7 +545,7 @@ def check_poa_clearsky(poa_global, poa_clearsky, kt_max=1.1):
 
 @mask_flags('NIGHTTIME')
 def check_day_night(solar_zenith, max_zenith=87):
-    """ Checks for day/night periods based on solar zenith.
+    """Check for day/night periods based on solar zenith.
 
     Parameters
     ----------

--- a/solarforecastarbiter/validation/validator.py
+++ b/solarforecastarbiter/validation/validator.py
@@ -399,18 +399,18 @@ def check_rh_limits(rh, rh_limits=(0, 100)):
 
 
 @mask_flags('LIMITS EXCEEDED')
-def check_ac_power_limits(power, solar_zenith, capacity,
+def check_ac_power_limits(power, day_night, capacity,
                           capacity_limit_low=-0.05,
                           capacity_limit_high_day=1.05,
                           capacity_limit_high_night=0.05):
-    """ Checks for extreme AC power.
+    """Check for extreme AC power.
 
     Parameters
     ----------
     power : Series
         DC or AC power.
-    solar_zenith : Series
-        Solar zenith angle in degrees.
+    day_night : Series
+        True for day time points, False for night time points.
     capacity : float
         AC capacity.
     capacity_limit_low : float
@@ -425,16 +425,15 @@ def check_ac_power_limits(power, solar_zenith, capacity,
     flags : Series
         True for values that are within the limits:
           * power > capacity * capacity_limit_low, AND
-            * power < capacity * capacity_limit_high_day AND solar_zenith < 93, OR
-            * power < capacity * capacity_limit_high_night AND solar_zenith > 93
+            * power < capacity * capacity_limit_high_day AND day_night, OR
+            * power < capacity * capacity_limit_high_night AND NOT day_night
 
     Notes
     -----
     Day time is defined as zenith < 93 degrees.
-    """  # noqa: E501
-
+    """
     flags = _check_power_limits(
-        power, solar_zenith, capacity, capacity_limit_low,
+        power, day_night, capacity, capacity_limit_low,
         capacity_limit_high_day, capacity_limit_high_night
         )
 
@@ -442,18 +441,18 @@ def check_ac_power_limits(power, solar_zenith, capacity,
 
 
 @mask_flags('LIMITS EXCEEDED')
-def check_dc_power_limits(power, solar_zenith, capacity,
+def check_dc_power_limits(power, day_night, capacity,
                           capacity_limit_low=-0.05,
                           capacity_limit_high_day=1.20,
                           capacity_limit_high_night=0.05):
-    """ Checks for extreme AC power.
+    """Check for extreme AC power.
 
     Parameters
     ----------
     power : Series
         DC or AC power.
-    solar_zenith : Series
-        Solar zenith angle in degrees.
+    day_night : Series
+        True for day time points, False for night time points.
     capacity : float
         DC capacity.
     capacity_limit_low : float
@@ -468,16 +467,11 @@ def check_dc_power_limits(power, solar_zenith, capacity,
     flags : Series
         True for values that are within the limits:
           * power > capacity * capacity_limit_low, AND
-            * power < capacity * capacity_limit_high_day AND solar_zenith < 93, OR
-            * power < capacity * capacity_limit_high_night AND solar_zenith > 93
-
-    Notes
-    -----
-    Day time is defined as zenith < 93 degrees.
-    """  # noqa: E501
-
+            * power < capacity * capacity_limit_high_day AND day_night, OR
+            * power < capacity * capacity_limit_high_night AND NOT day_night
+    """
     flags = _check_power_limits(
-        power, solar_zenith, capacity, capacity_limit_low,
+        power, day_night, capacity, capacity_limit_low,
         capacity_limit_high_day, capacity_limit_high_night
         )
 
@@ -485,7 +479,7 @@ def check_dc_power_limits(power, solar_zenith, capacity,
 
 
 def _check_power_limits(
-        power, solar_zenith, capacity, capacity_limit_low,
+        power, day_night, capacity, capacity_limit_low,
         capacity_limit_high_day, capacity_limit_high_night
         ):
 
@@ -493,9 +487,6 @@ def _check_power_limits(
     capacity_low = capacity * capacity_limit_low
     capacity_high_day = capacity * capacity_limit_high_day
     capacity_high_night = capacity * capacity_limit_high_night
-
-    # True for daytime values
-    day_night = check_day_night(solar_zenith, max_zenith=93)
 
     flag_low = _check_limits(power, lb=capacity_low)
     flag_high_day = _check_limits(power, ub=capacity_high_day) & day_night

--- a/solarforecastarbiter/validation/validator.py
+++ b/solarforecastarbiter/validation/validator.py
@@ -557,22 +557,61 @@ def check_poa_clearsky(poa_global, poa_clearsky, kt_max=1.1):
 
 
 @mask_flags('NIGHTTIME')
-def check_irradiance_day_night(solar_zenith, max_zenith=87):
+def check_irradiance_day_night(
+        solar_zenith, max_zenith=87, closed=None, interval_length=None,
+        solar_zenith_interval_length=None, fraction_of_interval=0.1,
+        ):
     """ Checks for day/night periods based on solar zenith.
+
+    Interval average data may be analyzed by supplying higher resolution
+    solar zenith data and parameters that describe the desired intervals.
 
     Parameters
     ----------
     solar_zenith : Series
-        Solar zenith angle in degrees
-    max_zenith : maximum zenith angle for a daylight time
+        Solar zenith angle in degrees.
+    max_zenith : float
+        Maximum zenith angle for a daylight time.
+    closed : {None, 'left', 'right'}
+        None for instantaneous data, 'left' for interval beginning labeled
+        data, 'right' for interval ending labeled data.
+    interval_length : None or Timedelta
+        Interval length to resample day/night periods to.
+    solar_zenith_interval_length : None or Timedelta
+        Required if solar_zenith contains gaps and closed is not None.
+    fraction_of_interval : float
+        The fraction of the points in an interval that must be daytime
+        in order to mark the interval as daytime.
 
     Returns
     -------
     flags : Series
-        True when solar zenith is less than max_zenith.
+        True when solar zenith is less than max_zenith (closed == None),
+        or when sufficient points within an interval are less than
+        max_zenith (closed != None).
     """
-    flags = _check_limits(solar_zenith, ub=max_zenith)
-    return flags
+    # True = daytime. False = nighttime.
+    daytime = _check_limits(solar_zenith, ub=max_zenith)
+    if closed is None:
+        # instantaneous or event data
+        return daytime
+    else:
+        # number of daytime minutes within the interval
+        daytime_sum = daytime.resample(
+            interval_length, closed=closed, label=closed
+        ).sum()
+        # if not provided, try to interval length for normalization
+        if solar_zenith_interval_length is None:
+            solar_zenith_interval_length = pd.infer_freq(
+                solar_zenith.index, warn=False)
+        # If points corresponding to fraction_of_interval is daytime,
+        # then the interval is daytime
+        count_threshold = int(
+            interval_length * fraction_of_interval
+            / solar_zenith_interval_length
+            )
+        daytime = daytime_sum > count_threshold
+        return daytime
 
 
 @mask_flags('UNEVEN FREQUENCY')

--- a/solarforecastarbiter/validation/validator.py
+++ b/solarforecastarbiter/validation/validator.py
@@ -37,6 +37,8 @@ QCRAD_CONSISTENCY = {
             {'zenith_bounds': [75, 93], 'ghi_bounds': [50, np.Inf],
              'ratio_bounds': [0.0, 1.10]}}}
 
+DAY_NIGHT_MAX_ZENITH = 87.
+
 
 def _check_limits(val, lb=None, ub=None, lb_ge=False, ub_le=False):
     """ Returns True where lb < (or <=) val < (or <=) ub
@@ -544,7 +546,7 @@ def check_poa_clearsky(poa_global, poa_clearsky, kt_max=1.1):
 
 
 @mask_flags('NIGHTTIME')
-def check_day_night(solar_zenith, max_zenith=87):
+def check_day_night(solar_zenith, max_zenith=DAY_NIGHT_MAX_ZENITH):
     """Check for day/night periods based on solar zenith.
 
     Parameters
@@ -568,7 +570,7 @@ def check_day_night(solar_zenith, max_zenith=87):
 def check_day_night_interval(
         solar_zenith, closed, interval_length,
         solar_zenith_interval_length=None, fraction_of_interval=0.1,
-        max_zenith=87):
+        max_zenith=DAY_NIGHT_MAX_ZENITH):
     """Check for day/night periods based on solar zenith.
 
     Interval average data may be analyzed by supplying higher resolution

--- a/solarforecastarbiter/validation/validator.py
+++ b/solarforecastarbiter/validation/validator.py
@@ -581,9 +581,8 @@ def check_irradiance_day_night(solar_zenith, max_zenith=87):
 def check_irradiance_day_night_interval(
         solar_zenith, closed, interval_length,
         solar_zenith_interval_length=None, fraction_of_interval=0.1,
-        max_zenith=87,
-        ):
-    """ Checks for day/night periods based on solar zenith.
+        max_zenith=87):
+    """Check for day/night periods based on solar zenith.
 
     Interval average data may be analyzed by supplying higher resolution
     solar zenith data and parameters that describe the desired intervals.
@@ -598,6 +597,7 @@ def check_irradiance_day_night_interval(
     interval_length : Timedelta
         Interval length to resample day/night periods to.
     solar_zenith_interval_length : None or Timedelta
+        If None, attempt to infer.
         Required if solar_zenith contains gaps and closed is not None.
     fraction_of_interval : float
         The fraction of the points in an interval that must be daytime
@@ -609,7 +609,8 @@ def check_irradiance_day_night_interval(
     -------
     flags : Series
         True when sufficient points within an interval are less than
-        max_zenith.
+        max_zenith. Index conforms to solar_zenith resampled to
+        interval_length.
     """
     # True = daytime. False = nighttime.
     daytime = _check_limits(solar_zenith, ub=max_zenith)

--- a/solarforecastarbiter/validation/validator.py
+++ b/solarforecastarbiter/validation/validator.py
@@ -495,7 +495,7 @@ def _check_power_limits(
     capacity_high_night = capacity * capacity_limit_high_night
 
     # True for daytime values
-    day_night = check_irradiance_day_night(solar_zenith, max_zenith=93)
+    day_night = check_day_night(solar_zenith, max_zenith=93)
 
     flag_low = _check_limits(power, lb=capacity_low)
     flag_high_day = _check_limits(power, ub=capacity_high_day) & day_night
@@ -557,7 +557,7 @@ def check_poa_clearsky(poa_global, poa_clearsky, kt_max=1.1):
 
 
 @mask_flags('NIGHTTIME')
-def check_irradiance_day_night(solar_zenith, max_zenith=87):
+def check_day_night(solar_zenith, max_zenith=87):
     """ Checks for day/night periods based on solar zenith.
 
     Parameters
@@ -578,7 +578,7 @@ def check_irradiance_day_night(solar_zenith, max_zenith=87):
 
 
 @mask_flags('NIGHTTIME')
-def check_irradiance_day_night_interval(
+def check_day_night_interval(
         solar_zenith, closed, interval_length,
         solar_zenith_interval_length=None, fraction_of_interval=0.1,
         max_zenith=87):

--- a/solarforecastarbiter/validation/validator.py
+++ b/solarforecastarbiter/validation/validator.py
@@ -556,7 +556,7 @@ def check_day_night(solar_zenith, max_zenith=87):
 
     Returns
     -------
-    flags : Series
+    daytime : Series
         True when solar zenith is less than max_zenith.
     """
     # True = daytime. False = nighttime.
@@ -594,7 +594,7 @@ def check_day_night_interval(
 
     Returns
     -------
-    flags : Series
+    daytime : Series
         True when sufficient points within an interval are less than
         max_zenith. Index conforms to solar_zenith resampled to
         interval_length.


### PR DESCRIPTION

  - [x] Closes #567 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Making a PR for concrete discussion but not committed to the current approach.

I added a new function `validation.tasks._solpos_night_resample` that calculates solar position at every minute to determine the nightime flag value using the fraction of daytime minutes within an interval. 

Timings from my laptop:

```python
start = '20200101T0000'
end = '20200331T2359'
index = pd.date_range(start=start, end=end, freq='1min', tz='UTC')
index_hrly = index[::60]
obs_data_3m = pd.DataFrame({'value': 1, 'quality_flag': 2}, index=index)
obs_data_hrly_3m = pd.DataFrame({'value': 1, 'quality_flag': 2}, index=index_hrly)

%timeit tasks._solpos_night(obs, obs_data_3m)

1.2 s ± 35.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit tasks._solpos_night(obs, obs_data_hrly_3m)

28 ms ± 540 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit tasks._solpos_night_resample(obs_hrly, obs_data_hrly_3m)

1.17 s ± 9.65 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

The good news is that this approach is no slower than computing the flag for 1 minute resolution data of the same length. That implies the solar position calculation takes the vast majority of the time and the remaining resample calls are cheap.
