### PR TITLE
Use tojson filter to escape nested json and html

### DIFF
--- a/docs/source/whatsnew/1.0.0.rst
+++ b/docs/source/whatsnew/1.0.0.rst
@@ -20,6 +20,8 @@ Bug fixes
   (:issue:`611`, :pull:`613`)
 * Added configurable timeouts when fetching NWP forecast grids to avoid
   timeout exceptions (:issue:`130`, :pull:`614`)
+* Fixed bug causing report observation and forecast metadata download to fail.
+  (:pull:`618`)
 
 
 Contributors

--- a/solarforecastarbiter/reports/templates/html/load_metadata.html
+++ b/solarforecastarbiter/reports/templates/html/load_metadata.html
@@ -1,1 +1,1 @@
-<script>var metadata_json = JSON.parse('{{ metadata_json |safe }}');</script>
+<script>var metadata_json = JSON.parse({{ metadata_json | tojson }});</script>

--- a/solarforecastarbiter/reports/tests/test_jinja_templates.py
+++ b/solarforecastarbiter/reports/tests/test_jinja_templates.py
@@ -1,0 +1,28 @@
+import json
+from jinja2 import Environment, PackageLoader, select_autoescape
+import pytest
+
+
+from solarforecastarbiter.reports import template
+
+
+@pytest.mark.parametrize('metadata,expected', [
+    (json.dumps([{'name': 'obs', 'field': '{"field": {"inner": 1}}'}]),
+     r'"[{\"name\": \"obs\", \"field\": \"{\\\"field\\\": {\\\"inner\\\": 1}}\"}]"'),  # noqa
+    (json.dumps([{'name': 'obs', 'field': '{"field": "<div>html</div>"}'}]),
+     r'"[{\"name\": \"obs\", \"field\": \"{\\\"field\\\": \\\"\u003cdiv\u003ehtml\u003c/div\u003e\\\"}\"}]"'),  # noqa
+
+])
+def test_load_metadata(metadata, expected):
+    env = Environment(
+        loader=PackageLoader(
+            'solarforecastarbiter.reports', 'templates/html'),
+        autoescape=select_autoescape(['html', 'xml']),
+        lstrip_blocks=True,
+        trim_blocks=True
+    )
+    env.filters['unique_flags_filter'] = template._unique_flags_filter
+    html_template = env.get_template('load_metadata.html')
+    rendered = html_template.render(metadata_json=metadata)
+    ex = f"<script>var metadata_json = JSON.parse({expected});</script>"
+    assert rendered == ex


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Fixes a bug where dumped report metadata json is not correctly escaped which causes the metadata download function to fail. 