### PR TITLE
reports display warnings instead of empty tables if no total metrics

### DIFF
--- a/docs/source/whatsnew/1.0.2.rst
+++ b/docs/source/whatsnew/1.0.2.rst
@@ -13,6 +13,8 @@ Fixed
 * Updated PyPI classifiers. (:issue:`637`, :pull:`643`)
 * Updated :ref:`installation` page with instructions for PyPI, conda-forge,
   and docker. (:issue:`635`, :pull:`649`)
+* If total metrics category was not selected, the report now displays warnings
+  instead of confusing blank tables. (:issue:`629`, :pull:`652`)
 
 Testing
 ~~~~~~~

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -224,7 +224,13 @@ Plotly.newPlot("scatter-div", scat_plot);
   <a href="javascript:download_stats_as_csv('{{ report_name }}')">CSV format</a>
   or <a href="javascript:download_stats_as_json('{{ report_name }}')">JSON format</a>.
 </p>
-{{ macros.summary_stats_table_vert(report.raw_report.metrics | selectattr("is_summary"), "total") }}
+{% if "total" in report.report_parameters.categories %}
+  {{ macros.summary_stats_table_vert(report.raw_report.metrics | selectattr("is_summary"), "total") }}
+{% else %}
+  <div class="alert alert-warning">
+    <h5>Total metrics not selected in report configuration. Summary total statistics table not available. See CSV/JSON files for other summary statistics.</h5>
+  </div>
+{% endif %}
 <br>
 {% endblock %}
 
@@ -238,8 +244,13 @@ Plotly.newPlot("scatter-div", scat_plot);
   <a href="javascript:download_metrics_as_csv('{{ report_name }}')">CSV format</a>
   or <a href="javascript:download_metrics_as_json('{{ report_name }}')">JSON format</a>.
 </p>
-
-{{ macros.metric_table_fx_vert(report.raw_report.metrics | rejectattr("is_summary"), "total", report.report_parameters.metrics) }}
+{% if "total" in report.report_parameters.categories %}
+  {{ macros.metric_table_fx_vert(report.raw_report.metrics | rejectattr("is_summary"), "total", report.report_parameters.metrics) }}
+{% else %}
+  <div class="alert alert-warning">
+    <h5>Total metrics not selected in report configuration. Total metrics table not available. See CSV/JSON files for other metrics.</h5>
+  </div>
+{% endif %}
 
 <script>var metric_plots = {};</script>
 <div id="metric-plot-wrapper">

--- a/solarforecastarbiter/reports/templates/pdf/base.tex
+++ b/solarforecastarbiter/reports/templates/pdf/base.tex
@@ -100,18 +100,25 @@ forecasts over the entire study period is shown below. Downloads of summary
 statistics for other categories are available on the
 \href{\VAR{report_url}}{web version of this report}.
 
-\VAR{macros.summary_statistics_table(report.raw_report.metrics | selectattr('is_summary'), 'total')}
-
+%- if "total" in report.report_parameters.categories
+  \VAR{macros.summary_statistics_table(report.raw_report.metrics | selectattr('is_summary'), 'total')}
+%- else
+  Total metrics not selected in report configuration. Summary total statistics table not available. See CSV/JSON files for other summary statistics.
+%- endif
 \section{Metrics}
 \FloatBarrier
 
 \VAR{macros.metrics_meta_table()}
 
 A table of metrics over the entire study period and metric figures are shown below.
-Metrics may be downloaded in CSV format through the HTML version of this report
+Metrics may be downloaded in CSV and JSON formats through the HTML version of this report
 available \href{\VAR{report_url}}{here}.
 
-\VAR{macros.metric_table(report.raw_report.metrics | rejectattr('is_summary'), 'total', report.report_parameters.metrics)}
+%- if "total" in report.report_parameters.categories
+  \VAR{macros.metric_table(report.raw_report.metrics | rejectattr('is_summary'), 'total', report.report_parameters.metrics)}
+%- else
+  Total metrics not selected in report configuration. Total metrics table not available. See CSV/JSON files for other metrics.
+%- endif
 
 \FloatBarrier
 %- for category in report.report_parameters.categories


### PR DESCRIPTION
…available


  - [x] Closes #629  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - ~Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.~
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - ~New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

I'm not sure about a test for this since reasonably we can only test if the code within the else block doesn't cause a problem. And it's uncommon to begin with. Here's a zip file with examples showing that it works. 

[no_total_warning_examples.zip](https://github.com/SolarArbiter/solarforecastarbiter-core/files/5857610/no_total_warning_examples.zip)
