### PR TITLE
fix issue with prob fx label

### DIFF
--- a/docs/source/whatsnew/1.0.0.rst
+++ b/docs/source/whatsnew/1.0.0.rst
@@ -1,4 +1,4 @@
-.. _whatsnew_100rc4:
+.. _whatsnew_100:
 
 .. py:currentmodule:: solarforecastarbiter
 

--- a/docs/source/whatsnew/1.0.0.rst
+++ b/docs/source/whatsnew/1.0.0.rst
@@ -1,0 +1,25 @@
+.. _whatsnew_100rc4:
+
+.. py:currentmodule:: solarforecastarbiter
+
+1.0.0 (November ??, 2020)
+-------------------------
+
+
+Bug fixes
+~~~~~~~~~
+* Fix labeling of probabilistic forecasts of thresholds (``axis='x'``).
+  (:issue:`611`, :pull:`612`)
+
+
+Contributors
+~~~~~~~~~~~~
+
+* Will Holmgren (:ghuser:`wholmgren`)
+* Leland Boeman (:ghuser:`lboeman`)
+* Cliff Hansen (:ghuser:`cwhanse`)
+* Tony Lorenzo (:ghuser:`alorenzo175`)
+* Justin Sharp (:ghuser:`MrWindAndSolar`)
+* Aidan Tuohy
+* Adam Wigington (:ghuser:`awig`)
+* David Larson (:ghuser:`dplarson`)

--- a/docs/source/whatsnew/index.rst
+++ b/docs/source/whatsnew/index.rst
@@ -9,6 +9,7 @@ These are new features and improvements of note in each release.
 .. toctree::
    :maxdepth: 2
 
+   1.0.0
    1.0.0rc4
    1.0.0rc3
    1.0.0rc2

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -821,8 +821,9 @@ def _name_pfxobs(current_names, forecast, i=1):
         forecast_name = forecast.name
         if isinstance(forecast, datamodel.ProbabilisticForecastConstantValue):
             if forecast.axis == 'x':
-                forecast_name += \
-                    f' Prob(x <= {forecast.constant_value} {forecast.units})'
+                forecast_name += (
+                    f' Prob(x <= {forecast.constant_value} '
+                    f'{forecast.constant_value_units})')
             else:
                 forecast_name += f' Prob(f <= x) = {forecast.constant_value}%'
     if i > 99:

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -815,9 +815,28 @@ def process_forecast_observations(forecast_observations, filters,
 
 
 def _name_pfxobs(current_names, forecast, i=1):
+    """Create unique, descriptive name for forecast.
+
+    Users should call this function with a ``Forecast`` object. This
+    will augment the ``Forecast.name`` attribute with probabilistic
+    descriptors (if needed). The function will then inspect the list of
+    names in ``current_names``. If the name is not unique, a recursive
+    call, using a string, will allow up to 99 variants of the name.
+
+    Parameters
+    ----------
+    current_names : list of str
+    forecast : datamodel.Forecast or str
+
+    Returns
+    -------
+    str
+    """
     if isinstance(forecast, str):
+        # handle input when called recursively
         forecast_name = forecast
     else:
+        # handle initial augmentation of forecast.name
         forecast_name = forecast.name
         if isinstance(forecast, datamodel.ProbabilisticForecastConstantValue):
             if forecast.axis == 'x':

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -1110,6 +1110,24 @@ def test_name_pfxobs_recursion_limit():
     assert preprocessing._name_pfxobs(cn, name) == f'{name}-99'
 
 
+def test_name_pfxobs(
+        single_forecast, single_event_forecast, prob_forecasts,
+        prob_forecasts_y, prob_forecast_constant_value,
+        prob_forecast_constant_value_y):
+
+    name = 'whoami'
+    fxs = (
+        single_forecast, single_event_forecast, prob_forecasts,
+        prob_forecasts_y, prob_forecast_constant_value,
+        prob_forecast_constant_value_y)
+    expected = [name]*4 + [name + ' Prob(x <= 0 W/m^2)',
+                           name + ' Prob(f <= x) = 50.0%']
+    current_names = []
+    for fx, exp in zip(fxs, expected):
+        fx = fx.replace(name=name)
+        assert preprocessing._name_pfxobs(current_names, fx) == exp
+
+
 @pytest.mark.parametrize('dtype', ['int', 'bool', 'float'])
 @pytest.mark.parametrize("obs_index,fx_index,expected_dt", [
     (THREE_HOURS, THREE_HOURS, THREE_HOURS),


### PR DESCRIPTION
  - [x] Closes #611 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

I wonder if we should switch `x` to `o` (for observation) while we're at it. The metrics documentation uses `o`.

The naming function is only tested for recursion, so I didn't modify any tests. I suppose I *could* add one.