### PR TITLE
Adjust summary table header forecast type check

### DIFF
--- a/docs/source/whatsnew/1.0.3.rst
+++ b/docs/source/whatsnew/1.0.3.rst
@@ -1,0 +1,30 @@
+.. _whatsnew_102:
+
+.. py:currentmodule:: solarforecastarbiter
+
+
+1.0.3 (August 02, 2021)
+---------------------
+
+Enhancements
+~~~~~~~~~~~~
+
+Fixed
+~~~~~
+* Fixed report summary statistics table always displaying event statistics.
+  (:issue:`694`)(:pull:`701`)
+
+Testing
+~~~~~~~
+
+Contributors
+~~~~~~~~~~~~
+
+* Will Holmgren (:ghuser:`wholmgren`)
+* Leland Boeman (:ghuser:`lboeman`)
+* Cliff Hansen (:ghuser:`cwhanse`)
+* Tony Lorenzo (:ghuser:`alorenzo175`)
+* Justin Sharp (:ghuser:`MrWindAndSolar`)
+* Aidan Tuohy
+* Adam Wigington (:ghuser:`awig`)
+* David Larson (:ghuser:`dplarson`)

--- a/docs/source/whatsnew/1.0.3.rst
+++ b/docs/source/whatsnew/1.0.3.rst
@@ -1,10 +1,10 @@
-.. _whatsnew_102:
+.. _whatsnew_103:
 
 .. py:currentmodule:: solarforecastarbiter
 
 
-1.0.3 (August 02, 2021)
----------------------
+1.0.3 (August 2, 2021)
+----------------------
 
 Enhancements
 ~~~~~~~~~~~~

--- a/docs/source/whatsnew/index.rst
+++ b/docs/source/whatsnew/index.rst
@@ -9,6 +9,7 @@ These are new features and improvements of note in each release.
 .. toctree::
    :maxdepth: 2
 
+   1.0.3
    1.0.2
    1.0.1
    1.0.0

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -168,13 +168,14 @@ def _get_render_kwargs(report, dash_url, with_timeseries):
         rendering.
     """
     # macros render columns for every allowed summary statistic, so be
-    # specific to avoid unnecessary blanks
+    # specific about which columns to include to avoid unnecessary blanks.
+
     # Check that the report is complete, and if the processed forecasts are
     # all event forecasts. Checking processed forecast pairs instead of
     # report_parameters.object pairs allows us to skip the step of loading
     # or shuffling around forecasts when working with a raw api response on
     # the dashboard without the aid of solarforecastarbiter.io.api's
-    # process_report_dict.
+    # process_report_dict. See issue 694 for context.
     if report.status == "complete" and all(
         type(x.original.forecast) is datamodel.EventForecast for x in
         report.raw_report.processed_forecasts_observations

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -169,9 +169,9 @@ def _get_render_kwargs(report, dash_url, with_timeseries):
     """
     # macros render columns for every allowed summary statistic, so be
     # specific to avoid unnecessary blanks
-    if all(
-        type(x.forecast) is datamodel.EventForecast for x in
-        report.report_parameters.object_pairs
+    if report.status == "complete" and all(
+        type(x.original.forecast) is datamodel.EventForecast for x in
+        report.raw_report.processed_forecasts_observations
     ):
         human_statistics = datamodel.ALLOWED_EVENT_SUMMARY_STATISTICS
     else:

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -169,6 +169,12 @@ def _get_render_kwargs(report, dash_url, with_timeseries):
     """
     # macros render columns for every allowed summary statistic, so be
     # specific to avoid unnecessary blanks
+    # Check that the report is complete, and if the processed forecasts are
+    # all event forecasts. Checking processed forecast pairs instead of
+    # report_parameters.object pairs allows us to skip the step of loading
+    # or shuffling around forecasts when working with a raw api response on
+    # the dashboard without the aid of solarforecastarbiter.io.api's
+    # process_report_dict.
     if report.status == "complete" and all(
         type(x.original.forecast) is datamodel.EventForecast for x in
         report.raw_report.processed_forecasts_observations

--- a/solarforecastarbiter/reports/tests/test_template.py
+++ b/solarforecastarbiter/reports/tests/test_template.py
@@ -146,6 +146,28 @@ def test__get_render_kwargs_with_series_exception(
     assert 'timeseries_prob_spec' not in kwargs
 
 
+def test__get_render_kwargs_no_param_object_pairs(
+        mocked_timeseries_plots, various_report_with_raw, dash_url,
+        with_series, expected_kwargs):
+    # regression test for #694
+    report_with_raw, report_type = various_report_with_raw
+    report_dict = report_with_raw.to_dict()
+    report_dict['report_parameters']['object_pairs'] = []
+    no_pair_report = datamodel.Report.from_dict(report_dict)
+    kwargs = template._get_render_kwargs(
+        no_pair_report,
+        dash_url,
+        with_series
+    )
+    kwargs.pop('report')
+    exp = expected_kwargs(
+        report_with_raw, with_series, report_type=report_type)
+    exp.pop('report')
+    # reports will now be different, but everything else should stay
+    # the same
+    assert kwargs == exp
+
+
 @pytest.fixture(params=[0, 1, 2])
 def good_or_bad_report(request, report_with_raw, failed_report,
                        pending_report):


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #694 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Bug was caused when checking `report.report_parameters.object_pairs` for event forecasts to set a list of correct summary table headers. The dashboard drops the `object_pairs` from reports before rendering to avoid having to load or insert metadata into the pairs since that data is available in the raw_report. 