### PR TITLE
avoid report logs in sentry

### DIFF
--- a/docs/source/whatsnew/1.0.0rc4.rst
+++ b/docs/source/whatsnew/1.0.0rc4.rst
@@ -79,6 +79,8 @@ Bug fixes
 * Fixed bug in process management when fetching NWP files which caused the
   script to hang indefinitely if a process were killed by the OS
   (:issue:`343`) (:pull:`594`)
+* Stop errors generated in the report process from being sent to
+  sentry (:issue:`329`) (:pull:`597`)
 
 
 Contributors

--- a/solarforecastarbiter/reports/templates/html/pending.html
+++ b/solarforecastarbiter/reports/templates/html/pending.html
@@ -5,6 +5,7 @@
 {% endblock %}
 <div class="alert alert-info">
   Report generation is pending. We will try and fetch the report again in 30 seconds, or you can try reloading this page.
+  If no report is available after 30 minutes, try recomputing the report.
 </div>
 <script>setInterval(function () {  window.location.reload(); }, 30000);</script>
 {% endblock %}

--- a/solarforecastarbiter/tests/test_utils.py
+++ b/solarforecastarbiter/tests/test_utils.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pandas.testing as pdt
 import pytest
+import sentry_sdk
 
 
 from solarforecastarbiter import utils
@@ -499,6 +500,30 @@ def test_hijack_loggers(mocker):
     with utils.hijack_loggers(['testhijack']):
         assert logger.handlers[0] == new_handler
     assert logger.handlers[0] == old_handler
+
+
+def test_hijack_loggers_sentry(mocker):
+    events = set()
+
+    def before_send(event, hint):
+        events.add(event['logger'])
+        return
+
+    sentry_sdk.init(
+        "https://examplePublicKey@o0.ingest.sentry.io/0",
+        before_send=before_send)
+    logger = logging.getLogger('testlog')
+    with utils.hijack_loggers(['testlog']):
+        logging.getLogger('root').error('will show up')
+        logger.error('AHHH')
+    assert 'root' in events
+    assert 'testlog' not in events
+
+    events = set()
+    logging.getLogger('root').error('will show up')
+    logger.error('AHHH')
+    assert 'root' in events
+    assert 'testlog' in events
 
 
 @pytest.mark.parametrize('data,freq,expected', [

--- a/solarforecastarbiter/utils.py
+++ b/solarforecastarbiter/utils.py
@@ -6,6 +6,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
+from sentry_sdk.integrations import logging as sentry_logging
 
 
 from solarforecastarbiter import datamodel
@@ -268,10 +269,15 @@ def hijack_loggers(loggers, level=logging.INFO):
         logger = logging.getLogger(name)
         old_handlers[name] = logger.handlers
         logger.handlers = [handler]
+        sentry_logging.ignore_logger(name)
     yield handler
     for name in loggers:
         logger = logging.getLogger(name)
         logger.handlers = old_handlers[name]
+        try:
+            sentry_logging._IGNORED_LOGGERS.remove(name)
+        except Exception:
+            pass
     del handler
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #329 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

and add a comment to request a report recompute if it isn't computed in 30 minutes for #526