### PR TITLE
clean up freq expectations for pd>=1.1 compat

### DIFF
--- a/docs/source/whatsnew/1.0.2.rst
+++ b/docs/source/whatsnew/1.0.2.rst
@@ -1,0 +1,27 @@
+.. _whatsnew_102:
+
+.. py:currentmodule:: solarforecastarbiter
+
+1.0.2 (January ??, 2021)
+-------------------------
+
+
+Testing
+~~~~~~~
+
+* Clarified expectations for ``pandas.DatetimeIndex.freq`` attribute
+  throughout test suite. Improves compatibility with pandas >= 1.1.
+  (:issue:`641`)
+
+
+Contributors
+~~~~~~~~~~~~
+
+* Will Holmgren (:ghuser:`wholmgren`)
+* Leland Boeman (:ghuser:`lboeman`)
+* Cliff Hansen (:ghuser:`cwhanse`)
+* Tony Lorenzo (:ghuser:`alorenzo175`)
+* Justin Sharp (:ghuser:`MrWindAndSolar`)
+* Aidan Tuohy
+* Adam Wigington (:ghuser:`awig`)
+* David Larson (:ghuser:`dplarson`)

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -75,7 +75,7 @@ def observation_values_text():
 
 @pytest.fixture()
 def observation_values():
-    return pd.DataFrame.from_records(
+    df = pd.DataFrame.from_records(
         [(0, 0),
          (1.0, 0),
          (1.5, 0),
@@ -88,11 +88,13 @@ def observation_values():
                             tz='America/Denver',
                             name='timestamp'),
         columns=['value', 'quality_flag']).tz_convert('UTC')
+    df.index.freq = None
+    return df
 
 
 @pytest.fixture()
 def validated_observation_values():
-    return pd.DataFrame.from_records(
+    df = pd.DataFrame.from_records(
         [(0, 2),
          (1.0, 3),
          (1.5, 2),
@@ -105,6 +107,8 @@ def validated_observation_values():
                             tz='America/Denver',
                             name='timestamp'),
         columns=['value', 'quality_flag']).tz_convert('UTC')
+    df.index.freq = None
+    return df
 
 
 @pytest.fixture()
@@ -147,13 +151,16 @@ def forecast_values_text():
 
 @pytest.fixture()
 def forecast_values():
-    return pd.Series([0.0, 1, 2, 3, 4, 5],
-                     name='value',
-                     index=pd.date_range(start='20190101T0600',
-                                         end='20190101T1100',
-                                         freq='1h',
-                                         tz='America/Denver',
-                                         name='timestamp')).tz_convert('UTC')
+    s = pd.Series(
+        [0.0, 1, 2, 3, 4, 5],
+        name='value',
+        index=pd.date_range(start='20190101T0600',
+                            end='20190101T1100',
+                            freq='1h',
+                            tz='America/Denver',
+                            name='timestamp')).tz_convert('UTC')
+    s.index.freq = None
+    return s
 
 
 @pytest.fixture()
@@ -265,7 +272,7 @@ b"""
 
 @pytest.fixture()
 def prob_forecast_values():
-    return pd.DataFrame(
+    df = pd.DataFrame(
         {'25.0': [0.0, 1, 2, 3, 4, 5],
          '50.0': [1.0, 2, 3, 4, 5, 6],
          '75.0': [2.0, 3, 4, 5, 6, 7]},
@@ -274,6 +281,8 @@ def prob_forecast_values():
                             freq='1h',
                             tz='America/Denver',
                             name='timestamp')).tz_convert('UTC')
+    df.index.freq = None
+    return df
 
 
 @pytest.fixture(scope='module')

--- a/solarforecastarbiter/io/reference_observations/tests/test_common.py
+++ b/solarforecastarbiter/io/reference_observations/tests/test_common.py
@@ -299,12 +299,12 @@ def test_create_observation_with_kwargs(
 
     # nans not extended to start end
     (pd.DataFrame({'ghi': [0, 1]}, dtype='float',
-                  index=pd.DatetimeIndex(
-                      ['2019-10-04T1201Z', '2019-10-04T1202Z'])),
+                  index=pd.date_range('2019-10-04T1201Z',
+                                      freq='1min', periods=2)),
      pd.DataFrame({'value': [0.0, 1.0],
                    'quality_flag': [0, 0]},
-                  index=pd.DatetimeIndex(
-                      ['2019-10-04T1201Z', '2019-10-04T1202Z']))),
+                  index=pd.date_range('2019-10-04T1201Z',
+                                      freq='1min', periods=2))),
 ])
 def test_prepare_data_to_post(inp, expected, observation, resample_how):
     start = pd.Timestamp('2019-10-04T1200Z')

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -1649,6 +1649,7 @@ def test_apisession_chunk_value_requests_obs_df(requests_mock):
         index=pd.date_range(start, end, freq='1H', name='timestamp'),
         data={'value': 1.0, 'quality_flag': 0},
     )
+    expected.index.freq = None
     matcher = re.compile(
         f'{session.base_url}/observations/.*/values')
     requests_mock.register_uri('GET', matcher, content=callback)
@@ -1671,6 +1672,7 @@ def test_apisession_chunk_value_requests_fx_series(requests_mock):
         index=pd.date_range(start, end, freq='1H', name='timestamp'),
         name='value',
     )
+    expected.index.freq = None
     matcher = re.compile(
         f'{session.base_url}/forecasts/.*/values')
     requests_mock.register_uri('GET', matcher, content=callback)

--- a/solarforecastarbiter/io/tests/test_io_utils.py
+++ b/solarforecastarbiter/io/tests/test_io_utils.py
@@ -15,6 +15,7 @@ DF_INDEX = pd.date_range(start=pd.Timestamp('2019-01-24T00:00'),
                          freq='1min',
                          periods=5,
                          tz='UTC', name='timestamp')
+DF_INDEX.freq = None
 TEST_DATA = pd.DataFrame(TEST_DICT, index=DF_INDEX)
 EMPTY_SERIES = pd.Series(dtype=float)
 EMPTY_TIMESERIES = pd.Series([], name='value', index=pd.DatetimeIndex(
@@ -435,6 +436,7 @@ def test_load_report_values(raw_report, report_objects):
                     name='value', index=pd.date_range(
                         start='20200101', freq='5min', periods=10,
                         tz='UTC', name='timestamp'))
+    ser.index.freq = None
     val = utils.serialize_timeseries(ser)
     vals = [{'id': id_, 'processed_values': val} for id_ in
             (fx0.forecast_id, fx1.forecast_id, obs.observation_id,

--- a/solarforecastarbiter/reference_forecasts/tests/test_forecast.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_forecast.py
@@ -47,7 +47,7 @@ def rfs_series():
 )
 def test_reindex_fill_slice(rfs_series, start, end, start_slice, end_slice,
                             fill_method, exp_val, exp_idx):
-    exp = pd.Series(exp_val, index=pd.DatetimeIndex(exp_idx))
+    exp = pd.Series(exp_val, index=pd.DatetimeIndex(exp_idx, freq='30min'))
     out = forecast.reindex_fill_slice(
         rfs_series, freq='30min', start=start, end=end,
         start_slice=start_slice, end_slice=end_slice, fill_method=fill_method)
@@ -64,7 +64,7 @@ def test_reindex_fill_slice_some_nan():
     exp_idx = [
         '20190101 01', '20190101 0130', '20190101 02', '20190101 0230',
         '20190101 03', '20190101 0330', '20190101 04']
-    exp = pd.Series(exp_val, index=pd.DatetimeIndex(exp_idx))
+    exp = pd.Series(exp_val, index=pd.DatetimeIndex(exp_idx, freq='30min'))
     out = forecast.reindex_fill_slice(
         rfs_series, freq='30min', start=start, end=end,
         start_slice=start_slice, end_slice=end_slice, fill_method=fill_method)
@@ -77,7 +77,7 @@ def test_reindex_fill_slice_all_nan():
     out = forecast.reindex_fill_slice(arg, freq='30min')
     exp = pd.Series([None]*5, index=pd.DatetimeIndex(
         ['20190101 01', '20190101 0130', '20190101 02', '20190101 0230',
-         '20190101 03']))
+         '20190101 03'], freq='30min'))
     assert_series_equal(out, exp)
 
 

--- a/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
@@ -198,7 +198,8 @@ def test_persistence_scalar_index(
     fx = persistence.persistence_scalar_index(
         observation, data_start, data_end, forecast_start, forecast_end,
         interval_length, interval_label, load_data)
-    expected_index = pd.DatetimeIndex(expected_index, tz=tz)
+    expected_index = pd.DatetimeIndex(
+        expected_index, tz=tz, freq=interval_length)
     expected = pd.Series(expected_ghi, index=expected_index)
     assert_series_equal(fx, expected, check_names=False)
 
@@ -230,7 +231,7 @@ def test_persistence_scalar_index_instant_obs_fx(
         observation, data_start, data_end, forecast_start, forecast_end,
         interval_length, interval_label, load_data)
     expected_index = pd.DatetimeIndex(
-        ['20190404 1300', '20190404 1330'], tz=tz)
+        ['20190404 1300', '20190404 1330'], tz=tz, freq=interval_length)
     expected_values = [96.59022431746838, 91.99405501672328]
     expected = pd.Series(expected_values, index=expected_index)
     assert_series_equal(fx, expected, check_names=False)
@@ -251,7 +252,7 @@ def test_persistence_scalar_index_instant_obs_fx(
         observation, data_start, data_end, forecast_start, forecast_end,
         interval_length, interval_label, load_data)
     expected_index = pd.DatetimeIndex(
-        ['20190404 1300', '20190404 1330'], tz=tz)
+        ['20190404 1300', '20190404 1330'], tz=tz, freq=interval_length)
     expected_values = [96.55340033645147, 91.89662922267517]
     expected = pd.Series(expected_values, index=expected_index)
     assert_series_equal(fx, expected, check_names=False)

--- a/solarforecastarbiter/tests/test_utils.py
+++ b/solarforecastarbiter/tests/test_utils.py
@@ -166,7 +166,7 @@ def test_compute_aggregate_no_overlap(ids):
          'quality_flag': [2, 10, 9, 338 | 880, 10]},
         index=pd.DatetimeIndex([
             '20191002T0100Z', '20191002T0130Z', '20191002T0200Z',
-            '20191002T0230Z', '20191002T0300Z']))
+            '20191002T0230Z', '20191002T0300Z'], freq='30min'))
     pdt.assert_frame_equal(agg, expected)
 
 
@@ -189,7 +189,7 @@ def test_compute_aggregate_missing_before_effective(ids):
          'quality_flag': [2, 10, 338, 880, 10]},
         index=pd.DatetimeIndex([
             '20191002T0100Z', '20191002T0130Z', '20191002T0200Z',
-            '20191002T0230Z', '20191002T0300Z']))
+            '20191002T0230Z', '20191002T0300Z'], freq='30min'))
     pdt.assert_frame_equal(agg, expected)
 
 

--- a/solarforecastarbiter/validation/tests/test_validation_tasks.py
+++ b/solarforecastarbiter/validation/tests/test_validation_tasks.py
@@ -1384,6 +1384,8 @@ def test__group_continuous_week_post(mocker, make_observation):
                 tz='UTC',
                 freq='1h')),
     ]
+    for df in split_dfs:
+        df.index.freq = None
     ov = pd.concat(split_dfs, axis=0)
     obs = make_observation('ghi')
     session = mocker.MagicMock()

--- a/solarforecastarbiter/validation/tests/test_validator.py
+++ b/solarforecastarbiter/validation/tests/test_validator.py
@@ -290,7 +290,7 @@ def test_check_day_night_interval_irregular():
         solar_zenith_interval_length=solar_zenith_interval_length
     )
     expected = pd.Series([False, False, True], index=pd.DatetimeIndex(
-        ['20200917 0000', '20200917 0100', '20200917 0200']))
+        ['20200917 0000', '20200917 0100', '20200917 0200'], freq='1h'))
     assert_series_equal(result, expected)
 
 
@@ -405,10 +405,10 @@ def ghi_clearsky():
 def ghi_clipped(ghi_clearsky):
     ghi_clipped = ghi_clearsky.copy()
     ghi_clipped = np.minimum(ghi_clearsky, 800)
-    ghi_clipped.iloc[12:17] = np.minimum(ghi_clearsky, 300)
-    ghi_clipped.iloc[18:20] = np.minimum(ghi_clearsky, 300)
+    ghi_clipped.iloc[12:17] = np.minimum(ghi_clearsky.iloc[12:17], 300)
+    ghi_clipped.iloc[18:20] = np.minimum(ghi_clearsky.iloc[18:20], 300)
     ghi_clipped.iloc[26:28] *= 0.5
-    ghi_clipped.iloc[36:] = np.minimum(ghi_clearsky, 400)
+    ghi_clipped.iloc[36:] = np.minimum(ghi_clearsky.iloc[36:], 400)
     return ghi_clipped
 
 

--- a/solarforecastarbiter/validation/tests/test_validator.py
+++ b/solarforecastarbiter/validation/tests/test_validator.py
@@ -238,16 +238,16 @@ def test_check_day_night():
 @pytest.mark.parametrize('closed,solar_zenith,expected', (
     ('left', [89]*11 + [80]*13,
      pd.Series([False, True], index=pd.DatetimeIndex(
-            ['20200917 0000', '20200917 0100']))),
+            ['20200917 0000', '20200917 0100'], freq='1h'))),
     ('right', [89]*11 + [80]*13,
      pd.Series([False, True], index=pd.DatetimeIndex(
-        ['20200917 0100', '20200917 0200']))),
+        ['20200917 0100', '20200917 0200'], freq='1h'))),
     ('left', [89]*10 + [80]*14,
      pd.Series([True, True], index=pd.DatetimeIndex(
-            ['20200917 0000', '20200917 0100']))),
+            ['20200917 0000', '20200917 0100'], freq='1h'))),
     ('right', [89]*10 + [80]*14,
      pd.Series([True, True], index=pd.DatetimeIndex(
-        ['20200917 0100', '20200917 0200'])))
+        ['20200917 0100', '20200917 0200'], freq='1h')))
 ))
 def test_check_day_night_interval(closed, solar_zenith, expected):
     interval_length = pd.Timedelta('1h')


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #641 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - ~[ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.~
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

I saw two options:

1. make the test expectations for ``freq`` more explicit, or
2. increase the minimum pandas to 1.1 and add ``check_freq=False`` to a bunch of tests. Unfortunately, the ``check_freq`` kwarg was introduced in 1.1 with a default value of ``True`` while the previous hard-coded behavior was ``check_freq=False``.

I figured "explicit is better...". In some cases I set ``freq = None`` on the input series/dataframe index because we do not generally assume serially complete time series and therefore data returned by `api.py` does not have defined ``freq``.