### PR TITLE
clarify auto reference forecasts are arbiter only

### DIFF
--- a/docs/source/reference-forecasts.rst
+++ b/docs/source/reference-forecasts.rst
@@ -106,6 +106,11 @@ forecasts.
 Automated Generation
 ====================
 
+The Solar Forecast Arbiter runs workers that automatically create reference
+forecasts. This feature is currently limited to reference forecasts defined
+by the Arbiter itself. In the future we hope to extend this to user-defined
+reference forecasts.
+
 Automated generation of reference NWP forecasts is achieved by adding
 a set of parameters to a Forecast's extra_parameters (formatted as JSON).
 These parameters are:

--- a/docs/source/whatsnew/1.0.2.rst
+++ b/docs/source/whatsnew/1.0.2.rst
@@ -57,6 +57,8 @@ Fixed
   :py:func:`~reference_forecasts.persistence.persistence_probabilistic`.
   Hour ahead reference forecasts are replaced with day ahead reference
   forecasts. (:issue:`639`, :pull:`645`)
+* Clarified that automated generation of reference forecasts is currently
+  limited to privileged accounts. (:issue:`659`, :pull:`691`)
 
 Testing
 ~~~~~~~

--- a/docs/source/whatsnew/1.0.2.rst
+++ b/docs/source/whatsnew/1.0.2.rst
@@ -3,8 +3,8 @@
 .. py:currentmodule:: solarforecastarbiter
 
 
-1.0.2 (July ??, 2021)
--------------------------
+1.0.2 (July 22, 2021)
+---------------------
 
 Enhancements
 ~~~~~~~~~~~~


### PR DESCRIPTION


  - [x] Closes #659 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - ~Tests added.~
  - ~Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.~
  - ~Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
  - ~New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Also updates the whats new date.