### PR TITLE
fix prob pers time of day when interval_label=ending

### DIFF
--- a/docs/source/whatsnew/1.0.3.rst
+++ b/docs/source/whatsnew/1.0.3.rst
@@ -15,7 +15,8 @@ Fixed
   (:issue:`694`, :pull:`701`)
 * Fixed inability of
   :py:func:`~reference_forecasts.persistence.persistence_probabilistic_timeofday`
-  to account for ``interval_label='ending'``. (:issue:`700`, :pull:`703`)
+  to account for ``interval_label='ending'`` and improper accounting for
+  observation interval label when resampling. (:issue:`700`, :pull:`703`)
 
 Testing
 ~~~~~~~

--- a/docs/source/whatsnew/1.0.3.rst
+++ b/docs/source/whatsnew/1.0.3.rst
@@ -12,7 +12,10 @@ Enhancements
 Fixed
 ~~~~~
 * Fixed report summary statistics table always displaying event statistics.
-  (:issue:`694`)(:pull:`701`)
+  (:issue:`694`, :pull:`701`)
+* Fixed inability of
+  :py:func:`~reference_forecasts.persistence.persistence_probabilistic_timeofday`
+  to account for ``interval_label='ending'``. (:issue:`700`, :pull:`703`)
 
 Testing
 ~~~~~~~

--- a/docs/source/whatsnew/1.0.3.rst
+++ b/docs/source/whatsnew/1.0.3.rst
@@ -17,7 +17,6 @@ Fixed
   :py:func:`~reference_forecasts.persistence.persistence_probabilistic_timeofday`
   to account for ``interval_label='ending'`` and improper accounting for
   observation interval label when resampling. (:issue:`700`, :pull:`703`)
-  (:issue:`694`)(:pull:`701`)
 * Differentiated observations in report timeseries plot legend by adding
   interval length and interval label of the resampled observation.
   (:issue:`675`)(:pull:`703`)

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -584,6 +584,7 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
                            forecast_start, forecast_end,
                            observation.interval_length)
 
+    closed_obs = datamodel.CLOSED_MAPPING[observation.interval_label]
     closed = datamodel.CLOSED_MAPPING[interval_label]
     fx_index = pd.date_range(start=forecast_start, end=forecast_end,
                              freq=interval_length, closed=closed)
@@ -593,7 +594,7 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
     # unlike other functions in this module, we do need label=closed
     # here because we will match the resampled obs time of day to
     # the desired forecast time of day.
-    obs = obs.resample(interval_length, closed=closed, label=closed).mean()
+    obs = obs.resample(interval_length, closed=closed_obs, label=closed).mean()
     if obs.empty:
         raise ValueError("Insufficient data to match by time of day")
 

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -585,16 +585,18 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
                            observation.interval_length)
 
     closed_obs = datamodel.CLOSED_MAPPING[observation.interval_label]
-    closed = datamodel.CLOSED_MAPPING[interval_label]
+    closed_fx = datamodel.CLOSED_MAPPING[interval_label]
     fx_index = pd.date_range(start=forecast_start, end=forecast_end,
-                             freq=interval_length, closed=closed)
+                             freq=interval_length, closed=closed_fx)
 
     # observation data resampled to match forecast sampling
     obs = load_data(observation, data_start, data_end)
     # unlike other functions in this module, we do need label=closed
     # here because we will match the resampled obs time of day to
     # the desired forecast time of day.
-    obs = obs.resample(interval_length, closed=closed_obs, label=closed).mean()
+    obs = obs.resample(
+        interval_length, closed=closed_obs, label=closed_fx
+    ).mean()
     if obs.empty:
         raise ValueError("Insufficient data to match by time of day")
 

--- a/solarforecastarbiter/reference_forecasts/persistence.py
+++ b/solarforecastarbiter/reference_forecasts/persistence.py
@@ -171,6 +171,8 @@ def persistence_interval(observation, data_start, data_end, forecast_start,
     # put in nans if appropriate
     obs = obs.reindex(obs_index)
     # average data within bins of length interval_length
+    # label does not matter because we are going to strip the series
+    # down to its values
     persistence_quantity = obs.resample(interval_length,
                                         closed=closed_obs).mean()
 
@@ -476,6 +478,7 @@ def persistence_probabilistic(observation, data_start, data_end,
 
     # observation data resampled to match forecast sampling
     obs = load_data(observation, data_start, data_end)
+    # don't need label=closed because of how we assign fx values below.
     obs = obs.resample(interval_length, closed=closed).mean()
 
     if obs.empty:
@@ -587,7 +590,10 @@ def persistence_probabilistic_timeofday(observation, data_start, data_end,
 
     # observation data resampled to match forecast sampling
     obs = load_data(observation, data_start, data_end)
-    obs = obs.resample(interval_length, closed=closed).mean()
+    # unlike other functions in this module, we do need label=closed
+    # here because we will match the resampled obs time of day to
+    # the desired forecast time of day.
+    obs = obs.resample(interval_length, closed=closed, label=closed).mean()
     if obs.empty:
         raise ValueError("Insufficient data to match by time of day")
 

--- a/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
@@ -680,17 +680,17 @@ PROB_PERS_TOD_OBS_INDEX = pd.DatetimeIndex([
     ('ending', PROB_PERS_TOD_OBS_INDEX)
 ])
 @pytest.mark.parametrize('fx_interval_label_index', [
-    ('beginning', pd.DatetimeIndex(['20190514T0900Z'])),
-    ('ending', pd.DatetimeIndex(['20190514T1000Z']))
+    ('beginning', pd.DatetimeIndex(['20190514T0900Z'], freq='1h')),
+    ('ending', pd.DatetimeIndex(['20190514T1000Z'], freq='1h'))
 ])
 @pytest.mark.parametrize("obs_values,axis,constant_values,expected_values", [
     # constant_values = variable values
     # forecasts = percentiles [%]
-    ([0] * 22 + [20] * 22, 'x', [10, 20], [50, 100]),
+    ([0] * 22 + [20] * 22, 'x', [10, 20], [50., 100.]),
 
     # constant_values = percentiles [%]
     # forecasts = variable values
-    ([0] * 22 + [4] * 22, 'y', [50], [2]),
+    ([0] * 22 + [4] * 22, 'y', [50], [2.]),
 ])
 def test_persistence_probabilistic_timeofday_resample(
     site_metadata,
@@ -730,13 +730,10 @@ def test_persistence_probabilistic_timeofday_resample(
         interval_length, fx_interval_label, load_data, axis, constant_values
     )
     assert isinstance(forecasts, list)
-    for i, fx in enumerate(forecasts):
-        pd.testing.assert_index_equal(fx.index, expected_index,
-                                      check_categorical=False)
-
+    for expected, fx in zip(expected_values, forecasts):
         pd.testing.assert_series_equal(
             fx,
-            pd.Series(expected_values[i], index=expected_index, dtype=float)
+            pd.Series(expected, index=expected_index)
         )
 
 

--- a/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
@@ -686,11 +686,13 @@ PROB_PERS_TOD_OBS_INDEX = pd.DatetimeIndex([
 @pytest.mark.parametrize("obs_values,axis,constant_values,expected_values", [
     # constant_values = variable values
     # forecasts = percentiles [%]
-    ([0] * 22 + [20] * 22, 'x', [10, 20], [50., 100.]),
+    # intervals always average to 10 if done properly, but 0 or 20 if
+    # done improperly
+    ([0, 20] * 22, 'x', [10, 20], [100., 100.]),
 
     # constant_values = percentiles [%]
     # forecasts = variable values
-    ([0] * 22 + [4] * 22, 'y', [50], [2.]),
+    ([0, 4] * 22, 'y', [50], [2.]),
 ])
 def test_persistence_probabilistic_timeofday_resample(
     site_metadata,

--- a/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
+++ b/solarforecastarbiter/reference_forecasts/tests/test_persistence.py
@@ -646,6 +646,7 @@ def test_persistence_probabilistic_resampling(
         )
 
 
+@pytest.mark.parametrize('interval_label', ['beginning', 'ending'])
 @pytest.mark.parametrize("obs_values,axis,constant_values,expected_values", [
     # constant_values = variable values
     # forecasts = percentiles [%]
@@ -660,11 +661,11 @@ def test_persistence_probabilistic_timeofday_resample(
     obs_values,
     axis,
     constant_values,
-    expected_values
+    expected_values,
+    interval_label
 ):
 
     tz = 'UTC'
-    interval_label = "beginning"
     observation = default_observation(
         site_metadata,
         interval_length='30min',


### PR DESCRIPTION

  - [x] Closes #700 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - ~Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.~
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

pre fix:

<img width="740" alt="Screen Shot 2021-07-30 at 1 19 30 PM" src="https://user-images.githubusercontent.com/4383303/127707584-3f57c06e-36e4-4509-abe5-4132eb9c2581.png">

post fix:

<img width="734" alt="Screen Shot 2021-07-30 at 1 19 40 PM" src="https://user-images.githubusercontent.com/4383303/127707579-9d8012d5-1506-4788-83a0-b1befaef8006.png">

I confirmed that the modified test does fail unless the fix is implemented.

FYI @dplarson (not trying to cast blame - just thought you might like to know since you're continuing to work on similar problems!)