### PR TITLE
avoid stacking in total metric plots

### DIFF
--- a/docs/source/whatsnew/1.0.0rc4.rst
+++ b/docs/source/whatsnew/1.0.0rc4.rst
@@ -84,6 +84,8 @@ Bug fixes
   (:issue:`343`) (:pull:`594`)
 * Stop errors generated in the report process from being sent to
   sentry (:issue:`329`) (:pull:`597`)
+* Avoid stacking of forecasts errors in the Total plots in reports
+  and show the full forecast name on hover (:issue:`463`) (:pull:`599`)
 
 
 Contributors

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -835,7 +835,10 @@ def bar(df, metric):
     data = df[(df['category'] == 'total') & (df['metric'] == metric)]
     y_range = None
     x_axis_kwargs = {}
-    x_values = data['abbrev'].str.cat(['\0' * i for i in data.index])
+    x_values = []
+    for val, ser in data[['abbrev']].groupby('abbrev'):
+        x_values += [val + ('\0' * i) for i in range(len(ser))]
+    x_values = pd.Series(x_values, name='abbrev')
     palette = cycle(PALETTE)
     palette = [next(palette) for _ in x_values]
     metric_name = datamodel.ALLOWED_METRICS[metric]

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -836,6 +836,8 @@ def bar(df, metric):
     y_range = None
     x_axis_kwargs = {}
     x_values = []
+    # to avoid stacking, add null characters to fx with 
+    # same abbreviated name. GH463
     for val, ser in data[['abbrev']].groupby('abbrev'):
         x_values += [val + ('\0' * i) for i in range(len(ser))]
     x_values = pd.Series(x_values, name='abbrev')
@@ -846,6 +848,7 @@ def bar(df, metric):
     # remove height limit when long abbreviations are used or there are more
     # than 5 pairs to problems with labels being cut off.
     plot_layout_args = deepcopy(PLOT_LAYOUT_DEFAULTS)
+    # ok to cut off null characters at the end of the labels
     longest_x_label = x_values.map(lambda x: len(x.rstrip('\0'))).max()
     if longest_x_label > 15 or x_values.size > 6:
         # Set explicit height and set automargin on x axis to allow for dynamic

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -836,7 +836,7 @@ def bar(df, metric):
     y_range = None
     x_axis_kwargs = {}
     x_values = []
-    # to avoid stacking, add null characters to fx with 
+    # to avoid stacking, add null characters to fx with
     # same abbreviated name. GH463
     for val, ser in data[['abbrev']].groupby('abbrev'):
         x_values += [val + ('\0' * i) for i in range(len(ser))]


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #463  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
 
And make hover on total plots show the full name