### PR TITLE
Adjust plotly x_label_height_factor

### DIFF
--- a/docs/source/whatsnew/1.0.0rc4.rst
+++ b/docs/source/whatsnew/1.0.0rc4.rst
@@ -22,7 +22,7 @@ Bug fixes
 * Fix spacing of plot titles to avoid long names running out of container and
   Plotly toolbar overlap. (:issue:`577`) (:pull:`581`)
 * Dynamically calculate plot height to avoid truncating long forecast names
-  in total metric plots. (:issue:`576`) (:pull:`581`) (:pull:`581`)
+  in total metric plots. (:issue:`576`) (:pull:`581`) (:pull:`582`)
 
 
 Contributors

--- a/docs/source/whatsnew/1.0.0rc4.rst
+++ b/docs/source/whatsnew/1.0.0rc4.rst
@@ -22,7 +22,7 @@ Bug fixes
 * Fix spacing of plot titles to avoid long names running out of container and
   Plotly toolbar overlap. (:issue:`577`) (:pull:`581`)
 * Dynamically calculate plot height to avoid truncating long forecast names
-  in total metric plots. (:issue:`576`) (:pull:`581`)
+  in total metric plots. (:issue:`576`) (:pull:`581`) (:pull:`581`)
 
 
 Contributors

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -66,7 +66,7 @@ PLOT_LAYOUT_DEFAULTS = {
 # present. The length of the longest label of the plot will be multiplies by
 # this value and added o the height of PLOT_LAYOUT_DEFAULTS to determine the
 # new height.
-X_LABEL_HEIGHT_FACTOR = 10
+X_LABEL_HEIGHT_FACTOR = 11
 
 # If for some reason, the fail.pdf (just a pdf with some text that
 # pdf generation failed) is unavailable, use an empty pdf
@@ -831,7 +831,8 @@ def bar(df, metric):
         plot_height = plot_layout_args['height'] + (
             max_name_length * X_LABEL_HEIGHT_FACTOR)
         plot_layout_args['height'] = plot_height
-        x_axis_kwargs = {'automargin': True}
+        x_axis_kwargs = {'automargin': True,
+                         'tickangle': 90.0}
     fig = go.Figure()
     fig.add_trace(go.Bar(x=x_values, y=data['value'],
                          marker=go.bar.Marker(color=palette)))

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -831,9 +831,8 @@ def bar(df, metric):
         plot_height = plot_layout_args['height'] + (
             max_name_length * X_LABEL_HEIGHT_FACTOR)
         plot_layout_args['height'] = plot_height
-        x_axis_kwargs = {'automargin': True}
-        if x_values.size > 6:
-            x_axis_kwargs.update({'tickangle': 90.0})
+        x_axis_kwargs = {'automargin': True,
+                         'tickangle': 90.0}
     fig = go.Figure()
     fig.add_trace(go.Bar(x=x_values, y=data['value'],
                          marker=go.bar.Marker(color=palette)))

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -831,8 +831,9 @@ def bar(df, metric):
         plot_height = plot_layout_args['height'] + (
             max_name_length * X_LABEL_HEIGHT_FACTOR)
         plot_layout_args['height'] = plot_height
-        x_axis_kwargs = {'automargin': True,
-                         'tickangle': 90.0}
+        x_axis_kwargs = {'automargin': True}
+        if x_values.size > 6:
+            x_axis_kwargs.update({'tickangle': 90.0})
     fig = go.Figure()
     fig.add_trace(go.Bar(x=x_values, y=data['value'],
                          marker=go.bar.Marker(color=palette)))

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -822,7 +822,8 @@ def bar(df, metric):
     # remove height limit when long abbreviations are used or there are more
     # than 5 pairs to problems with labels being cutt off.
     plot_layout_args = deepcopy(PLOT_LAYOUT_DEFAULTS)
-    if x_values.map(len).max() > 15 or x_values.size > 6:
+    longest_x_label = x_values.map(len).max()
+    if longest_x_label > 15 or x_values.size > 6:
         # Set explicit height and set automargin on x axis to allow for dynamic
         # sizing to accomodate long x axis labels. Height is set based on
         # length of longest x axis label, due to a failure that can occur when
@@ -831,8 +832,12 @@ def bar(df, metric):
         plot_height = plot_layout_args['height'] + (
             max_name_length * X_LABEL_HEIGHT_FACTOR)
         plot_layout_args['height'] = plot_height
-        x_axis_kwargs = {'automargin': True,
-                         'tickangle': 90.0}
+        x_axis_kwargs = {'automargin': True}
+        if longest_x_label > 60:
+            x_axis_kwargs.update({'tickangle': 90})
+        elif longest_x_label > 30:
+            x_axis_kwargs.update({'tickangle': 45})
+
     fig = go.Figure()
     fig.add_trace(go.Bar(x=x_values, y=data['value'],
                          marker=go.bar.Marker(color=palette)))

--- a/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
@@ -262,6 +262,11 @@ def metric_dataframe():
 def test_bar(metric_dataframe):
     out = figures.bar(metric_dataframe, 'mae')
     assert isinstance(out, graph_objects.Figure)
+    plot_spec = out.to_dict()
+    layout = plot_spec['layout']
+    assert 'automargin' not in layout['xaxis']
+    assert 'tickangle' not in layout['xaxis']
+    assert layout['height'] == figures.PLOT_LAYOUT_DEFAULTS['height']
 
 
 def test_bar_no_metric(metric_dataframe):
@@ -444,3 +449,19 @@ def test_probabilistic_plotting_asymmetric_cv(
     assert isinstance(scatter_spec, str)
     assert isinstance(ts_prob_spec, str)
     assert inc_dist
+
+
+@pytest.mark.parametrize('new_name,tickangle,height', [
+    ('some what long name used when test',
+     45, 250 + 34 * figures.X_LABEL_HEIGHT_FACTOR),
+    ('very long name used when test very long names with plot tick angle',
+     90, 250 + 66 * figures.X_LABEL_HEIGHT_FACTOR),
+])
+def test_bar_height_tick_adjustment(
+        metric_dataframe, new_name, tickangle, height):
+    metric_dataframe['abbrev'] = new_name
+    out = figures.bar(metric_dataframe, 'mae')
+    assert isinstance(out, graph_objects.Figure)
+    assert out.layout.height == height
+    assert out.layout.xaxis.tickangle == tickangle
+    assert out.layout.xaxis.automargin


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [ ] Closes #xxxx .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Adjusted the `X_LABEL_HEIGHT_FACTOR` to work with the longest possible forecast name: A forecast name containing 13 4 letter words separated by spaces, + the 'Prob(f <= x)  = 100.0%' labelling added by the plotting code. I hit a few cases where Plotly tried to angle the x axis labels, which caused some labels to run off the right side of the plot. So I've forced the plot to display x axis labels vertically when there are more than 6 labels. .