### PR TITLE
Add NaNs in detect_clearsky to work around observation gaps

### DIFF
--- a/docs/source/whatsnew/1.0.2.rst
+++ b/docs/source/whatsnew/1.0.2.rst
@@ -42,8 +42,8 @@ Fixed
   validating event forecast data. (:issue:`660`, :pull:`661`)
 * Changed GFS fetch directory for compatibility with March 22, 2021, 12Z
   model upgrade. (:issue:`662`, :pull:`663`)
-* Fixed ``CLEARSKY`` GHI validation to work around NaNs in the data
-  instead of not calculating the flag at all (:pull:`673`)
+* Worked around data gaps during ``CLEARSKY`` GHI validation that cause uneven
+  frequencies which lead to skipping validation entirely (:pull:`673`)
 
 Testing
 ~~~~~~~

--- a/docs/source/whatsnew/1.0.2.rst
+++ b/docs/source/whatsnew/1.0.2.rst
@@ -42,6 +42,8 @@ Fixed
   validating event forecast data. (:issue:`660`, :pull:`661`)
 * Changed GFS fetch directory for compatibility with March 22, 2021, 12Z
   model upgrade. (:issue:`662`, :pull:`663`)
+* Fixed ``CLEARSKY`` GHI validation to work around NaNs in the data
+  instead of not calculating the fla(:pull:`673`)
 
 Testing
 ~~~~~~~

--- a/docs/source/whatsnew/1.0.2.rst
+++ b/docs/source/whatsnew/1.0.2.rst
@@ -43,7 +43,7 @@ Fixed
 * Changed GFS fetch directory for compatibility with March 22, 2021, 12Z
   model upgrade. (:issue:`662`, :pull:`663`)
 * Fixed ``CLEARSKY`` GHI validation to work around NaNs in the data
-  instead of not calculating the fla(:pull:`673`)
+  instead of not calculating the flag at all (:pull:`673`)
 
 Testing
 ~~~~~~~

--- a/solarforecastarbiter/validation/tests/test_validator.py
+++ b/solarforecastarbiter/validation/tests/test_validator.py
@@ -468,7 +468,7 @@ def test_detect_clearsky_ghi_warn_interval_length(ghi_clearsky):
     assert (flags == 0).all()
 
 
-def test_detect_clearsky_ghi_warn_regular_interval(ghi_clearsky):
+def test_detect_clearsky_ghi_with_data_gap(ghi_clearsky):
     ser = ghi_clearsky[:-2].append(ghi_clearsky[-1:])
     flags = validator.detect_clearsky_ghi(ser, ser)
     assert (flags[:7] == 0).all()

--- a/solarforecastarbiter/validation/tests/test_validator.py
+++ b/solarforecastarbiter/validation/tests/test_validator.py
@@ -479,12 +479,13 @@ def test_detect_clearsky_ghi_warn_regular_interval(ghi_clearsky):
 
 def test_detect_clearsky_ghi_nans(ghi_clearsky):
     ser = ghi_clearsky.copy()
-    ser.iloc[[10, 21, 22]] = np.nan
+    ser.iloc[[10, 21, 22, 24]] = np.nan
     flags = validator.detect_clearsky_ghi(ser, ghi_clearsky)
-    assert (flags.iloc[[10, 21, 22]] == 0).all()
+    assert (flags.iloc[[10, 21, 22, 23, 24]] == 0).all()
+    # 23 0 because can't detect_clearsky on single point
     assert (flags[:11] == 0).all()
     assert (flags[11:21] == 1).all()
-    assert (flags[23:-6] == 1).all()
+    assert (flags[25:-6] == 1).all()
     assert (flags[-6:] == 0).all()
 
 

--- a/solarforecastarbiter/validation/tests/test_validator.py
+++ b/solarforecastarbiter/validation/tests/test_validator.py
@@ -472,7 +472,20 @@ def test_detect_clearsky_ghi_warn_regular_interval(ghi_clearsky):
     with pytest.warns(RuntimeWarning):
         ser = ghi_clearsky[:-2].append(ghi_clearsky[-1:])
         flags = validator.detect_clearsky_ghi(ser, ser)
-    assert (flags == 0).all()
+    assert (flags[:7] == 0).all()
+    assert (flags[-5:] == 0).all()
+    assert (flags[7:-5]).all()
+
+
+def test_detect_clearsky_ghi_nans(ghi_clearsky):
+    ser = ghi_clearsky.copy()
+    ser.iloc[[10, 21, 22]] = np.nan
+    flags = validator.detect_clearsky_ghi(ser, ghi_clearsky)
+    assert (flags.iloc[[10, 21, 22]] == 0).all()
+    assert (flags[:11] == 0).all()
+    assert (flags[11:21] == 1).all()
+    assert (flags[23:-6] == 1).all()
+    assert (flags[-6:] == 0).all()
 
 
 def test_detect_clearsky_ghi_one_val(ghi_clearsky):

--- a/solarforecastarbiter/validation/tests/test_validator.py
+++ b/solarforecastarbiter/validation/tests/test_validator.py
@@ -469,9 +469,8 @@ def test_detect_clearsky_ghi_warn_interval_length(ghi_clearsky):
 
 
 def test_detect_clearsky_ghi_warn_regular_interval(ghi_clearsky):
-    with pytest.warns(RuntimeWarning):
-        ser = ghi_clearsky[:-2].append(ghi_clearsky[-1:])
-        flags = validator.detect_clearsky_ghi(ser, ser)
+    ser = ghi_clearsky[:-2].append(ghi_clearsky[-1:])
+    flags = validator.detect_clearsky_ghi(ser, ser)
     assert (flags[:7] == 0).all()
     assert (flags[-5:] == 0).all()
     assert (flags[7:-5]).all()


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #xxxx .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Evaluates `detect_clearsky` in `validator.detect_clearsky_ghi` only on continuous not-NA periods. Previously, if one tried to validate a period with missing times from the index, no clearsky validation would take place at all. Another option would be to reindex the input to a set frequency and insert nans. The current approach avoids applying `detect_clearsky` to any NaN values at all, but may reduce the length of the series that `detect_clearsky` sees.

For example, the approach in this PR works like
```
ghi = pd.Series(data, index=[2020-01-01T12:00Z, 2020-01-01T12:15Z, 2020-01-01T13:00Z, 2020-01-01T13:15Z])
out = detect_clearsky(ghi[2020-01-01T12:00Z:2020-0101T12:15Z]) + 
    detect_clearsky(ghi[2020-01-01T13:00Z:2020-01-01T13:15Z])
```
if reindexing were used instead, a longer series would be fed in to `detect_clearsky`
```
ghi = pd.Series(data, index=[2020-01-01T12:00Z, 2020-01-01T12:15Z, 2020-01-01T13:00Z, 2020-01-01T13:15Z])
inp = ghi.reindex(...) # pd.Series([data, data, NaN, NaN, data, data], 
                                       index=pd.date_range(start=2020-01-01T12:00Z, end=2020-01-01T13:15Z, freq='15min'))
out = detect_clearsky(inp)
```
