### PR TITLE
metrics: add CRPSS

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -580,6 +580,7 @@ Functions to compute forecast probabilistic performance metrics:
     metrics.probabilistic.uncertainty
     metrics.probabilistic.sharpness
     metrics.probabilistic.continuous_ranked_probability_score
+    metrics.probabilistic.crps_skill_score
 
 Event
 -----

--- a/docs/source/whatsnew/1.0.0rc4.rst
+++ b/docs/source/whatsnew/1.0.0rc4.rst
@@ -36,6 +36,8 @@ API Changes
   from the BSRN network (:issue:`541`) (:pull:`604`)
 * Removed ``preprocessing.VALIDATION_RESULT_TOTAL_STRING`` and
   ``preprocessing.UNDEFINED_DATA_STRING``.
+* Added CRPS skill score metric :py:func:`metrics.probabilistic.crps_skill_score`
+  (:issue:`494`) (:pull:`605`)
 
 
 Enhancements

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -529,6 +529,47 @@ def continuous_ranked_probability_score(obs, fx, fx_prob):
     return crps
 
 
+def crps_skill_score(obs, fx, fx_prob, ref, ref_prob):
+    """CRPS skill score.
+
+        CRPSS = 1 - CRPS_fx / CRPS_ref
+
+    where CRPS_fx is the CPRS of the evaluated forecast and CRPS_ref is the
+    CRPS of a reference forecast.
+
+    Parameters
+    ----------
+    obs : (n,) array_like
+        Observations (physical unit).
+    fx : (n, d) array_like
+        Forecasts (physical units) of the right-hand-side of a CDF with d
+        intervals (d >= 2), e.g., fx = [10 MW, 20 MW, 30 MW] is interpreted as
+        <= 10 MW, <= 20 MW, <= 30 MW.
+    fx_prob : (n,) array_like
+        Probability [%] associated with the forecasts.
+    ref : (n, d) array_like
+        Reference forecasts (physical units) of the right-hand-side of a CDF
+        with d intervals (d >= 2), e.g., fx = [10 MW, 20 MW, 30 MW] is
+        interpreted as <= 10 MW, <= 20 MW, <= 30 MW.
+    ref_prob : (n,) array_like
+        Probability [%] associated with the reference forecast.
+
+    Returns
+    -------
+    skill : float
+        The CRPS skill score [unitless].
+
+    See Also
+    --------
+    :py:func:`solarforecastarbiter.metrics.probabilistic.continuous_ranked_probability_score`
+
+    """
+
+    crps_fx = continuous_ranked_probability_score(obs, fx, fx_prob)
+    crps_ref = continuous_ranked_probability_score(obs, ref, ref_prob)
+    return 1 - crps_fx / crps_ref
+
+
 # Add new metrics to this map to map shorthand to function
 _MAP = {
     'bs': (brier_score, 'BS'),
@@ -540,18 +581,19 @@ _MAP = {
     'qss': (quantile_skill_score, 'QSS'),
     # 'sh': (sharpness, 'SH'),  # TODO
     'crps': (continuous_ranked_probability_score, 'CRPS'),
+    'crpss': (crps_skill_score, 'CRPSS'),
 }
 
 __all__ = [m[0].__name__ for m in _MAP.values()]
 
 # Functions that require a reference forecast
-_REQ_REF_FX = ['bss', 'qss']
+_REQ_REF_FX = ['bss', 'qss', 'crpss']
 
 # Functions that require normalized factor
 _REQ_NORM = []
 
 # Functions that require full distribution forecasts (as 2dim)
-_REQ_DIST = ['crps']
+_REQ_DIST = ['crps', 'crpss']
 
 # TODO: Functions that require two forecasts (e.g., sharpness)
 # _REQ_FX_FX = ['sh']

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -583,10 +583,16 @@ def crps_skill_score(obs, fx, fx_prob, ref, ref_prob):
     if np.isscalar(ref):
         return np.nan
     else:
-        print("Valid ref:", ref, type(ref))
         crps_fx = continuous_ranked_probability_score(obs, fx, fx_prob)
         crps_ref = continuous_ranked_probability_score(obs, ref, ref_prob)
-        return 1 - crps_fx / crps_ref
+
+        if crps_fx == crps_ref:
+            return 0.0
+        elif crps_ref == 0.0:
+            # avoid divide by zero
+            return np.NINF
+        else:
+            return 1 - crps_fx / crps_ref
 
 
 # Add new metrics to this map to map shorthand to function

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -522,16 +522,14 @@ def continuous_ranked_probability_score(obs, fx, fx_prob):
     """
 
     # match observations to fx shape: (n,) => (n, d)
-    try:
-        n, d = np.shape(fx)   # throws ValueError if 1D array
-        if d < 2:
-            raise ValueError("forecasts must have d >= 2 CDF intervals "
-                             f"(expected >= 2, got {d})")
-        else:
-            obs = np.tile(obs, (fx.shape[1], 1)).T
-    except ValueError:
+    if np.ndim(fx) < 2:
         raise ValueError("forecasts must be 2D arrays (expected (n,d), got"
                          f"{np.shape(fx)})")
+    elif np.shape(fx)[1] < 2:
+        raise ValueError("forecasts must have d >= 2 CDF intervals "
+                         f"(expected >= 2, got {np.shape(fx)[1]})")
+    else:
+        obs = np.tile(obs, (fx.shape[1], 1)).T
 
     # event: 0=did not happen, 1=did happen
     o = np.where(obs <= fx, 1.0, 0.0)
@@ -582,9 +580,13 @@ def crps_skill_score(obs, fx, fx_prob, ref, ref_prob):
 
     """
 
-    crps_fx = continuous_ranked_probability_score(obs, fx, fx_prob)
-    crps_ref = continuous_ranked_probability_score(obs, ref, ref_prob)
-    return 1 - crps_fx / crps_ref
+    if np.isscalar(ref):
+        return np.nan
+    else:
+        print("Valid ref:", ref, type(ref))
+        crps_fx = continuous_ranked_probability_score(obs, fx, fx_prob)
+        crps_ref = continuous_ranked_probability_score(obs, ref, ref_prob)
+        return 1 - crps_fx / crps_ref
 
 
 # Add new metrics to this map to map shorthand to function

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -303,10 +303,9 @@ def test_calculate_metrics_with_probablistic(single_observation,
                                           PROB_NO_REF)
     assert len(result) == 1
     assert isinstance(result[0], datamodel.MetricResult)
-    verify_metric_result(result[0],
-                         proc_prfx_obs,
-                         LIST_OF_CATEGORIES,
-                         set(probabilistic._REQ_DIST) - set(probabilistic._REQ_REF_FX))
+    verify_metric_result(
+        result[0], proc_prfx_obs, LIST_OF_CATEGORIES,
+        set(probabilistic._REQ_DIST) - set(probabilistic._REQ_REF_FX))
 
     # With reference
     ref_fx_values = fx_values + .5
@@ -384,9 +383,10 @@ def test_calculate_metrics_with_probablistic(single_observation,
 
     # Distribution and constant values
     all_results = calculator.calculate_metrics(
-        [proc_prfx_obs] + cv_proc_ref_prfx_obs, LIST_OF_CATEGORIES,
+        [proc_ref_prfx_obs] + cv_proc_ref_prfx_obs, LIST_OF_CATEGORIES,
         # reverse to ensure order output is independent
         PROBABILISTIC_METRICS[::-1])
+
     assert all_results[0] == dist_results[0]
     assert len(all_results[1:]) == len(cv_results)
     for a, b in zip(all_results[1:], cv_results):
@@ -589,7 +589,8 @@ def test_calculate_probabilistic_metrics_missing_ref(
         pd.DataFrame(np.random.randn(10, 3), index=create_dt_index(10)),
         pd.Series(np.random.randn(10), index=create_dt_index(10)))
     result = calculator.calculate_probabilistic_metrics(
-            proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX
+            proc_fxobs, LIST_OF_CATEGORIES,
+            set(probabilistic._REQ_REF_FX) - set(probabilistic._REQ_DIST)
         )
     assert isinstance(result, datamodel.MetricResult)
     assert result.values == ()
@@ -606,7 +607,8 @@ def test_calculate_probabilistic_metrics_no_reference_data(
         pd.Series(np.random.randn(10), index=create_dt_index(10)),
         ref_values=None)
     result = calculator.calculate_probabilistic_metrics(
-            proc_fxobs, LIST_OF_CATEGORIES, probabilistic._REQ_REF_FX
+            proc_fxobs, LIST_OF_CATEGORIES,
+            set(probabilistic._REQ_REF_FX) - set(probabilistic._REQ_DIST)
         )
     assert isinstance(result, datamodel.MetricResult)
     assert result.values == ()
@@ -955,7 +957,7 @@ def test_apply_deterministic_bad_metric_func():
     ('unc', [1, 1, 1], [100, 100, 100], [1, 1, 1], None, None, 0.),
 
     # CRPS single forecast
-    ('crps', [[1]], [[100]], [[0]], None, None, 0.),
+    ('crps', [[1, 1]], [[100, 100]], [[0, 0]], None, None, 0.),
     # CRPS mulitple forecasts
     ('crps', [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
              [[100, 100, 100], [100, 100, 100], [100, 100, 100]],

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -306,7 +306,7 @@ def test_calculate_metrics_with_probablistic(single_observation,
     verify_metric_result(result[0],
                          proc_prfx_obs,
                          LIST_OF_CATEGORIES,
-                         probabilistic._REQ_DIST)
+                         set(probabilistic._REQ_DIST) - set(probabilistic._REQ_REF_FX))
 
     # With reference
     ref_fx_values = fx_values + .5
@@ -336,11 +336,11 @@ def test_calculate_metrics_with_probablistic(single_observation,
 
     expected = {
         0: ('total', 'crps', '0', 17.247),
-        1: ('year', 'crps', '2019', 17.247),
-        2: ('season', 'crps', 'JJA', 17.247),
-        3: ('month', 'crps', 'Aug', 17.247),
-        4: ('hour', 'crps', '0', 19.801000000000002),
-        5: ('hour', 'crps', '1', 19.405)
+        2: ('year', 'crps', '2019', 17.247),
+        4: ('season', 'crps', 'JJA', 17.247),
+        6: ('month', 'crps', 'Aug', 17.247),
+        8: ('hour', 'crps', '0', 19.801000000000002),
+        9: ('hour', 'crps', '1', 19.405)
     }
     attr_order = ('category', 'metric', 'index', 'value')
     for k, expected_attrs in expected.items():

--- a/solarforecastarbiter/metrics/tests/test_probabilistic.py
+++ b/solarforecastarbiter/metrics/tests/test_probabilistic.py
@@ -292,22 +292,21 @@ def test_crps(fx, fx_prob, obs, value):
 @pytest.mark.parametrize("fx,fx_prob,ref,ref_prob,obs,value", [
     # 2 samples, 3 CDF intervals
     (
-        np.array([[10, 20, 30], [10, 20, 30]]),   # fx
-        np.array([[0, 100, 100], [0, 100, 100]]), # fx_prob
-        np.array([[10, 20, 30], [10, 20, 30]]),   # ref
-        np.array([[0, 0, 100], [0, 0, 100]]),     # ref_prob
-        np.array([8, 8]),                         # obs
+        np.array([[10, 20, 30], [10, 20, 30]]),    # fx
+        np.array([[0, 100, 100], [0, 100, 100]]),  # fx_prob
+        np.array([[10, 20, 30], [10, 20, 30]]),    # ref
+        np.array([[0, 0, 100], [0, 0, 100]]),      # ref_prob
+        np.array([8, 8]),                          # obs
         1 - 10 / 20,
     ),
     (
-        np.array([[10, 20, 30], [10, 20, 30]]),   # fx
-        np.array([[0, 0, 100], [0, 0, 100]]),     # fx_prob
-        np.array([[10, 20, 30], [10, 20, 30]]),   # ref
-        np.array([[0, 100, 100], [0, 100, 100]]), # ref_prob
-        np.array([8, 8]),                         # obs
+        np.array([[10, 20, 30], [10, 20, 30]]),    # fx
+        np.array([[0, 0, 100], [0, 0, 100]]),      # fx_prob
+        np.array([[10, 20, 30], [10, 20, 30]]),    # ref
+        np.array([[0, 100, 100], [0, 100, 100]]),  # ref_prob
+        np.array([8, 8]),                          # obs
         1 - 20 / 10,
     ),
-
 ])
 def test_crps_skill_score(obs, fx, fx_prob, ref, ref_prob, value):
     crpss = prob.crps_skill_score(obs, fx, fx_prob, ref, ref_prob)

--- a/solarforecastarbiter/metrics/tests/test_probabilistic.py
+++ b/solarforecastarbiter/metrics/tests/test_probabilistic.py
@@ -299,6 +299,15 @@ def test_crps(fx, fx_prob, obs, value):
         np.array([8, 8]),                         # obs
         1 - 10 / 20,
     ),
+    (
+        np.array([[10, 20, 30], [10, 20, 30]]),   # fx
+        np.array([[0, 0, 100], [0, 0, 100]]),     # fx_prob
+        np.array([[10, 20, 30], [10, 20, 30]]),   # ref
+        np.array([[0, 100, 100], [0, 100, 100]]), # ref_prob
+        np.array([8, 8]),                         # obs
+        1 - 20 / 10,
+    ),
+
 ])
 def test_crps_skill_score(obs, fx, fx_prob, ref, ref_prob, value):
     crpss = prob.crps_skill_score(obs, fx, fx_prob, ref, ref_prob)

--- a/solarforecastarbiter/metrics/tests/test_probabilistic.py
+++ b/solarforecastarbiter/metrics/tests/test_probabilistic.py
@@ -287,3 +287,19 @@ def test_sharpness(fx_lower, fx_upper, value):
 def test_crps(fx, fx_prob, obs, value):
     crps = prob.continuous_ranked_probability_score(obs, fx, fx_prob)
     assert crps == value
+
+
+@pytest.mark.parametrize("fx,fx_prob,ref,ref_prob,obs,value", [
+    # 2 samples, 3 CDF intervals
+    (
+        np.array([[10, 20, 30], [10, 20, 30]]),   # fx
+        np.array([[0, 100, 100], [0, 100, 100]]), # fx_prob
+        np.array([[10, 20, 30], [10, 20, 30]]),   # ref
+        np.array([[0, 0, 100], [0, 0, 100]]),     # ref_prob
+        np.array([8, 8]),                         # obs
+        1 - 10 / 20,
+    ),
+])
+def test_crps_skill_score(obs, fx, fx_prob, ref, ref_prob, value):
+    crpss = prob.crps_skill_score(obs, fx, fx_prob, ref, ref_prob)
+    assert crpss == value

--- a/solarforecastarbiter/metrics/tests/test_probabilistic.py
+++ b/solarforecastarbiter/metrics/tests/test_probabilistic.py
@@ -325,6 +325,32 @@ def test_crps(fx, fx_prob, obs, value):
         np.array([8, 8]),                          # obs
         1 - 20 / 10,
     ),
+    (
+        np.array([[10, 20, 30], [10, 20, 30]]),    # fx
+        np.array([[0, 100, 100], [0, 100, 100]]),  # fx_prob
+        np.array([[10, 20, 30], [10, 20, 30]]),    # ref
+        np.array([[0, 100, 100], [0, 100, 100]]),  # ref_prob
+        np.array([8, 8]),                          # obs
+        0.0
+    ),
+    (
+        np.array([[10, 20, 30], [10, 20, 30]]),    # fx
+        np.array([[0, 100, 100], [0, 100, 100]]),  # fx_prob
+        np.array([[10, 20, 30], [10, 20, 30]]),    # ref
+        np.array([[0, 100, 100], [0, 100, 100]]),  # ref_prob
+        np.array([8, 8]),                          # obs
+        0.0
+    ),
+
+    # 2 samples, 2 CDF intervals
+    (
+        np.array([[10, 20], [10, 20]]),      # fx
+        np.array([[0, 100], [0, 100]]),      # fx_prob
+        np.array([[10, 20], [10, 20]]),      # ref
+        np.array([[100, 100], [100, 100]]),  # ref_prob
+        np.array([8, 8]),                    # obs
+        np.NINF,
+    ),
 ])
 def test_crps_skill_score(obs, fx, fx_prob, ref, ref_prob, value):
     crpss = prob.crps_skill_score(obs, fx, fx_prob, ref, ref_prob)

--- a/solarforecastarbiter/metrics/tests/test_probabilistic.py
+++ b/solarforecastarbiter/metrics/tests/test_probabilistic.py
@@ -218,10 +218,10 @@ def test_sharpness(fx_lower, fx_upper, value):
 
 
 @pytest.mark.parametrize("fx,fx_prob,obs,value", [
-    # 1 sample, 1 CDF interval
+    # 1 sample, 2 CDF intervals
     (
-        np.array([[10]]),
-        np.array([[100]]),
+        np.array([[10, 20]]),
+        np.array([[100, 100]]),
         np.array([8]),
         0.0,
     ),
@@ -282,6 +282,24 @@ def test_sharpness(fx_lower, fx_upper, value):
         np.array([[0, 50, 100], [0, 50, 100]]),
         np.array([8, 8]),
         (1.0 ** 2) * 10 + (0.5 ** 2) * 10,
+    ),
+
+    # fail: only 1 CDF interval
+    pytest.param(
+        np.array([[10], [20]]),
+        np.array([[100], [100]]),
+        np.array([8, 8]),
+        0.0,
+        marks=pytest.mark.xfail(strict=True, type=ValueError),
+    ),
+
+    # fail: forecast as 1D array (instead of 2D)
+    pytest.param(
+        np.array([10, 20]),
+        np.array([100, 100]),
+        np.array([8, 8]),
+        0.0,
+        marks=pytest.mark.xfail(strict=True, type=ValueError),
     ),
 ])
 def test_crps(fx, fx_prob, obs, value):


### PR DESCRIPTION
  - [x] Closes #494 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Add skill score version of the CRPS metric, which shows the relative improvement (in terms of CRPS) between a forecast versus a reference forecast.
