### PR TITLE
implement report_parameters.timezone

### DIFF
--- a/docs/source/whatsnew/1.0.2.rst
+++ b/docs/source/whatsnew/1.0.2.rst
@@ -3,7 +3,7 @@
 .. py:currentmodule:: solarforecastarbiter
 
 
-1.0.2 (January ??, 2021)
+1.0.2 (July ??, 2021)
 -------------------------
 
 Enhancements
@@ -15,6 +15,9 @@ Enhancements
   (:issue:`541`, :pull:`656`)
 * Added functions to parse data for the PNNL reference data site.
   (:issue:`563`, :pull:`669`)
+* Report timezone may now be set by passing the ``timezone`` keyword
+  argument to :py:class:`~datamodel.ReportParameters`.
+  (:issue:`317`, :pull:`681`)
 
 Fixed
 ~~~~~

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -9,7 +9,7 @@ import itertools
 import json
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
-from typing import Tuple, Union, ClassVar
+from typing import Optional, Tuple, Union, ClassVar
 
 
 import numpy as np
@@ -1939,6 +1939,9 @@ class ReportParameters(BaseModel):
         to compute cost metrics for that pair. Each object pair must have
         the 'cost' parameter set to None (no cost calculation will be
         performed) or one of the names of these costs.
+    timezone : str or None
+        The timezone in which to compute daily, hourly, etc. statistics.
+        If None, inferred from data in object_pairs.
     """
     name: str
     start: pd.Timestamp
@@ -1950,6 +1953,7 @@ class ReportParameters(BaseModel):
     filters: Tuple[BaseFilter, ...] = field(
         default_factory=lambda: (QualityFlagFilter(), ))
     costs: Tuple[Cost, ...] = tuple()
+    timezone: Optional[str] = None
 
     def __post_init__(self):
         # ensure that all forecast and observation units are the same

--- a/solarforecastarbiter/io/tests/test_api.py
+++ b/solarforecastarbiter/io/tests/test_api.py
@@ -813,9 +813,15 @@ def test_apisession_list_reports_empty(requests_mock):
     assert out == []
 
 
-def test_apisession_create_report(requests_mock, report_objects, mocker):
+@pytest.mark.parametrize('timezone', [None, 'Etc/GMT+5'])
+def test_apisession_create_report(
+        requests_mock, report_objects, mocker, timezone
+):
     session = api.APISession('')
     report = report_objects[0]
+    if timezone:
+        params = report.report_parameters.replace(timezone=timezone)
+        report = report.replace(report_parameters=params)
     mocked = requests_mock.register_uri('POST', f'{session.base_url}/reports/')
     mocker.patch('solarforecastarbiter.io.api.APISession.get_report',
                  return_value=report)
@@ -867,7 +873,8 @@ def test_apisession_create_report(requests_mock, report_objects, mocker):
                         "net": True
                     }
                 }
-            ]
+            ],
+            "timezone": timezone
         }}
     session.create_report(report)
     posted = mocked.last_request.json()
@@ -953,7 +960,8 @@ def test_apisession_create_report_mult_costs(requests_mock, report_objects,
                         "net": True
                     }
                 }
-            ]
+            ],
+            "timezone": None
         }}
     session.create_report(report)
     posted = mocked.last_request.json()
@@ -1008,7 +1016,8 @@ def test_apisession_create_report_no_costs(
                  "aggregate": "458ffc27-df0b-11e9-b622-62adb5fd6af0",
                  "uncertainty": "5.0"}
             ],
-            "costs": []
+            "costs": [],
+            "timezone": None
         }}
     session.create_report(report)
     posted = mocked.last_request.json()

--- a/solarforecastarbiter/reports/main.py
+++ b/solarforecastarbiter/reports/main.py
@@ -170,7 +170,10 @@ def create_raw_report_from_data(report, data):
     """
     generated_at = pd.Timestamp.now(tz='UTC')
     report_params = report.report_parameters
-    timezone = infer_timezone(report_params)
+    if report_params.timezone:
+        timezone = report_params.timezone
+    else:
+        timezone = infer_timezone(report_params)
     versions = get_versions()
     with hijack_loggers([
         'solarforecastarbiter.metrics',

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -1129,3 +1129,10 @@ def test_probabilistic_units_data_object_matching(
 
     pfx = datamodel.ProbabilisticForecast.from_dict(params)
     datamodel.ForecastObservation(pfx, single_observation)
+
+
+def test_report_parameters_timezone(report_params_dict, report_params):
+    report_params_dict['timezone'] = 'Etc/GMT+7'
+    rpd = datamodel.ReportParameters.from_dict(report_params_dict)
+    rp = report_params.replace(timezone='Etc/GMT+7')
+    assert rpd == rp


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #317 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - ~Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.~
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Needs more tests, but works

no tz specified in report parameters

![sfa default timezone](https://user-images.githubusercontent.com/4383303/124215476-ef5ad380-daa8-11eb-9e49-e4ba500bf897.png)
<img width="1077" alt="sfa default timezone hour metric" src="https://user-images.githubusercontent.com/4383303/124215521-04cffd80-daa9-11eb-816d-ed0f2e19ea02.png">

America/Denver specified in report parameters

![sfa america denver timezone](https://user-images.githubusercontent.com/4383303/124215545-0f8a9280-daa9-11eb-9481-c1a0b83bccae.png)
<img width="1087" alt="sfa america denver timezone hour metric" src="https://user-images.githubusercontent.com/4383303/124215555-12858300-daa9-11eb-81ec-d175447493a4.png">
