### PR TITLE
add stale, interpolated flags to discard before resample

### DIFF
--- a/docs/source/whatsnew/1.0.2.rst
+++ b/docs/source/whatsnew/1.0.2.rst
@@ -13,6 +13,9 @@ Fixed
 * Updated PyPI classifiers. (:issue:`637`, :pull:`643`)
 * Updated :ref:`installation` page with instructions for PyPI, conda-forge,
   and docker. (:issue:`635`, :pull:`649`)
+* Added the following flags to ``DISCARD_BEFORE_RESAMPLE``:
+  ``'STALE VALUES'``, ``'INTERPOLATED VALUES'``, ``'DAYTIME STALE VALUES'``,
+  ``'DAYTIME INTERPOLATED VALUES'``. (:issue:`626`, :pull:`653`)
 
 Testing
 ~~~~~~~

--- a/solarforecastarbiter/validation/quality_mapping.py
+++ b/solarforecastarbiter/validation/quality_mapping.py
@@ -56,7 +56,13 @@ DERIVED_MASKS = {
 # flags that should typically be discarded before resampling because they
 # represent truly bad data
 DISCARD_BEFORE_RESAMPLE = [
-    'USER FLAGGED', 'LIMITS EXCEEDED', 'INCONSISTENT IRRADIANCE COMPONENTS'
+    'USER FLAGGED',
+    'LIMITS EXCEEDED',
+    'INCONSISTENT IRRADIANCE COMPONENTS',
+    'STALE VALUES',
+    'INTERPOLATED VALUES',
+    'DAYTIME STALE VALUES',
+    'DAYTIME INTERPOLATED VALUES'
 ]
 
 # should never change unless another VERSION IDENTIFIER is required


### PR DESCRIPTION


  - [x] Closes #626  .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - ~Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.~
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - ~New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

I don't think we need more tests here. We already test this list works and I don't see the point of testing if elements are in it in convoluted ways.