### PR TITLE
Allow uncertainty to be null

### DIFF
--- a/docs/source/whatsnew/1.0.0rc4.rst
+++ b/docs/source/whatsnew/1.0.0rc4.rst
@@ -43,6 +43,8 @@ Enhancements
   the report's forecasts and observations. Users with limited permissions on a
   report may need to instantiate a :py:class:`datamodel.Report` object from an
   api response from the ``/reports`` endpoint manually. (:pull:`585`)
+* Allow setting ``uncertainty=None`` on :py:class:`datamodel.Observation` to
+  indicate an unknown uncertainty (:pull:`591`)
 
 
 Bug fixes

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -539,7 +539,7 @@ def ac_power_observation_metadata(powerplant_metadata):
         name='Albuquerque Baseline AC Power', variable='ac_power',
         interval_value_type='instantaneous',
         interval_length=pd.Timedelta('5min'),
-        interval_label='instant', site=powerplant_metadata, uncertainty=1)
+        interval_label='instant', site=powerplant_metadata, uncertainty=1.)
     return ac_power_meta
 
 
@@ -549,7 +549,7 @@ def dc_power_observation_metadata(powerplant_metadata):
         name='Albuquerque Baseline DC Power', variable='dc_power',
         interval_value_type='instantaneous',
         interval_length=pd.Timedelta('5min'),
-        interval_label='instant', site=powerplant_metadata, uncertainty=1)
+        interval_label='instant', site=powerplant_metadata, uncertainty=1.)
     return dc_power_meta
 
 
@@ -559,7 +559,7 @@ def wind_speed_observation_metadata(powerplant_metadata):
         name='Albuquerque Baseline Wind Speed', variable='wind_speed',
         interval_value_type='instantaneous',
         interval_length=pd.Timedelta('5min'),
-        interval_label='instant', site=powerplant_metadata, uncertainty=1)
+        interval_label='instant', site=powerplant_metadata, uncertainty=1.)
     return wind_speed_meta
 
 
@@ -568,7 +568,7 @@ def ac_power_observation_metadata_label(request, powerplant_metadata):
     ac_power_meta = datamodel.Observation(
         name='Albuquerque Baseline AC Power', variable='ac_power',
         interval_value_type='mean', interval_length=pd.Timedelta('5min'),
-        interval_label=request.param, site=powerplant_metadata, uncertainty=1)
+        interval_label=request.param, site=powerplant_metadata, uncertainty=1.)
     return ac_power_meta
 
 
@@ -578,14 +578,14 @@ def ghi_observation_metadata(site_metadata):
         name='Albuquerque Baseline GHI', variable='ghi',
         interval_value_type='instantaneous',
         interval_length=pd.Timedelta('5min'),
-        interval_label='instant', site=site_metadata, uncertainty=1)
+        interval_label='instant', site=site_metadata, uncertainty=1.)
     return ghi_meta
 
 
 def default_observation(
         site_metadata,
         name='Albuquerque Baseline', variable='ghi',
-        interval_value_type='mean', uncertainty=1, interval_length='1h',
+        interval_value_type='mean', uncertainty=1., interval_length='1h',
         interval_label='beginning'):
     """
     Helpful when you want to test a couple of parameters and don't
@@ -804,7 +804,7 @@ def many_observations_text():
     "observation_id": "123e4567-e89b-12d3-a456-426655440000",
     "provider": "Organization 1",
     "site_id": "123e4567-e89b-12d3-a456-426655440001",
-    "uncertainty": 0.1,
+    "uncertainty": null,
     "variable": "ghi"
   }
 ]"""  # NOQA
@@ -2493,13 +2493,13 @@ def report_text():
              {"forecast": "68a1c22c-87b5-11e9-bf88-0a580a8200ae",
               "observation": "9f657636-7e49-11e9-b77f-0a580a8003e9",
               "normalization": "1000",
-              "uncertainty": "15",
+              "uncertainty": "15.",
               "cost": "example cost",
               "reference_forecast": "refbc386-8712-11e9-a1c7-0a580a8200ae"},
              {"forecast": "49220780-76ae-4b11-bef1-7a75bdc784e3",
               "aggregate": "458ffc27-df0b-11e9-b622-62adb5fd6af0",
               "cost": "example cost",
-              "uncertainty": "5"}
+              "uncertainty": "5."}
          ]
      },
      "raw_report": null,

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -497,9 +497,10 @@ class Observation(BaseModel):
         average, indicates an instantaneous value, or indicates an event.
     site : Site
         The site that this Observation was generated for.
-    uncertainty : float
+    uncertainty : float or None
         A measure of the uncertainty of the observation values. The format
-        will be determined later.
+        will be determined later. None indicates that the uncertainty is
+        unknown for this Observation.
     observation_id : str, optional
         UUID of the observation in the API
     provider : str, optional
@@ -518,7 +519,7 @@ class Observation(BaseModel):
     interval_length: pd.Timedelta
     interval_label: str
     site: Site
-    uncertainty: float
+    uncertainty: Union[float, None]
     observation_id: str = ''
     provider: str = ''
     extra_parameters: str = ''

--- a/solarforecastarbiter/io/reference_observations/common.py
+++ b/solarforecastarbiter/io/reference_observations/common.py
@@ -148,8 +148,8 @@ def create_observation(api, site, variable, extra_params=None, **kwargs):
         Defaults to 'ending'
     interval_value_type: string
         Defaults to 'interval_mean'
-    uncertainty: float
-        Defaults to 0.
+    uncertainty: float or None
+        Defaults to None.
 
     Returns
     -------
@@ -190,7 +190,7 @@ def create_observation(api, site, variable, extra_params=None, **kwargs):
         'interval_value_type': kwargs.get('interval_value_type',
                                           'interval_mean'),
         'site': site,
-        'uncertainty': kwargs.get('uncertainty', 0),
+        'uncertainty': kwargs.get('uncertainty'),
         'variable': variable,
         'extra_parameters': json.dumps(extra_parameters)
     })

--- a/solarforecastarbiter/io/reference_observations/pvdaq_reference_sites.json
+++ b/solarforecastarbiter/io/reference_observations/pvdaq_reference_sites.json
@@ -468,7 +468,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 4, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -499,7 +499,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 4, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -530,7 +530,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ambient_temp\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 4, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -561,7 +561,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"poa_irradiance\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 4, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -592,7 +592,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 33, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -623,7 +623,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 33, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -654,7 +654,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ambient_temp\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 33, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -685,7 +685,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"poa_irradiance\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 33, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -716,7 +716,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 34, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -747,7 +747,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 34, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -778,7 +778,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ambient_temp\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 34, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -809,7 +809,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"poa_irradiance\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 34, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -840,7 +840,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"wind_speed\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 34, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -871,7 +871,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 39, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -902,7 +902,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 39, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -933,7 +933,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ambient_temp\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 39, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -964,7 +964,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"poa_irradiance\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 39, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -995,7 +995,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 50, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -1026,7 +1026,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 50, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -1057,7 +1057,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ambient_temp\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 50, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -1088,7 +1088,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 51, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -1119,7 +1119,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 51, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -1150,7 +1150,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ambient_temp\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 51, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -1181,7 +1181,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"poa_irradiance\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 51, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -1212,7 +1212,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"inv1_ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1199, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 5, \"resample_how\": \"first\"}"
@@ -1243,7 +1243,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"inv1_dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1199, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 5, \"resample_how\": \"first\"}"
@@ -1274,7 +1274,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1200, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 5, \"resample_how\": \"first\"}"
@@ -1305,7 +1305,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1201, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 5, \"resample_how\": \"first\"}"
@@ -1336,7 +1336,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1201, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 5, \"resample_how\": \"first\"}"
@@ -1367,7 +1367,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power_metered\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1202, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 5, \"resample_how\": \"first\"}"
@@ -1398,7 +1398,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1208, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"mean\"}"
@@ -1429,7 +1429,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1208, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"mean\"}"
@@ -1460,7 +1460,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1232, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1491,7 +1491,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power_metered_A\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1234, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1522,7 +1522,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1276, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1553,7 +1553,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1276, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1584,7 +1584,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ambient_temp\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1276, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1615,7 +1615,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"poa_irradiance\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1276, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1646,7 +1646,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"wind_speed\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1276, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1677,7 +1677,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1277, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1708,7 +1708,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1277, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1739,7 +1739,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ambient_temp\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1277, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1770,7 +1770,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"poa_irradiance\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1277, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1801,7 +1801,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"wind_speed\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1277, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1832,7 +1832,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"inv1_ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1278, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1863,7 +1863,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"inv1_dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1278, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1894,7 +1894,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ambient_temp\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1278, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1925,7 +1925,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"poa_irradiance\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1278, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1956,7 +1956,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"wind_speed\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1278, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 15, \"resample_how\": \"first\"}"
@@ -1987,7 +1987,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"poa_irradiance\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1283, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"mean\"}"
@@ -2018,7 +2018,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1283, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"mean\"}"
@@ -2049,7 +2049,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ambient_temp\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1283, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"mean\"}"
@@ -2080,7 +2080,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1283, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"mean\"}"
@@ -2111,7 +2111,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"wind_speed\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1283, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"mean\"}"
@@ -2142,7 +2142,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1289, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -2173,7 +2173,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1289, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -2204,7 +2204,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ambient_temp\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1289, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -2235,7 +2235,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"poa_irradiance\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1289, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -2266,7 +2266,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power_metered\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1332, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"mean\"}"
@@ -2297,7 +2297,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1403, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -2328,7 +2328,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ambient_temp\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1403, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -2359,7 +2359,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1403, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -2390,7 +2390,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"poa_irradiance\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1403, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -2421,7 +2421,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ac_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1423, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -2452,7 +2452,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ambient_temp\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1423, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -2483,7 +2483,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1423, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -2514,7 +2514,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"poa_irradiance\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1423, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -2545,7 +2545,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"AC_PowerA\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1426, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -2576,7 +2576,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"ambient_temperature\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1426, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -2607,7 +2607,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"dc_power\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1426, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"
@@ -2638,7 +2638,7 @@
                     "tracking_type": "fixed"
                 }
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "observation_id": "",
             "provider": "",
             "extra_parameters": "{\"network_data_label\": \"poa_irradiance\", \"network\": \"NREL PVDAQ\", \"network_api_id\": 1426, \"network_api_abbreviation\": \"pvdaq\", \"observation_interval_length\": 1, \"resample_how\": \"first\"}"

--- a/solarforecastarbiter/io/reference_observations/srml_reference_sites.json
+++ b/solarforecastarbiter/io/reference_observations/srml_reference_sites.json
@@ -28,7 +28,7 @@
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "variable": "dc_power"
         },
         {
@@ -59,7 +59,7 @@
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "variable": "ac_power"
         },
         {
@@ -90,7 +90,7 @@
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "variable": "dc_power"
         },
         {
@@ -121,7 +121,7 @@
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "variable": "ac_power"
         },
         {
@@ -152,7 +152,7 @@
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "variable": "dc_power"
         },
         {
@@ -183,7 +183,7 @@
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "variable": "ac_power"
         },
         {
@@ -214,7 +214,7 @@
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "variable": "dc_power"
         },
         {
@@ -245,7 +245,7 @@
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "variable": "ac_power"
         },
         {
@@ -276,7 +276,7 @@
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "variable": "dc_power"
         },
         {
@@ -338,7 +338,7 @@
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "variable": "dc_power"
         },
         {
@@ -369,7 +369,7 @@
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "variable": "dc_power"
         },
         {
@@ -400,7 +400,7 @@
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "variable": "dc_power"
         },
         {
@@ -431,7 +431,7 @@
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "variable": "ac_power"
         },
         {
@@ -462,7 +462,7 @@
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "variable": "ac_power"
         },
         {
@@ -493,7 +493,7 @@
                 "site_id": "",
                 "timezone": "Etc/GMT+8"
             },
-            "uncertainty": 0,
+            "uncertainty": null,
             "variable": "dc_power"
         }
     ],

--- a/solarforecastarbiter/io/reference_observations/tests/conftest.py
+++ b/solarforecastarbiter/io/reference_observations/tests/conftest.py
@@ -117,7 +117,7 @@ def site_to_obs(site):
         'interval_value_type': 'interval_mean',
         'interval_length': interval_length,
         'site': site,
-        'uncertainty': 0,
+        'uncertainty': None,
         'extra_parameters': site.extra_parameters
     })
 

--- a/solarforecastarbiter/io/reference_observations/tests/test_common.py
+++ b/solarforecastarbiter/io/reference_observations/tests/test_common.py
@@ -34,7 +34,7 @@ site_test_observation = Observation.from_dict({
     'interval_value_type': 'interval_mean',
     'interval_length': 1,
     'site': site_objects[0],
-    'uncertainty': 0,
+    'uncertainty': 0.,
     'extra_parameters': ('{"network": "DOE ARM", '
                          '"observation_interval_length": 1,'
                          '"network_api_id": "api_id", '
@@ -154,7 +154,7 @@ observation_long_site_name = Observation.from_dict({
     'interval_value_type': 'interval_mean',
     'interval_length': 1,
     'site': long_site_name,
-    'uncertainty': 0,
+    'uncertainty': None,
     'extra_parameters': ('{"network": "DOE ARM", "network_api_abbreviation": '
                          '"site_abbrev", "network_api_id": "thing", '
                          '"observation_interval_length": 1}'),
@@ -177,7 +177,7 @@ observation_with_extra_params = Observation.from_dict({
     'interval_value_type': 'interval_mean',
     'interval_length': 5,
     'site': site_objects[0],
-    'uncertainty': 0,
+    'uncertainty': None,
     'extra_parameters': '{"network": "", "observation_interval_length": 5}'
 })
 observation_params = {
@@ -205,7 +205,7 @@ observation_dict = {
     'interval_value_type': 'instantaneous',
     'interval_length': 1,
     'site': site_objects[0],
-    'uncertainty': 2,
+    'uncertainty': 2.,
     'extra_parameters': ('{"network": "DOE ARM", '
                          '"network_api_id": "B13", '
                          '"network_api_abbreviation": "sgp", '
@@ -221,7 +221,7 @@ obs_kwargs = {
     'interval_label': 'beginning',
     'name': 'just observation',
     'interval_value_type': 'instantaneous',
-    'uncertainty': 2,
+    'uncertainty': 2.,
 }
 
 observation_dict_resample_mean = observation_dict.copy()
@@ -474,7 +474,7 @@ def site_obs():
             'interval_value_type': 'interval_mean',
             'interval_length': '5',
             'site': site,
-            'uncertainty': 0,
+            'uncertainty': 0.,
             'extra_parameters': site.extra_parameters
         }) for site in site_objects[:2]]
 

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -1032,3 +1032,12 @@ def test_cost_from_json(cost_json):
     cjson, exp = cost_json
     out = datamodel.Cost.from_dict(json.loads(cjson))
     assert out == exp
+
+
+def test_forecastobservation_null_uncertainty(
+        single_forecast, many_observations):
+    obs = many_observations[-1]
+    assert obs.uncertainty is None
+    assert datamodel.ForecastObservation.from_dict({
+        'forecast': single_forecast.to_dict(), 'observation': obs.to_dict(),
+        'uncertainty': 'observation_uncertainty'}).uncertainty is None


### PR DESCRIPTION
but still required it to be set. This make sure a user thinks about it
before going with none and allows the Union[Observation, Forecast] to
determine the proper from_dict type. Also set the default uncertainty
for reference observations to None.

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [ ] Closes #xxxx .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
