### PR TITLE
Fix reference forecast links, add report timerange to links

### DIFF
--- a/docs/source/whatsnew/1.0.2.rst
+++ b/docs/source/whatsnew/1.0.2.rst
@@ -19,7 +19,8 @@ Enhancements
   argument to :py:class:`~datamodel.ReportParameters`.
   (:issue:`317`, :pull:`681`)
 * Report tables of observations, forecasts and reference forecasts now link
-  users to data used in the report (:issue:`679`, :pull:`688`)
+  users to the date range of the data used in the report. 
+  (:issue:`679`, :pull:`688`)
 
 Fixed
 ~~~~~
@@ -61,7 +62,7 @@ Fixed
   forecasts. (:issue:`639`, :pull:`645`)
 * Clarified that automated generation of reference forecasts is currently
   limited to privileged accounts. (:issue:`659`, :pull:`691`)
-* Fixed reference forecast links in report tables(:issue:`678`, :pull:`688`)
+* Fixed reference forecast links in report tables (:issue:`678`, :pull:`688`)
 
 Testing
 ~~~~~~~

--- a/docs/source/whatsnew/1.0.2.rst
+++ b/docs/source/whatsnew/1.0.2.rst
@@ -18,6 +18,8 @@ Enhancements
 * Report timezone may now be set by passing the ``timezone`` keyword
   argument to :py:class:`~datamodel.ReportParameters`.
   (:issue:`317`, :pull:`681`)
+* Report tables of observations, forecasts and reference forecasts now link
+  users to data used in the report (:issue:`679`, :pull:`688`)
 
 Fixed
 ~~~~~
@@ -59,6 +61,7 @@ Fixed
   forecasts. (:issue:`639`, :pull:`645`)
 * Clarified that automated generation of reference forecasts is currently
   limited to privileged accounts. (:issue:`659`, :pull:`691`)
+* Fixed reference forecast links in report tables(:issue:`678`, :pull:`688`)
 
 Testing
 ~~~~~~~

--- a/solarforecastarbiter/reports/templates/html/macros.j2
+++ b/solarforecastarbiter/reports/templates/html/macros.j2
@@ -406,3 +406,9 @@ forecasts/single/{{ forecast.forecast_id }}
     }
 </script>
 {% endmacro %}
+
+{% macro start_end_query(report_parameters) %}
+{% if report_parameters is defined %}
+?start={{ report_parameters.start }}&end={{ report_parameters.end }}
+{% endif %}
+{% endmacro %}

--- a/solarforecastarbiter/reports/templates/html/obsfx_table.html
+++ b/solarforecastarbiter/reports/templates/html/obsfx_table.html
@@ -32,6 +32,7 @@
       <th>Interval Label<br>Interval Length</th>
     </tr>
   </thead>
+  {{ report.report_parameters.start }}
   <tbody style="text-align: left; overflow-wrap: break-word;">
     {% for pfxobs in report.raw_report.processed_forecasts_observations %}
     <tr>
@@ -43,11 +44,11 @@
       </td>
       <td>
         {% if pfxobs.original.observation is defined %}
-        <a href="{{ dash_url }}/observations/{{ pfxobs.original.observation.observation_id }}">
+        <a href="{{ dash_url }}/observations/{{ pfxobs.original.observation.observation_id }}{{ macros.start_end_query(report.report_parameters)}}">
           {{ pfxobs.original.observation.name }}
         </a>
         {% else %}
-        <a href="{{ dash_url }}/aggregates/{{ pfxobs.original.aggregate.aggregate_id }}">
+        <a href="{{ dash_url }}/aggregates/{{ pfxobs.original.aggregate.aggregate_id }}{{ macros.start_end_query(report.report_parameters)}}">
           {{ pfxobs.original.aggregate.name }}
         </a>
         {% endif %}
@@ -58,7 +59,7 @@
         {{ (pfxobs.original.data_object.interval_length.total_seconds() // 60) | int }} min
       </td>
       <td>
-        <a href="{{ dash_url }}/{{ macros.forecast_route(pfxobs.original.forecast) }}">
+        <a href="{{ dash_url }}/{{ macros.forecast_route(pfxobs.original.forecast) }}{{ macros.start_end_query(report.report_parameters) }}">
           {{ pfxobs.original.forecast.name }}
          </a>
       </td>
@@ -69,7 +70,7 @@
       </td>
       <td>
         {% if pfxobs.original.reference_forecast != none %}
-        <a href="{{ dash_url }}/{{ macros.forecast_route(pfxobs.original.reference_forecast.forecast_id) }}">
+        <a href="{{ dash_url }}/{{ macros.forecast_route(pfxobs.original.reference_forecast) }}{{ macros.start_end_query(report.report_parameters) }}">
           {{ pfxobs.original.reference_forecast.name if pfxobs.original.reference_forecast != none else 'None' }}
         </a>
         {% else %}

--- a/solarforecastarbiter/reports/templates/html/obsfx_table.html
+++ b/solarforecastarbiter/reports/templates/html/obsfx_table.html
@@ -32,7 +32,6 @@
       <th>Interval Label<br>Interval Length</th>
     </tr>
   </thead>
-  {{ report.report_parameters.start }}
   <tbody style="text-align: left; overflow-wrap: break-word;">
     {% for pfxobs in report.raw_report.processed_forecasts_observations %}
     <tr>


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #679 closes #678.
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
