### PR TITLE
Report table styles

### DIFF
--- a/docs/source/whatsnew/1.0.0rc4.rst
+++ b/docs/source/whatsnew/1.0.0rc4.rst
@@ -60,6 +60,9 @@ Bug fixes
 * Dynamically calculate plot height to avoid truncating long forecast names
   in total metric plots. (:issue:`576`) (:pull:`581`) (:pull:`582`)
 * Fix GEFS file fetching for upgraded model (:issue:`544`) (:pull:`584`)
+* Fixed issue with overlapping table entries for report metric, validation, and
+  preprocessing tables. Tables are now horizontally scrollable to avoid overlap
+  of columns. (:issue:`418`) (:pull:`588`)
 
 
 Contributors

--- a/solarforecastarbiter/reports/templates/html/base.html
+++ b/solarforecastarbiter/reports/templates/html/base.html
@@ -7,7 +7,7 @@
     <main role="main" class="flex-shrink-0">
       <div class="container">
         <div class="row">
-          <div class="content col-md-9 col-sm-12">
+          <div class="content col-md-12 col-sm-12">
             {% block body %}{% endblock %}
           </div>
         </div>

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -12,6 +12,9 @@
   }
   .report-table-wrapper caption{
       max-width: 40vw;
+      position: sticky;
+      left: 0;
+      top: 0;
   }
   .report-table-wrapper table.table{
       overflow: unset;

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -3,6 +3,32 @@
 {% set report_name = report.report_parameters.name %}
 
 {% block body %}
+<style type="text/css" scoped>
+  #report-block .report-table-wrapper{
+      max-width: 100%;
+      max-height: 100%;
+      position: relative;
+      overflow-x: scroll;
+  }
+  #report-block .report-table-wrapper caption{
+      max-width: 40vw;
+  }
+  #report-block .report-table-wrapper table.table{
+      overflow: unset;
+      table-layout: auto;
+  }
+  #report-block .report-table-wrapper table.table tr th:first-child,
+  #report-block .report-table-wrapper table.table tr td:first-child{
+      position: -webkit-sticky;
+      position: sticky;
+      left: 0;
+      top: auto;
+      background-color: #fff;
+      border-right: #dee2e6;
+      width: fit-content;
+      font-weight: 700
+  }
+</style>
 {% block report_title %}
 <h1 id="report-title">{{ report_name }}</h1>
 {% endblock %}

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -4,21 +4,21 @@
 
 {% block body %}
 <style type="text/css" scoped>
-  #report-block .report-table-wrapper{
+  .report-table-wrapper{
       max-width: 100%;
       max-height: 100%;
       position: relative;
       overflow-x: scroll;
   }
-  #report-block .report-table-wrapper caption{
+  .report-table-wrapper caption{
       max-width: 40vw;
   }
-  #report-block .report-table-wrapper table.table{
+  .report-table-wrapper table.table{
       overflow: unset;
       table-layout: auto;
   }
-  #report-block .report-table-wrapper table.table tr th:first-child,
-  #report-block .report-table-wrapper table.table tr td:first-child{
+  .report-table-wrapper table.table tr th:first-child,
+  .report-table-wrapper table.table tr td:first-child{
       position: -webkit-sticky;
       position: sticky;
       left: 0;

--- a/solarforecastarbiter/reports/templates/html/macros.j2
+++ b/solarforecastarbiter/reports/templates/html/macros.j2
@@ -9,6 +9,7 @@ forecasts/single/{{ forecast.forecast_id }}
 {% endmacro %}
 
 {% macro metric_table_fx_vert(report_metrics, category, metric_ordering) %}
+<div class="report-table-wrapper">
 <table class="table table-striped metric-table-fx-vert" style="width:100%;">
   <caption style="caption-side:top; text-align:center">
     Table of {{ category }} metrics
@@ -45,6 +46,7 @@ forecasts/single/{{ forecast.forecast_id }}
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endmacro %}
 
 
@@ -107,6 +109,7 @@ forecasts/single/{{ forecast.forecast_id }}
 
 
 {% macro validation_table(proc_fxobs_list, quality_filters) %}
+<div class="report-table-wrapper">
 <table class="table table-striped validation-table" style="width:100%;">
   <caption style="caption-side:top; text-align:center">
     Table of data validation results
@@ -149,6 +152,7 @@ forecasts/single/{{ forecast.forecast_id }}
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endmacro %}
 
 
@@ -161,6 +165,7 @@ forecasts/single/{{ forecast.forecast_id }}
     {% endif %}
   {% endfor %}
 {% endfor %}
+<div class="report-table-wrapper">
 <table class="table table-striped preprocessing-table" style="width:100%;">
   <caption style="caption-side:top; text-align:center">
     Table of data preprocessing results
@@ -195,6 +200,7 @@ forecasts/single/{{ forecast.forecast_id }}
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endmacro %}
 
 

--- a/solarforecastarbiter/reports/templates/html/macros.j2
+++ b/solarforecastarbiter/reports/templates/html/macros.j2
@@ -11,7 +11,7 @@ forecasts/single/{{ forecast.forecast_id }}
 {% macro metric_table_fx_vert(report_metrics, category, metric_ordering) %}
 <div class="report-table-wrapper">
 <table class="table table-striped metric-table-fx-vert" style="width:100%;">
-  <caption style="caption-side:top; text-align:center">
+  <caption style="caption-side:top; text-align: left">
     Table of {{ category }} metrics
   </caption>
   <thead>
@@ -111,7 +111,7 @@ forecasts/single/{{ forecast.forecast_id }}
 {% macro validation_table(proc_fxobs_list, quality_filters) %}
 <div class="report-table-wrapper">
 <table class="table table-striped validation-table" style="width:100%;">
-  <caption style="caption-side:top; text-align:center">
+  <caption style="caption-side:top; text-align: left">
     Table of data validation results
   </caption>
   <thead>
@@ -167,7 +167,7 @@ forecasts/single/{{ forecast.forecast_id }}
 {% endfor %}
 <div class="report-table-wrapper">
 <table class="table table-striped preprocessing-table" style="width:100%;">
-  <caption style="caption-side:top; text-align:center">
+  <caption style="caption-side:top; text-align: left">
     Table of data preprocessing results
   </caption>
   <thead>

--- a/solarforecastarbiter/reports/templates/html/metrics_meta_table.html
+++ b/solarforecastarbiter/reports/templates/html/metrics_meta_table.html
@@ -1,7 +1,7 @@
 {% include 'metrics_meta_table_text' %}
 <div class="report-table-wrapper">
 <table class="table table-striped table-borderless metrics-meta-table" style="width:100%; ">
-    <caption style="caption-side: top; text-align: center;">
+    <caption style="caption-side: top; text-align: left;">
     Table of metrics metadata
     </caption>
     <colgroup>

--- a/solarforecastarbiter/reports/templates/html/metrics_meta_table.html
+++ b/solarforecastarbiter/reports/templates/html/metrics_meta_table.html
@@ -1,4 +1,5 @@
 {% include 'metrics_meta_table_text' %}
+<div class="report-table-wrapper">
 <table class="table table-striped table-borderless metrics-meta-table" style="width:100%; ">
     <caption style="caption-side: top; text-align: center;">
     Table of metrics metadata
@@ -34,3 +35,4 @@
     {% endfor %}
     </tbody>
 </table>
+</div>

--- a/solarforecastarbiter/reports/templates/html/obsfx_table.html
+++ b/solarforecastarbiter/reports/templates/html/obsfx_table.html
@@ -1,7 +1,7 @@
 {% include "obsfx_table_text" %}
 {% import "macros.j2" as macros with context %}
 <table class="table table-striped table-borderless obsfx-table" style="width:100%; ">
-  <caption style="caption-side: top; text-align: center;">
+  <caption style="caption-side: top; text-align: left;">
     Table of data alignment parameters
   </caption>
   <colgroup>

--- a/solarforecastarbiter/reports/templates/html/obsfx_table.html
+++ b/solarforecastarbiter/reports/templates/html/obsfx_table.html
@@ -1,5 +1,6 @@
 {% include "obsfx_table_text" %}
 {% import "macros.j2" as macros with context %}
+<div class="report-table-wrapper">
 <table class="table table-striped table-borderless obsfx-table" style="width:100%; ">
   <caption style="caption-side: top; text-align: center;">
     Table of data alignment parameters
@@ -87,3 +88,4 @@
     {% endfor %}
   </tbody>
 </table>
+</div>

--- a/solarforecastarbiter/reports/templates/html/obsfx_table.html
+++ b/solarforecastarbiter/reports/templates/html/obsfx_table.html
@@ -1,6 +1,5 @@
 {% include "obsfx_table_text" %}
 {% import "macros.j2" as macros with context %}
-<div class="report-table-wrapper">
 <table class="table table-striped table-borderless obsfx-table" style="width:100%; ">
   <caption style="caption-side: top; text-align: center;">
     Table of data alignment parameters
@@ -88,4 +87,3 @@
     {% endfor %}
   </tbody>
 </table>
-</div>

--- a/solarforecastarbiter/reports/tests/test_macros.py
+++ b/solarforecastarbiter/reports/tests/test_macros.py
@@ -21,7 +21,8 @@ def macro_test_template():
     return fn
 
 
-metric_table_fx_vert_format = """<table class="table table-striped metric-table-fx-vert" style="width:100%;">
+metric_table_fx_vert_format = """<div class="report-table-wrapper">
+<table class="table table-striped metric-table-fx-vert" style="width:100%;">
   <caption style="caption-side:top; text-align:center">
     Table of {} metrics
   </caption>
@@ -46,6 +47,7 @@ metric_table_fx_vert_format = """<table class="table table-striped metric-table-
       </tr>
   </tbody>
 </table>
+</div>
 """
 
 
@@ -111,7 +113,8 @@ def test_metric_table_fx_horz(report_with_raw, macro_test_template):
             category, 5, expected_metric[0].name)
 
 
-validation_table_format = """<table class="table table-striped validation-table" style="width:100%;">
+validation_table_format = """<div class="report-table-wrapper">
+<table class="table table-striped validation-table" style="width:100%;">
   <caption style="caption-side:top; text-align:center">
     Table of data validation results
   </caption>
@@ -153,6 +156,7 @@ validation_table_format = """<table class="table table-striped validation-table"
       </tr>
   </tbody>
 </table>
+</div>
 """
 
 
@@ -173,7 +177,8 @@ def test_validation_table(report_with_raw, macro_test_template):
         *qfilters)
 
 
-preprocessing_table_format = """<table class="table table-striped preprocessing-table" style="width:100%;">
+preprocessing_table_format = """<div class="report-table-wrapper">
+<table class="table table-striped preprocessing-table" style="width:100%;">
   <caption style="caption-side:top; text-align:center">
     Table of data preprocessing results
   </caption>
@@ -216,6 +221,7 @@ preprocessing_table_format = """<table class="table table-striped preprocessing-
       </tr>
   </tbody>
 </table>
+</div>
 """
 
 

--- a/solarforecastarbiter/reports/tests/test_macros.py
+++ b/solarforecastarbiter/reports/tests/test_macros.py
@@ -23,7 +23,7 @@ def macro_test_template():
 
 metric_table_fx_vert_format = """<div class="report-table-wrapper">
 <table class="table table-striped metric-table-fx-vert" style="width:100%;">
-  <caption style="caption-side:top; text-align:center">
+  <caption style="caption-side:top; text-align: left">
     Table of {} metrics
   </caption>
   <thead>
@@ -115,7 +115,7 @@ def test_metric_table_fx_horz(report_with_raw, macro_test_template):
 
 validation_table_format = """<div class="report-table-wrapper">
 <table class="table table-striped validation-table" style="width:100%;">
-  <caption style="caption-side:top; text-align:center">
+  <caption style="caption-side:top; text-align: left">
     Table of data validation results
   </caption>
   <thead>
@@ -179,7 +179,7 @@ def test_validation_table(report_with_raw, macro_test_template):
 
 preprocessing_table_format = """<div class="report-table-wrapper">
 <table class="table table-striped preprocessing-table" style="width:100%;">
-  <caption style="caption-side:top; text-align:center">
+  <caption style="caption-side:top; text-align: left">
     Table of data preprocessing results
   </caption>
   <thead>

--- a/solarforecastarbiter/reports/tests/test_template.py
+++ b/solarforecastarbiter/reports/tests/test_template.py
@@ -144,7 +144,7 @@ def test_render_html_body_only(report_with_raw, dash_url, with_series,
                                mocked_timeseries_plots):
     rendered = template.render_html(
         report_with_raw, dash_url, with_series, True)
-    assert rendered[:22] == '<h1 id="report-title">'
+    assert rendered[:30] == '<style type="text/css" scoped>'
 
 
 def test_render_html_full_html(report_with_raw, dash_url, with_series,


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #418  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Allows scrolling for tables that scale with the number of selected metrics/pairs/quality flags.
Here is a report rendered both ways:
With new scrolling: [post-scrolling.zip](https://github.com/SolarArbiter/solarforecastarbiter-core/files/5380758/post-scrolling.zip)
Without scrolling: [pre-scrolling.zip](https://github.com/SolarArbiter/solarforecastarbiter-core/files/5380760/pre-scrolling.zip)


