### PR TITLE
plot all observation values in time series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ celerybeat-schedule
 *.sage.py
 
 # Environments
-.env
+.env*
 .venv
 env/
 venv/

--- a/docs/source/whatsnew/1.0.2.rst
+++ b/docs/source/whatsnew/1.0.2.rst
@@ -47,6 +47,9 @@ Fixed
   model upgrade. (:issue:`662`, :pull:`663`)
 * Worked around data gaps during ``CLEARSKY`` GHI validation that cause uneven
   frequencies which lead to skipping validation entirely (:pull:`673`)
+* Fixed issue with processed observations failing to be plotted due to a
+  missing forecast. Processed observations are now plotted for all
+  points for which there is a forecast. (:pull:`689`)
 
 Testing
 ~~~~~~~

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -706,7 +706,8 @@ def process_forecast_observations(forecast_observations, filters,
          resampled observation is NaN.
       5. Drop NaN observation values.
       6. Align observations to match forecast times. Observation times
-         for which there is not a matching forecast time are dropped.
+         for which there is not a matching forecast time are dropped on
+         a forecast by forecast basis.
       7. Create
          :py:class:`~solarforecastarbiter.datamodel.ProcessedForecastObservation`
          with resampled, aligned data and metadata.

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -378,8 +378,9 @@ def _plot_obs_timeseries(fig, timeseries_value_df, timeseries_meta_df):
             marker=dict(color=metadata['observation_color']),
             connectgaps=False,
             **plot_kwargs)
-        # collect in list
-        gos.append((metadata['pair_index'], go_))
+        # collect in list. sorting can safely be done on the first index.
+        first_pair_index = metadata['pair_index'].values[0]
+        gos.append((first_pair_index, go_))
     # Add traces in order of pair index
     for idx, go_ in sorted(gos, key=lambda x: x[0]):
         fig.add_trace(go_)

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -360,7 +360,9 @@ def _plot_obs_timeseries(fig, timeseries_value_df, timeseries_meta_df):
             metadata['pair_index']
         )
         duplicated = ts_this_obs_hash.index.duplicated()
-        ts_to_plot = timeseries_value_df[~duplicated]
+        # rows are initially ordered by pair_index, then dt index.
+        # now we only want the dt index and no longer care about the pair_index
+        ts_to_plot = timeseries_value_df[~duplicated].sort_index()
         plot_kwargs = plot_utils.line_or_step_plotly(
             metadata['interval_label'])
         data = _fill_timeseries(

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -362,6 +362,8 @@ def _plot_obs_timeseries(fig, timeseries_value_df, timeseries_meta_df):
         duplicated = ts_this_obs_hash.index.duplicated()
         # rows are initially ordered by pair_index, then dt index.
         # now we only want the dt index and no longer care about the pair_index
+        # _fill_timeseries will use index[0] and index[-1] to determine time
+        # range to plot, so failing to sort can prevent data from being plotted
         ts_to_plot = timeseries_value_df[~duplicated].sort_index()
         plot_kwargs = plot_utils.line_or_step_plotly(
             metadata['interval_label'])

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -246,6 +246,10 @@ def _fill_timeseries(df, interval_length):
 
 def _obs_name(fx_obs):
     # TODO: add code to ensure obs names are unique
+    # should be unique if plotting by hash and name includes
+    # pfxobs.interval_length, pfxobs.interval_value_type, pfxobs.interval_label
+    # name doens't need them if they are the same as the fx_obs parameters
+    # since that would guarantee uniqueness
     name = fx_obs.data_object.name
     if fx_obs.forecast.name == fx_obs.data_object.name:
         if isinstance(fx_obs.data_object, datamodel.Observation):
@@ -286,13 +290,20 @@ def _none_or_values0(metadata, key):
     return value
 
 
-def _extract_metadata_from_df(metadata_df, hash_, hash_key):
+def _extract_metadata_from_df(metadata_df, hash_, hash_key, keep_pairs=False):
+    # dataframe that is subset of total metadata dataframe
     metadata = metadata_df[metadata_df[hash_key] == hash_]
+    if keep_pairs:
+        pair_index = metadata['pair_index']
+    else:
+        pair_index = metadata['pair_index'].values[0]
+    # unclear why we don't use metadata.iloc[0] for most
     meta = {
-        'pair_index': metadata['pair_index'].values[0],
+        'pair_index': pair_index,
         'observation_name': metadata['observation_name'].values[0],
         'forecast_name': metadata['forecast_name'].values[0],
         'interval_label': metadata['interval_label'].values[0],
+        # np.timedelta64. unclear why we'd want this
         'interval_length': metadata['interval_length'].values[0],
         'observation_color': metadata['observation_color'].values[0],
     }
@@ -341,13 +352,19 @@ def _plot_obs_timeseries(fig, timeseries_value_df, timeseries_meta_df):
     gos = []
     # construct graph objects in random hash order
     for obs_hash in np.unique(timeseries_meta_df['observation_hash']):
+        # if observation is used multiple times, takes the plotting metadata
+        # from the first use of it but returns pair_index for all instances
         metadata = _extract_metadata_from_df(
-            timeseries_meta_df, obs_hash, 'observation_hash')
-        pair_idcs = timeseries_value_df['pair_index'] == metadata['pair_index']
+            timeseries_meta_df, obs_hash, 'observation_hash', keep_pairs=True)
+        ts_this_obs_hash = timeseries_value_df['pair_index'].isin(
+            metadata['pair_index']
+        )
+        duplicated = ts_this_obs_hash.index.duplicated()
+        ts_to_plot = timeseries_value_df[~duplicated]
         plot_kwargs = plot_utils.line_or_step_plotly(
             metadata['interval_label'])
         data = _fill_timeseries(
-            timeseries_value_df[pair_idcs],
+            ts_to_plot,
             metadata['interval_length'],
         )
         if data['observation_values'].isnull().all():


### PR DESCRIPTION


  - [ ] Closes #xxxx .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

The issue with the missing observations in time series plots is due to the fact that the processed observations are only plotted for the first instance of that processed observation. In the TA2 reports, the PNNL forecast is the first forecast/observation pair, so it gets the first pair index assigned to it during plotting. But that forecast has not yet been uploaded, so the observations are all dropped for that pair (recall missing forecasts are dropped on a forecast by forecast basis). And then there is nothing to plot.

This PR changes the observation plotting algorithm. The net result is that we plot the union of processed observations for all pairs.

Prod

<img width="827" alt="Screen Shot 2021-07-21 at 2 52 36 PM" src="https://user-images.githubusercontent.com/4383303/126565108-efde1c5c-aa8c-40a7-8bf7-67c6e2243716.png">

This PR

<img width="1120" alt="Screen Shot 2021-07-21 at 2 52 51 PM" src="https://user-images.githubusercontent.com/4383303/126565093-3449b307-661c-4892-b0d2-0ea51cbc5421.png">

I'm not aware of any good automated ways to test this.