### PR TITLE
set showlegend when plotting forecast timeseries to ensure legend exi…

### DIFF
--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -402,6 +402,7 @@ def _plot_fx_timeseries(fig, timeseries_value_df, timeseries_meta_df, axis):
             x=data.index,
             name=_legend_text(metadata['forecast_name']),
             legendgroup=metadata['forecast_name'],
+            showlegend=True,
             connectgaps=False,
             **plot_kwargs)
         fig.add_trace(go_)


### PR DESCRIPTION
…sts with a single forecast

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Sets explicit `showlegend` argument on fx timeseries plots to avoid bug where if a user only has permission to read one object in the plot.