### PR TITLE
add constant_value_units for prob. forecasts

### DIFF
--- a/docs/source/whatsnew/1.0.0rc4.rst
+++ b/docs/source/whatsnew/1.0.0rc4.rst
@@ -50,6 +50,9 @@ Enhancements
   for missing arguments to the underlying function (:issue:`498`)(:pull:`595`)
 * Interval label, interval value type, and aggregate type are now validated
   when creating datamodel objects (:issue:`213`) (:pull:`596`)
+* Add the automatically generated `constant_value_units` attribute to
+  :py:class:`datamodel.ProbabilisticForecast` and :py:class:`datamodel.ProbabilisticForecastConstantValue`
+  (:issue:`470`) (:pull:`598`)
 
 
 Bug fixes

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -848,7 +848,7 @@ def __set_constant_value_units__(cls):
         object.__setattr__(cls, 'constant_value_units', cls.units)
         object.__setattr__(cls, 'units', '%')
     else:
-        # e.g. Prob(o < f) = 90%. Forecast is in units of obs, constant value is %
+        # e.g. Prob(o < f) = 90%. Forecast in units of obs, constant value is %
         object.__setattr__(cls, 'constant_value_units', '%')
 
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1259,7 +1259,7 @@ def __check_units__(*args):
             unique_units.add(arg.constant_value_units)
         else:
             unique_units.add(arg.units)
-    if not len(unique_units) == 1:
+    if len(unique_units) > 1:
         raise ValueError('All units must be identical.')
 
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -844,6 +844,7 @@ class EventForecast(Forecast):
 
 def __set_constant_value_units__(cls):
     if cls.axis == 'x':
+        # e.g. Prob(o < 10 MW). Forecast is in %, constant value is 10 MW
         object.__setattr__(cls, 'constant_value_units', cls.units)
         object.__setattr__(cls, 'units', '%')
     else:

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -147,6 +147,8 @@ def _dict_factory(inp):
             dict_[k] = _time_conv(v)
     if 'units' in dict_:
         del dict_['units']
+    if 'constant_value_units' in dict_:
+        del dict_['constant_value_units']
     if 'data_object' in dict_:
         del dict_['data_object']
     return dict_
@@ -840,10 +842,19 @@ class EventForecast(Forecast):
         super().__post_init__()
 
 
+def __set_constant_value_units__(cls):
+    if cls.axis == 'x':
+        object.__setattr__(cls, 'constant_value_units', cls.units)
+        object.__setattr__(cls, 'units', '%')
+    else:
+        object.__setattr__(cls, 'constant_value_units', '%')
+
+
 @dataclass(frozen=True)
 class _ProbabilisticForecastConstantValueBase:
     axis: str
     constant_value: float
+    constant_value_units: str = field(init=False)
 
 
 @dataclass(frozen=True)
@@ -908,12 +919,14 @@ class ProbabilisticForecastConstantValue(
     def __post_init__(self):
         super().__post_init__()
         __check_axis__(self.axis)
+        __set_constant_value_units__(self)
 
 
 @dataclass(frozen=True)
 class _ProbabilisticForecastBase:
     axis: str
     constant_values: Tuple[Union[ProbabilisticForecastConstantValue, float, int], ...]  # NOQA
+    constant_value_units: str = field(init=False)
 
 
 @dataclass(frozen=True)
@@ -981,6 +994,7 @@ class ProbabilisticForecast(
     def __post_init__(self):
         super().__post_init__()
         __check_axis__(self.axis)
+        __set_constant_value_units__(self)
         __set_constant_values__(self)
         __check_axis_consistency__(self.axis, self.constant_values)
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -847,6 +847,7 @@ def __set_constant_value_units__(cls):
         object.__setattr__(cls, 'constant_value_units', cls.units)
         object.__setattr__(cls, 'units', '%')
     else:
+        # e.g. Prob(o < f) = 90%. Forecast is in units of obs, constant value is %
         object.__setattr__(cls, 'constant_value_units', '%')
 
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1253,8 +1253,13 @@ def __check_axis_consistency__(axis, constant_values):
 def __check_units__(*args):
     if len(args) == 0:
         return
-    ref_unit = args[0].units
-    if not all(arg.units == ref_unit for arg in args):
+    unique_units = set()
+    for arg in args:
+        if getattr(arg, 'axis', None) == 'x':
+            unique_units.add(arg.constant_value_units)
+        else:
+            unique_units.add(arg.units)
+    if not len(unique_units) == 1:
         raise ValueError('All units must be identical.')
 
 

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -1083,3 +1083,38 @@ def test_aggregate_type(il, at, aggregate, aggregate_observations):
     params['observations'] = aggregate_observations
     with pytest.raises(ValueError, match='must be one of'):
         datamodel.Aggregate(**params)
+
+
+def test_probabilistic_units(prob_forecasts):
+    params = prob_forecasts.to_dict()
+    assert 'constant_value_units' not in params
+    params['variable'] = 'ghi'
+    params['axis'] = 'x'
+    params['constant_values'] = [0, 1]
+
+    pfx = datamodel.ProbabilisticForecast(**params)
+    assert pfx.units == '%'
+    assert pfx.constant_value_units == 'W/m^2'
+
+    params['axis'] = 'y'
+
+    pfx = datamodel.ProbabilisticForecast(**params)
+    assert pfx.units == 'W/m^2'
+    assert pfx.constant_value_units == '%'
+
+
+def test_probabilistic_single_units(prob_forecast_constant_value):
+    params = prob_forecast_constant_value.to_dict()
+    assert 'constant_value_units' not in params
+    params['variable'] = 'ghi'
+    params['axis'] = 'x'
+
+    pfx = datamodel.ProbabilisticForecastConstantValue(**params)
+    assert pfx.units == '%'
+    assert pfx.constant_value_units == 'W/m^2'
+
+    params['axis'] = 'y'
+
+    pfx = datamodel.ProbabilisticForecastConstantValue(**params)
+    assert pfx.units == 'W/m^2'
+    assert pfx.constant_value_units == '%'

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -1118,3 +1118,14 @@ def test_probabilistic_single_units(prob_forecast_constant_value):
     pfx = datamodel.ProbabilisticForecastConstantValue(**params)
     assert pfx.units == 'W/m^2'
     assert pfx.constant_value_units == '%'
+
+
+def test_probabilistic_units_data_object_matching(
+        prob_forecasts, single_observation):
+    params = prob_forecasts.to_dict()
+    assert 'constant_value_units' not in params
+    params['variable'] = 'ghi'
+    params['axis'] = 'x'
+
+    pfx = datamodel.ProbabilisticForecast.from_dict(params)
+    datamodel.ForecastObservation(pfx, single_observation)


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #470 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
