### PR TITLE
make sure hijacking loggers also captures children

### DIFF
--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -752,7 +752,7 @@ def process_forecast_observations(forecast_observations, filters,
         total_discard_before_resample = _search_validation_results(
             val_results, 'TOTAL DISCARD BEFORE RESAMPLE')
         if total_discard_before_resample is None:
-            logging.warning(
+            logger.warning(
                 'TOTAL DISCARD BEFORE RESAMPLE not available for pair '
                 '(%s, %s)', fxobs.forecast.name, fxobs.data_object.name)
         else:
@@ -763,7 +763,7 @@ def process_forecast_observations(forecast_observations, filters,
         total_discard_after_resample = _search_validation_results(
             val_results, 'TOTAL DISCARD AFTER RESAMPLE')
         if total_discard_after_resample is None:
-            logging.warning(
+            logger.warning(
                 'TOTAL DISCARD AFTER RESAMPLE not available for pair (%s, %s)',
                 fxobs.forecast.name, fxobs.data_object.name)
         else:

--- a/solarforecastarbiter/reports/tests/test_reports_main.py
+++ b/solarforecastarbiter/reports/tests/test_reports_main.py
@@ -172,7 +172,8 @@ def test_create_raw_report_from_data(mocker, report_objects, _test_data):
     assert len(raw.plots.figures) > 0
 
 
-def test_create_raw_report_from_data_no_fx(mocker, report_objects, _test_data):
+def test_create_raw_report_from_data_no_fx(mocker, report_objects, _test_data,
+                                           caplog):
     report = report_objects[0]
     data = {}
     for fxobs in report.report_parameters.object_pairs:
@@ -189,10 +190,11 @@ def test_create_raw_report_from_data_no_fx(mocker, report_objects, _test_data):
     raw = main.create_raw_report_from_data(report, data)
     assert isinstance(raw, datamodel.RawReport)
     assert len(raw.plots.figures) > 0
+    assert len(caplog.records) == 0
 
 
 def test_create_raw_report_from_data_no_obs(mocker, report_objects,
-                                            _test_data):
+                                            _test_data, caplog):
     report = report_objects[0]
     data = {}
     for fxobs in report.report_parameters.object_pairs:
@@ -205,9 +207,10 @@ def test_create_raw_report_from_data_no_obs(mocker, report_objects,
     raw = main.create_raw_report_from_data(report, data)
     assert isinstance(raw, datamodel.RawReport)
     assert len(raw.plots.figures) > 0
+    assert len(caplog.records) == 0
 
 
-def test_create_raw_report_from_data_no_data(mocker, report_objects):
+def test_create_raw_report_from_data_no_data(mocker, report_objects, caplog):
     report = report_objects[0]
     data = {}
     for fxobs in report.report_parameters.object_pairs:
@@ -218,6 +221,7 @@ def test_create_raw_report_from_data_no_data(mocker, report_objects):
     raw = main.create_raw_report_from_data(report, data)
     assert isinstance(raw, datamodel.RawReport)
     assert len(raw.plots.figures) > 0
+    assert len(caplog.records) == 0
 
 
 def test_create_raw_report_from_data_event(mocker, event_report_objects,

--- a/solarforecastarbiter/tests/test_utils.py
+++ b/solarforecastarbiter/tests/test_utils.py
@@ -514,13 +514,16 @@ def test_hijack_loggers_sentry(mocker):
         before_send=before_send)
     logger = logging.getLogger('testlog')
     child = logging.getLogger('testlog.child')
+    notchild = logging.getLogger('testloggggger')
     with utils.hijack_loggers(['testlog']):
         logging.getLogger('root').error('will show up')
         logger.error('AHHH')
         child.error('Im a baby gotta love me')
+        notchild.error('pfft')
     assert 'root' in events
     assert 'testlog' not in events
     assert 'testlog.child' not in events
+    assert 'testloggggger' in events
 
     events = set()
     logging.getLogger('root').error('will show up')

--- a/solarforecastarbiter/tests/test_utils.py
+++ b/solarforecastarbiter/tests/test_utils.py
@@ -513,17 +513,24 @@ def test_hijack_loggers_sentry(mocker):
         "https://examplePublicKey@o0.ingest.sentry.io/0",
         before_send=before_send)
     logger = logging.getLogger('testlog')
+    child = logging.getLogger('testlog.child')
     with utils.hijack_loggers(['testlog']):
         logging.getLogger('root').error('will show up')
         logger.error('AHHH')
+        child.error('Im a baby gotta love me')
     assert 'root' in events
     assert 'testlog' not in events
+    assert 'testlog.child' not in events
 
     events = set()
     logging.getLogger('root').error('will show up')
     logger.error('AHHH')
+    child.error('c')
     assert 'root' in events
     assert 'testlog' in events
+    assert 'testlog.child' in events
+    assert logger.propagate
+    assert child.propagate
 
 
 @pytest.mark.parametrize('data,freq,expected', [

--- a/solarforecastarbiter/utils.py
+++ b/solarforecastarbiter/utils.py
@@ -239,7 +239,7 @@ class ListHandler(logging.Handler):
 
 def _get_children(name):
     return {k for k in logging.getLogger(name).manager.loggerDict.keys()
-            if k.startswith(name)}
+            if k.startswith(name + '.')}
 
 
 @contextmanager

--- a/solarforecastarbiter/utils.py
+++ b/solarforecastarbiter/utils.py
@@ -237,6 +237,11 @@ class ListHandler(logging.Handler):
         return tuple(out)
 
 
+def _get_children(name):
+    return {k for k in logging.getLogger(name).manager.loggerDict.keys()
+            if k.startswith(name)}
+
+
 @contextmanager
 def hijack_loggers(loggers, level=logging.INFO):
     """
@@ -245,7 +250,7 @@ def hijack_loggers(loggers, level=logging.INFO):
 
     Parameters
     ----------
-    loggers: list of str or logging.Logger
+    loggers: list of str
         Loggers to change
     level: logging LEVEL int
         Level to set the temporary handler to
@@ -264,16 +269,24 @@ def hijack_loggers(loggers, level=logging.INFO):
     handler = ListHandler()
     handler.setLevel(level)
 
-    old_handlers = {}
+    all_loggers = set()
     for name in loggers:
+        all_loggers.add(name)
+        all_loggers |= _get_children(name)
+
+    logger_info = {}
+    for name in all_loggers:
         logger = logging.getLogger(name)
-        old_handlers[name] = logger.handlers
+        logger_info[name] = (logger.handlers, logger.propagate)
         logger.handlers = [handler]
         sentry_logging.ignore_logger(name)
+        logger.propagate = False
     yield handler
-    for name in loggers:
+    for name in all_loggers:
         logger = logging.getLogger(name)
-        logger.handlers = old_handlers[name]
+        hnd, prop = logger_info[name]
+        logger.handlers = hnd
+        logger.propagate = prop
         try:
             sentry_logging._IGNORED_LOGGERS.remove(name)
         except Exception:


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [ ] Closes #xxxx .
  - [ ] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

#597 didn't fully capture children loggers to prevent messages from getting to sentry