### PR TITLE
explicitly set height

### DIFF
--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -1208,6 +1208,7 @@ def timeseries_plots(report):
         plot_bgcolor=PLOT_BGCOLOR,
         font=dict(size=14),
         margin=PLOT_MARGINS,
+        height=450
     )
     if ts_fig.data:
         ts_fig_json = ts_fig.to_json()
@@ -1231,6 +1232,7 @@ def timeseries_plots(report):
             plot_bgcolor=PLOT_BGCOLOR,
             font=dict(size=14),
             margin=PLOT_MARGINS,
+            height=450
         )
         if ts_prob_fig.data:
             ts_prob_fig_json = ts_prob_fig.to_json()


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [ ] Closes #https://github.com/SolarArbiter/solarforecastarbiter-dashboard/issues/422.
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Without explicitly specifying a height, timeseries plot containers are rendering at a height of 0px and the children are set to a height of 100%.