### PR TITLE
metrics: test unequal dist for CRPSS

### DIFF
--- a/solarforecastarbiter/metrics/tests/test_probabilistic.py
+++ b/solarforecastarbiter/metrics/tests/test_probabilistic.py
@@ -351,6 +351,26 @@ def test_crps(fx, fx_prob, obs, value):
         np.array([8, 8]),                    # obs
         np.NINF,
     ),
+
+    # 2 CDF intervals but not the same intervals between fx and ref
+    (
+        np.array([[10, 20], [10, 20]]),
+        np.array([[0, 100], [0, 100]]),
+        np.array([[10, 20], [10, 20]]),
+        np.array([[50, 100], [30, 100]]),
+        np.array([8, 8]),
+        1 - 10 / (((0.5 ** 2) * 10 + (0.7 ** 2) * 10) / 2),
+    ),
+
+    # ref and fx have different number of CDF intervals
+    (
+        np.array([[10, 20], [10, 20]]),
+        np.array([[0, 100], [0, 100]]),
+        np.array([[10, 20, 30], [10, 20, 30]]),
+        np.array([[0, 0, 100], [0, 0, 100]]),
+        np.array([8, 8]),
+        1 - 10 / 20,
+    ),
 ])
 def test_crps_skill_score(obs, fx, fx_prob, ref, ref_prob, value):
     crpss = prob.crps_skill_score(obs, fx, fx_prob, ref, ref_prob)


### PR DESCRIPTION
  - [ ] Closes #xxxx .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This PR is in response to discussion in PR #605:

Add tests for the situation in which the forecast (fx) and reference forecasts (ref) have unequal distribution, either a) the same number of CDF intervals but not the same intervals (e.g. [25, 75] and [50, 100]) or b) a different number of CDF intervals (e.g. [25, 50, 75] and [0, 20, 40, 60, 80, 100]). In these two cases, the expected behavior (currently) is that the CRPS is calculated for both the fx and ref, and then the CRPSS is calculated without any adjustments.
