### PR TITLE
Adjust templating and plotting to allow for partial reports as returned by the API

### DIFF
--- a/docs/source/whatsnew/1.0.0rc4.rst
+++ b/docs/source/whatsnew/1.0.0rc4.rst
@@ -13,7 +13,11 @@ API Changes
 
 Enhancements
 ~~~~~~~~~~~~
-
+* Allow users to render reports without full access to the time series data of
+  the report's forecasts and observations. Users with limited permissions on a
+  report may need to instantiate a
+  :py:class:`solarforecastarbiter.datamode.Report` object from an api response
+  from the `/reports` endpoint manually. (:pull:`585`)
 
 Bug fixes
 ~~~~~~~~~

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -357,6 +357,7 @@ def _plot_obs_timeseries(fig, timeseries_value_df, timeseries_meta_df):
             x=data.index,
             name=_legend_text(metadata['observation_name']),
             legendgroup=metadata['observation_name'],
+            showlegend=True,
             marker=dict(color=metadata['observation_color']),
             connectgaps=False,
             **plot_kwargs)
@@ -1253,7 +1254,7 @@ def timeseries_plots(report):
         scat_fig_json = scat_fig.to_json()
     else:
         scat_fig_json = None
-    includes_distribution = ts_prob_fig_json is not None and any(
+    includes_distribution = ts_fig_json is not None and any(
         (
             isinstance(pfxob.original.forecast,
                        datamodel.ProbabilisticForecast) and

--- a/solarforecastarbiter/reports/figures/tests/conftest.py
+++ b/solarforecastarbiter/reports/figures/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+@pytest.fixture
+def replace_pfxobs_attrs():
+    # Replaces the fields of each processed forecast and obs with kwargs
+    def fn(report_obj, **kwargs):
+        raw_report = report_obj.raw_report
+        missing_data = report_obj.replace(
+            raw_report=raw_report.replace(
+                processed_forecasts_observations=tuple(
+                    pfxobs.replace(**kwargs)
+                    for pfxobs in raw_report.processed_forecasts_observations
+                )
+            )
+        )
+        return missing_data
+    return fn

--- a/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
@@ -548,3 +548,26 @@ def test_timeseries_plots_missing_prob_fx_data(
     assert isinstance(scatter_spec, str)
     assert ts_prob_spec is None
     assert not inc_dist
+
+
+def test_timeseries_plots_only_x_axis_data(report_with_raw_xy):
+    pfxobs = report_with_raw_xy.raw_report.processed_forecasts_observations
+    only_x = report_with_raw_xy.replace(
+        raw_report=report_with_raw_xy.raw_report.replace(
+            processed_forecasts_observations=tuple(
+                pair
+                for pair in pfxobs if pair.original.forecast.axis == 'x'
+            )
+        )
+    )
+
+    ts_spec, scatter_spec, ts_prob_spec, inc_dist = figures.timeseries_plots(
+        only_x)
+    ts_spec_dict = json.loads(ts_spec)
+    assert len(ts_spec_dict['data']) == 1
+    obs_name = pfxobs[0].original.observation.name
+    assert ts_spec_dict['data'][0]['name'] == obs_name
+    assert isinstance(ts_spec, str)
+    assert scatter_spec is None
+    assert isinstance(ts_prob_spec, str)
+    assert not inc_dist

--- a/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
@@ -589,3 +589,24 @@ def test_timeseries_plots_only_x_axis_data(report_with_raw_xy):
     assert scatter_spec is None
     assert isinstance(ts_prob_spec, str)
     assert not inc_dist
+
+
+def test_timeseries_plots_only_x_axis_data_no_obs(
+        report_with_raw_xy, replace_pfxobs_attrs):
+    pfxobs = report_with_raw_xy.raw_report.processed_forecasts_observations
+    only_x = report_with_raw_xy.replace(
+        raw_report=report_with_raw_xy.raw_report.replace(
+            processed_forecasts_observations=tuple(
+                pair
+                for pair in pfxobs if pair.original.forecast.axis == 'x'
+            )
+        )
+    )
+
+    only_x = replace_pfxobs_attrs(only_x, observation_values=None)
+    ts_spec, scatter_spec, ts_prob_spec, inc_dist = figures.timeseries_plots(
+        only_x)
+    assert ts_spec is None
+    assert scatter_spec is None
+    assert isinstance(ts_prob_spec, str)
+    assert not inc_dist

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -56,9 +56,10 @@ def _get_render_kwargs(report, dash_url, with_timeseries):
     dash_url: str
         URL of the Solar Forecast arbiter dashboard to use when building links.
     with_timeseries: bool
-        Whether or not to include timeseries plots. If an error occurs, sets
-        `timeseries_script` to an empty string and `timeseries_div` will
-        contain a <div> element for warning the user of the failure.
+        Whether or not to include timeseries plots. If an error occurs when
+        trying to generate timeseries plots, the `timeseries_spec`,
+        `scatter_spec`, and `timeseries_prob_spec` arguments will not be
+        defined.
 
     Returns
     -------
@@ -82,19 +83,24 @@ def _get_render_kwargs(report, dash_url, with_timeseries):
 
     plot_plotly = getattr(report_plots, 'plotly_version', None)
     kwargs['plotly_version'] = plot_plotly if plot_plotly else plotly_version
+
     if with_timeseries:
         try:
             timeseries_specs = plotly_figures.timeseries_plots(report)
         except Exception:
             logger.exception(
                 'Failed to make Plotly items for timeseries and scatterplot')
-            timeseries_specs = ('{}', '{}', '{}', False)
-        kwargs['timeseries_spec'] = timeseries_specs[0]
-        kwargs['scatter_spec'] = timeseries_specs[1]
-        if timeseries_specs[2] is not None:
-            kwargs['timeseries_prob_spec'] = timeseries_specs[2]
+        else:
+            if timeseries_specs[0] is not None:
+                kwargs['timeseries_spec'] = timeseries_specs[0]
 
-        kwargs['includes_distribution'] = timeseries_specs[3]
+            if timeseries_specs[1] is not None:
+                kwargs['scatter_spec'] = timeseries_specs[1]
+
+            if timeseries_specs[2] is not None:
+                kwargs['timeseries_prob_spec'] = timeseries_specs[2]
+
+            kwargs['includes_distribution'] = timeseries_specs[3]
 
     return kwargs
 

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -116,13 +116,14 @@ Plotly.newPlot("timeseries-div", ts_plot);
 {% endif %}
 
 <div id="scatter-div"></div>
-<script>
+
 {% if scatter_spec is defined %}
+<script>
 scat_plot = JSON.parse('{{ scatter_spec | safe }}');
 Object.assign(scat_plot,{config: {responsive: true}});
 Plotly.newPlot("scatter-div", scat_plot);
-{% endif %}
 </script>
+{% endif %}
 
 {% if timeseries_prob_spec is defined %}
 <p>The plot below shows probability vs. time for probabilistic forecasts

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -107,17 +107,22 @@ parameterized asymmetrically around the 50th percentile, brighter colors
 indicate smaller percentiles and darker colors indicate larger percentiles.
 Use the hover tool to determine the percentile.</p>
 {% endif %}
-<div id="scatter-div"></div>
 
 <script>
 ts_plot = JSON.parse('{{ timeseries_spec | safe }}');
 Object.assign(ts_plot,{config: {responsive: true}});
 Plotly.newPlot("timeseries-div", ts_plot);
+</script>
+{% endif %}
+
+<div id="scatter-div"></div>
+<script>
+{% if scatter_spec is defined %}
 scat_plot = JSON.parse('{{ scatter_spec | safe }}');
 Object.assign(scat_plot,{config: {responsive: true}});
 Plotly.newPlot("scatter-div", scat_plot);
-</script>
 {% endif %}
+</script>
 
 {% if timeseries_prob_spec is defined %}
 <p>The plot below shows probability vs. time for probabilistic forecasts

--- a/solarforecastarbiter/reports/tests/test_template.py
+++ b/solarforecastarbiter/reports/tests/test_template.py
@@ -97,9 +97,9 @@ def test__get_render_kwargs_with_series_exception(
         dash_url,
         True
     )
-    assert kwargs['timeseries_spec'] == '{}'
-    assert kwargs['scatter_spec'] == '{}'
-    assert kwargs['timeseries_prob_spec'] == '{}'
+    assert 'timeseries_spec' not in kwargs
+    assert 'scatter_spec' not in kwargs
+    assert 'timeseries_prob_spec' not in kwargs
 
 
 @pytest.fixture(params=[0, 1, 2])
@@ -321,3 +321,49 @@ def test_figure_name_filter(val):
     new = template._figure_name_filter(val)
     match = NOTWORD.match(new)
     assert match is None
+
+
+def test__get_render_kwargs_with_missing_fx_data(
+        report_with_raw, dash_url):
+    raw_report = report_with_raw.raw_report
+    missing_data = report_with_raw.replace(
+        raw_report=raw_report.replace(
+            processed_forecasts_observations=tuple(
+                pfxobs.replace(forecast_values=None)
+                for pfxobs in raw_report.processed_forecasts_observations
+            )
+        )
+    )
+
+    kwargs = template._get_render_kwargs(
+        missing_data,
+        dash_url,
+        True
+    )
+    assert 'timeseries_spec' not in kwargs
+    assert 'scatter_spec' not in kwargs
+    assert 'timeseries_prob_spec' not in kwargs
+    assert not kwargs['includes_distribution']
+
+
+def test__get_render_kwargs_with_missing_obs_data(
+        report_with_raw, dash_url):
+    raw_report = report_with_raw.raw_report
+    missing_data = report_with_raw.replace(
+        raw_report=raw_report.replace(
+            processed_forecasts_observations=tuple(
+                pfxobs.replace(observation_values=None)
+                for pfxobs in raw_report.processed_forecasts_observations
+            )
+        )
+    )
+
+    kwargs = template._get_render_kwargs(
+        missing_data,
+        dash_url,
+        True
+    )
+    assert 'timeseries_spec' in kwargs
+    assert 'scatter_spec' not in kwargs
+    assert 'timeseries_prob_spec' not in kwargs
+    assert not kwargs['includes_distribution']


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
(https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
This adjusts `reports.template.py` and `reports.figures.plotly_figures.py` to handle cases where a user has only partial permissions to read time series data for the objects in a report.

Also selectively defines the plotly json specs for timeseries, scatter plot, and probabilistic timeseries figures to avoid intervening in the dashboard.

Previous behavior was such that the plotting code would fail at different points due to missing `observation_values` or `forecast_values` fields on the pairs in `Report.processed_forecasts_observations`. This would sometimes only emit a warning and result in empty plots.

The new behavior introduced by this PR should:
- Create no plots if no forecast data is available. Results in a report with only metrics plots. This is a situation in which users only have the `read_report` permission.
- Skip scatter plot creation if no observation data is available.
- Only add traces/legend entries for Forecasts/Observations that contain values for both Timeseries and Scatter plots.
