### PR TITLE
fix ensure_timestamps raising on bad args

### DIFF
--- a/docs/source/whatsnew/1.0.0rc4.rst
+++ b/docs/source/whatsnew/1.0.0rc4.rst
@@ -46,6 +46,8 @@ Enhancements
 * Add seasons to metrics category options. (:issue:`552`, :pull:`592`)
 * Allow setting ``uncertainty=None`` on :py:class:`datamodel.Observation` to
   indicate an unknown uncertainty (:pull:`591`)
+* Update :py:func:`io.utils.ensure_timestamps` to raise a descriptive TypeError
+  for missing arguments to the underlying function (:issue:`498`)(:pull:`595`)
 
 
 Bug fixes

--- a/solarforecastarbiter/io/tests/test_io_utils.py
+++ b/solarforecastarbiter/io/tests/test_io_utils.py
@@ -412,17 +412,17 @@ def test_ensure_timestamps_omitted_args():
     def f(start, end, a, *, other):  # pragma: no cover
         return start, end
 
-    with pytest.raises(TypeError) as err:
+    with pytest.raises(
+            TypeError, match="missing a required argument: 'end'"):
         start, end = f('2020-01-01T00:00Z')
-    assert str(err.value) == "missing a required argument: 'end'"
 
-    with pytest.raises(TypeError) as err:
+    with pytest.raises(
+            TypeError, match="missing a required argument: 'a'"):
         start, end = f('2020-01-01T00:00Z', '2020-01-02T00:00Z')
-    assert str(err.value) == "missing a required argument: 'a'"
 
-    with pytest.raises(TypeError) as err:
+    with pytest.raises(
+            TypeError, match="missing a required argument: 'other'"):
         start, end = f('2020-01-01T00:00Z', end='2020-01-02T00:00Z', a=0)
-    assert str(err.value) == "missing a required argument: 'other'"
 
     f('2020-01-01T00:00Z', '2020-01-02T00:00Z', 0, other=None)
     with pytest.raises(ValueError):

--- a/solarforecastarbiter/io/tests/test_io_utils.py
+++ b/solarforecastarbiter/io/tests/test_io_utils.py
@@ -407,6 +407,28 @@ def test_ensure_timestamps_err():
         start, end = f('', '2019-09-01T12:00Z', 'blah')
 
 
+def test_ensure_timestamps_omitted_args():
+    @utils.ensure_timestamps('start', 'end', 'other')
+    def f(start, end, a, *, other):  # pragma: no cover
+        return start, end
+
+    with pytest.raises(TypeError) as err:
+        start, end = f('2020-01-01T00:00Z')
+    assert str(err.value) == "missing a required argument: 'end'"
+
+    with pytest.raises(TypeError) as err:
+        start, end = f('2020-01-01T00:00Z', '2020-01-02T00:00Z')
+    assert str(err.value) == "missing a required argument: 'a'"
+
+    with pytest.raises(TypeError) as err:
+        start, end = f('2020-01-01T00:00Z', end='2020-01-02T00:00Z', a=0)
+    assert str(err.value) == "missing a required argument: 'other'"
+
+    f('2020-01-01T00:00Z', '2020-01-02T00:00Z', 0, other=None)
+    with pytest.raises(ValueError):
+        f('2020-01-01T00:00Z', '2020-01-02T00:00Z', 0, other='a')
+
+
 def test_load_report_values(raw_report, report_objects):
     _, obs, fx0, fx1, agg, fxagg = report_objects
     ser = pd.Series(np.random.random(10),

--- a/solarforecastarbiter/io/utils.py
+++ b/solarforecastarbiter/io/utils.py
@@ -446,7 +446,11 @@ def ensure_timestamps(*time_args):
                 if k in kwargs:
                     kwargs[k] = pd.Timestamp(kwargs[k])
                 elif ind is not None:
-                    nargs[ind] = pd.Timestamp(args[ind])
+                    try:
+                        nargs[ind] = pd.Timestamp(args[ind])
+                    except IndexError:
+                        pass
+            sig.bind(*nargs, **kwargs)
             return f(*nargs, **kwargs)
         return wrapper
     return decorator


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #498 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
