### PR TITLE
Report total metric ordering

### DIFF
--- a/docs/source/whatsnew/1.0.0.rst
+++ b/docs/source/whatsnew/1.0.0.rst
@@ -22,6 +22,8 @@ Bug fixes
   timeout exceptions (:issue:`130`, :pull:`614`)
 * Fixed bug causing report observation and forecast metadata download to fail.
   (:pull:`618`)
+* Fixed bug causing incorrect x axis labelling of report metric plots.
+  (:pull:`619`)
 
 
 Contributors

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -836,6 +836,11 @@ def bar(df, metric):
     y_range = None
     x_axis_kwargs = {}
     x_values = []
+
+    # Ensure data aligns with the x labels by pre-sorting. x_labels are sorted
+    # by the groupby process below.
+    data = data.sort_values('abbrev')
+
     # to avoid stacking, add null characters to fx with
     # same abbreviated name. GH463
     for val, ser in data[['abbrev']].groupby('abbrev'):

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -841,10 +841,10 @@ def bar(df, metric):
     # by the groupby process below.
     data = data.sort_values('abbrev')
 
-    # to avoid stacking, add null characters to fx with
+    # to avoid stacking, add BOM characters to fx with
     # same abbreviated name. GH463
     for val, ser in data[['abbrev']].groupby('abbrev'):
-        x_values += [val + ('\0' * i) for i in range(len(ser))]
+        x_values += [val + ('\ufeff' * i) for i in range(len(ser))]
     x_values = pd.Series(x_values, name='abbrev')
     palette = cycle(PALETTE)
     palette = [next(palette) for _ in x_values]
@@ -853,8 +853,8 @@ def bar(df, metric):
     # remove height limit when long abbreviations are used or there are more
     # than 5 pairs to problems with labels being cut off.
     plot_layout_args = deepcopy(PLOT_LAYOUT_DEFAULTS)
-    # ok to cut off null characters at the end of the labels
-    longest_x_label = x_values.map(lambda x: len(x.rstrip('\0'))).max()
+    # ok to cut off BOM characters at the end of the labels
+    longest_x_label = x_values.map(lambda x: len(x.rstrip('\ufeff'))).max()
     if longest_x_label > 15 or x_values.size > 6:
         # Set explicit height and set automargin on x axis to allow for dynamic
         # sizing to accomodate long x axis labels. Height is set based on

--- a/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
@@ -688,8 +688,8 @@ def test_bar_x_label_ordering():
 
     # Ensure x labels are in expected order
     assert (figure.data[0]['x'] == np.array([
-        "CA GHI", "DA GHi.", "DA GHi.\x00",
-        "DA GHi.\x00\x00", "EA GHI"], dtype=object)).all()
+        "CA GHI", "DA GHi.", "DA GHi.\ufeff",
+        "DA GHi.\ufeff\ufeff", "EA GHI"], dtype=object)).all()
     # ensure y values are in the same order as x labels
     assert (figure.data[0]['y'] == np.array([1, 3, 4, 7, 5])).all()
     # assert hover text (original name) matches x label order

--- a/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
@@ -664,3 +664,34 @@ def test_timeseries_plots_event_data_no_obs(
     assert scatter_spec is None
     assert ts_prob_spec is None
     assert not inc_dist
+
+
+def test_bar_x_label_ordering():
+    def make_row(name, abbrev, value):
+        return {
+            "name": name,
+            "abbrev": abbrev,
+            "category": "total",
+            "metric": "mae",
+            "value": value,
+            "index": 0
+        }
+    data = [make_row(n, a, v)
+            for n, a, v in [("EA GHI", "EA GHI", 5),
+                            ("DA GHi01", "DA GHi.", 3),
+                            ("DA GHi02", "DA GHi.", 4),
+                            ("DA GHi03", "DA GHi.", 7),
+                            ("CA GHI", "CA GHI", 1)]]
+    df = pd.DataFrame(data)
+
+    figure = figures.bar(df, "mae")
+
+    # Ensure x labels are in expected order
+    assert (figure.data[0]['x'] == np.array([
+        "CA GHI", "DA GHi.", "DA GHi.\x00",
+        "DA GHi.\x00\x00", "EA GHI"], dtype=object)).all()
+    # ensure y values are in the same order as x labels
+    assert (figure.data[0]['y'] == np.array([1, 3, 4, 7, 5])).all()
+    # assert hover text (original name) matches x label order
+    assert (figure.data[0]['text'] == np.array([
+        'CA GHI', "DA GHi01", "DA GHi02", "DA GHi03", "EA GHI"])).all()

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -256,7 +256,7 @@ Plotly.newPlot("scatter-div", scat_plot);
       {% if rep_fig.category == category and rep_fig.metric == metric %}
       {% set plot_id = (category+'_'+metric+'_'+rep_fig.name) | figure_name_filter %}
     <div class="metric-block" id="{{ plot_id }}" data-category="{{ rep_fig.category }}" data-metric="{{ rep_fig.metric }}" data-forecast="{{ rep_fig.name }}">
-        <script>plot=JSON.parse('{{ rep_fig.spec | safe }}');
+        <script>plot=JSON.parse({{ rep_fig.spec | tojson }});
                 Object.assign(plot,{config: {responsive: true}});
                 metric_plots['{{plot_id}}'] = plot;</script></div>
       {% endif %}


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Fixes a bug where the x_labels were mixed up do to implicit sorting by the DataFrame.groupby function. 

Also discovered that my test reports did not adequately cover #599 . The metrics preprocessing code suffixes names with numbers when there are duplicate forecast names, so null characters were never used. When the null values are used, the `JSON.parse` function chokes. due to improper encoding. Using the `tojson` filter here fixes that issue. 
It looks like Webkit (Opera and Chrome on ubuntu) are rendering the null characters, while FireFox does not. Screenshot below.
![Screenshot from 2020-11-13 16-08-37](https://user-images.githubusercontent.com/21206164/99129340-87638580-25ca-11eb-8c74-39183cea3870.png)
 