### PR TITLE
break up large requests

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -465,6 +465,7 @@ for observations, forecasts, aggregates, and probabilistic forecasts:
    :toctree: generated/
 
    io.api.APISession.get_values
+   io.api.APISession.chunk_value_request
 
 Utils
 -----

--- a/docs/source/whatsnew/1.0.0rc4.rst
+++ b/docs/source/whatsnew/1.0.0rc4.rst
@@ -55,6 +55,8 @@ Enhancements
   (:issue:`470`) (:pull:`598`)
 * Enable downloading the forecast/observation metadata and the resampled
   timeseries from a HTML report (:issue:`354`) (:pull:`601`)
+* Add :py:meth:`io.api.APISession.chunk_value_requests` for requesting large
+  amounts of data. (:issue:`573`)(:pull:`600`)
 
 
 Bug fixes

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -639,7 +639,7 @@ class APISession(requests.Session):
         ValueError
             If start or end cannot be converted into a Pandas Timestamp
         """
-        out = self._get_values(
+        out = self.chunk_value_requests(
             f'/observations/{observation_id}/values',
             start,
             end,
@@ -703,7 +703,7 @@ class APISession(requests.Session):
         ValueError
             If start or end cannot be converted into a Pandas Timestamp
         """
-        out = self._get_values(
+        out = self.chunk_value_requests(
             f'/forecasts/single/{forecast_id}/values',
             start,
             end,
@@ -770,7 +770,7 @@ class APISession(requests.Session):
         ValueError
             If start or end cannot be converted into a Pandas Timestamp
         """
-        out = self._get_values(
+        out = self.chunk_value_requests(
             f'/forecasts/cdf/single/{forecast_id}/values',
             start,
             end,
@@ -1248,7 +1248,7 @@ class APISession(requests.Session):
         ValueError
             If start or end cannot be converted into a Pandas Timestamp
         """
-        out = self._get_values(
+        out = self.chunk_value_requests(
             f'/aggregates/{aggregate_id}/values',
             start,
             end,
@@ -1338,7 +1338,7 @@ class APISession(requests.Session):
         else:
             raise ValueError('Invalid forecast type.')
 
-    def _get_values(
+    def chunk_value_requests(
             self, api_path, start, end, parse_fn, params={},
             request_limit=GET_VALUES_LIMIT):
         """Breaks up a get requests for values into multiple requests limited
@@ -1369,7 +1369,7 @@ class APISession(requests.Session):
             # needing to sort the result.
             request_start = end - pd.Timedelta(request_limit)
             data_objects.append(
-                self._get_values(
+                self.chunk_value_requests(
                     api_path,
                     start,
                     request_start,

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -1620,3 +1620,17 @@ def test_api_session_forecast_get_by_type_invalid_type():
     test_session = api.APISession('token')
     with pytest.raises(ValueError):
         test_session._forecast_get_by_type('bad_type')
+
+
+def test_apisession__get_values(requests_mock, empty_df):
+    session = api.APISession('')
+    matcher = re.compile(
+        f'{session.base_url}/observations/.*/values')
+    requests_mock.register_uri('GET', matcher, content=b'{"values":[]}')
+    out = session._get_values(
+        '/observations/obsid/values',
+        pd.Timestamp('2017-01-01T12:00:00-0700'),
+        pd.Timestamp('2020-01-01T12:25:00-0700'),
+        utils.json_payload_to_observation_df,
+    )
+    pdt.assert_frame_equal(out, empty_df)

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -1640,7 +1640,7 @@ def value_callback(include_qf=False, freq='1H'):
     return fn
 
 
-def test_apisession__get_values_obs_data(requests_mock):
+def test_apisession_chunk_value_requests(requests_mock):
     session = api.APISession('')
     callback = value_callback(True)
     start = pd.Timestamp('2017-01-01T12:00:00-0700')
@@ -1652,7 +1652,7 @@ def test_apisession__get_values_obs_data(requests_mock):
     matcher = re.compile(
         f'{session.base_url}/observations/.*/values')
     requests_mock.register_uri('GET', matcher, content=callback)
-    out = session._get_values(
+    out = session.chunk_value_requests(
         '/observations/obsid/values',
         start,
         end,
@@ -1661,7 +1661,7 @@ def test_apisession__get_values_obs_data(requests_mock):
     pdt.assert_frame_equal(out, expected.tz_convert('UTC'))
 
 
-def test_apisession__get_values_fx_data(requests_mock):
+def test_apisession_chunk_value_requests(requests_mock):
     session = api.APISession('')
     callback = value_callback(True)
     start = pd.Timestamp('2017-01-01T12:00:00-0700')
@@ -1674,7 +1674,7 @@ def test_apisession__get_values_fx_data(requests_mock):
     matcher = re.compile(
         f'{session.base_url}/forecasts/.*/values')
     requests_mock.register_uri('GET', matcher, content=callback)
-    out = session._get_values(
+    out = session.chunk_value_requests(
         '/forecasts/single/fxid/values',
         start,
         end,
@@ -1687,12 +1687,13 @@ def test_apisession__get_values_fx_data(requests_mock):
     '180D',
     '90D',
 ])
-def test_apisession__get_values_recursion(mocker, requests_mock, limit):
+def test_apisession_chunk_value_requests_recursion(
+        mocker, requests_mock, limit):
     session = api.APISession('')
     mocked_get = mocker.patch.object(
         session,
-        '_get_values',
-        side_effect=session._get_values
+        'chunk_value_requests',
+        side_effect=session.chunk_value_requests
     )
     callback = value_callback(True)
     start = pd.Timestamp('2017-01-01T12:00:00-0700')
@@ -1700,7 +1701,7 @@ def test_apisession__get_values_recursion(mocker, requests_mock, limit):
     matcher = re.compile(
         f'{session.base_url}/forecasts/.*/values')
     requests_mock.register_uri('GET', matcher, content=callback)
-    session._get_values(
+    session.chunk_value_requests(
         '/forecasts/single/fxid/values',
         start,
         end,

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -1640,7 +1640,7 @@ def value_callback(include_qf=False, freq='1H'):
     return fn
 
 
-def test_apisession_chunk_value_requests(requests_mock):
+def test_apisession_chunk_value_requests_obs_df(requests_mock):
     session = api.APISession('')
     callback = value_callback(True)
     start = pd.Timestamp('2017-01-01T12:00:00-0700')
@@ -1661,7 +1661,7 @@ def test_apisession_chunk_value_requests(requests_mock):
     pdt.assert_frame_equal(out, expected.tz_convert('UTC'))
 
 
-def test_apisession_chunk_value_requests(requests_mock):
+def test_apisession_chunk_value_requests_fx_series(requests_mock):
     session = api.APISession('')
     callback = value_callback(True)
     start = pd.Timestamp('2017-01-01T12:00:00-0700')

--- a/solarforecastarbiter/reports/tests/test_reports_main.py
+++ b/solarforecastarbiter/reports/tests/test_reports_main.py
@@ -45,7 +45,7 @@ def _test_data(report_objects, ref_forecast_id, remove_orca):
 
 @pytest.fixture()
 def mock_data(mocker, _test_data):
-    def get_data(id_, start, end, interval_label=None):
+    def get_data(id_, start, end, interval_label=None, **kwargs):
         return _test_data[id_].loc[start:end]
 
     get_forecast_values = mocker.patch(
@@ -110,7 +110,7 @@ def _test_event_data(event_report_objects, remove_orca):
 
 @pytest.fixture()
 def mock_event_data(mocker, _test_event_data):
-    def get_data(id_, start, end, interval_label=None):
+    def get_data(id_, start, end, interval_label=None, **kwargs):
         return _test_event_data[id_].loc[start:end]
 
     get_forecast_values = mocker.patch(


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #573  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Initial implementation of breaking large requests into individual requests to avoid timeouts/hitting api limits. @alorenzo175 what do you think of this approach? I've only adjusted `get_observation_values`