### PR TITLE
compatibility with new numpy and pandas

### DIFF
--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -976,10 +976,10 @@ def test_process_forecast_observations_empty_fx(
     # as series
     data_ser = {
         observation: obs_df,
-        forecast_0: pd.Series([], name='value', dtype=np.object),
-        forecast_1: pd.Series([], name='value', dtype=np.object),
-        forecast_ref: pd.Series([], name='value', dtype=np.object),
-        forecast_agg: pd.Series([], name='value', dtype=np.object),
+        forecast_0: pd.Series([], name='value', dtype=object),
+        forecast_1: pd.Series([], name='value', dtype=object),
+        forecast_ref: pd.Series([], name='value', dtype=object),
+        forecast_agg: pd.Series([], name='value', dtype=object),
         aggregate: agg_df
     }
     filters = [quality_filter]
@@ -1009,10 +1009,10 @@ def test_process_forecast_observations_empty_fx(
     # as dataframe
     data_df = {
         observation: obs_df,
-        forecast_0: pd.DataFrame(columns=['1', '2', '3'], dtype=np.object),
-        forecast_1: pd.DataFrame(columns=['1', '2', '3'], dtype=np.object),
-        forecast_ref: pd.DataFrame(columns=['1', '2', '3'], dtype=np.object),
-        forecast_agg: pd.DataFrame(columns=['1', '2', '3'], dtype=np.object),
+        forecast_0: pd.DataFrame(columns=['1', '2', '3'], dtype=object),
+        forecast_1: pd.DataFrame(columns=['1', '2', '3'], dtype=object),
+        forecast_ref: pd.DataFrame(columns=['1', '2', '3'], dtype=object),
+        forecast_agg: pd.DataFrame(columns=['1', '2', '3'], dtype=object),
         aggregate: agg_df
     }
     filters = [quality_filter]

--- a/solarforecastarbiter/tests/test_pvmodel.py
+++ b/solarforecastarbiter/tests/test_pvmodel.py
@@ -36,7 +36,8 @@ def test_calculate_solar_position(expected_solpos, golden_mst):
                                                       times)
     expected_solpos.index = times
     assert_frame_equal(expected_solpos,
-                       solar_position[expected_solpos.columns])
+                       solar_position[expected_solpos.columns],
+                       check_less_precise=3)
 
 
 # modified from pvlib

--- a/solarforecastarbiter/tests/test_pvmodel.py
+++ b/solarforecastarbiter/tests/test_pvmodel.py
@@ -36,8 +36,7 @@ def test_calculate_solar_position(expected_solpos, golden_mst):
                                                       times)
     expected_solpos.index = times
     assert_frame_equal(expected_solpos,
-                       solar_position[expected_solpos.columns],
-                       check_less_precise=3)
+                       solar_position[expected_solpos.columns])
 
 
 # modified from pvlib

--- a/solarforecastarbiter/validation/tasks.py
+++ b/solarforecastarbiter/validation/tasks.py
@@ -1,5 +1,5 @@
 import logging
-
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -703,7 +703,10 @@ def _group_continuous_week_post(session, observation, observation_values):
     # make series of week + year integers to further
     # split data to post at most one week at a time
     # ~10,000 pts of 1min data
-    week_int = (gid.index.week + gid.index.year).values
+    with warnings.catch_warnings():
+        # https://github.com/SolarArbiter/solarforecastarbiter-core/issues/685
+        warnings.simplefilter("ignore", category=FutureWarning)
+        week_int = (gid.index.week + gid.index.year).values
     # combine the continuous groups with groups of weeks
     # gid is unique for each group since week_int and cumsum
     # increase monotonically and are positive

--- a/solarforecastarbiter/validation/validator.py
+++ b/solarforecastarbiter/validation/validator.py
@@ -893,7 +893,7 @@ def detect_clearsky_ghi(ghi, ghi_clearsky):
         return pd.Series(0, index=ghi.index)
     # determine window length in minutes, 10 x interval for intervals <= 15m
     delta = ghi.index.to_series().diff()
-    delta_minutes = delta[1] / np.timedelta64(1, '60s')
+    delta_minutes = delta[1] / pd.Timedelta('60s')
     if delta_minutes <= 15:
         window_length = np.minimum(10*delta_minutes, 60.0)
         scale_factor = window_length / 10


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #683 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Created https://github.com/SolarArbiter/solarforecastarbiter-core/issues/685 to track need to address future pandas compatibility that e29d18a filters away.
