### PR TITLE
Gefs throttling

### DIFF
--- a/solarforecastarbiter/io/fetch/nwp.py
+++ b/solarforecastarbiter/io/fetch/nwp.py
@@ -57,6 +57,12 @@ logger = logging.getLogger(__name__)
 CHECK_URL = 'https://nomads.ncep.noaa.gov/pub/data/nccf/com/{}/prod'
 BASE_URL = 'https://nomads.ncep.noaa.gov/cgi-bin/'
 
+GEFS_BASE_URL = 'https://noaa-gefs-pds.s3.amazonaws.com'
+
+# When querying aws for directories, start-after is used to paginate.
+# 2020-09-23 is the date the expected folder structure with the atmos
+# dir appears.
+GEFS_STARTAFTER = 'gefs.20200923'
 
 GFS_0P25_1HR = {'endpoint': 'filter_gfs_0p25_1hr.pl',
                 'file': 'gfs.t{init_hr:02d}z.pgrb2.0p25.f{valid_hr:03d}',
@@ -288,7 +294,10 @@ async def get_available_dirs(session, model):
     """Get the available date/date+init_hr directories"""
     simple_model = _simple_model(model)
     is_init_date = 'init_date' in model['dir']
-    model_url = BASE_URL + model['endpoint']
+    if simple_model == 'gefs':
+        return await get_available_gefs_dirs(session)
+    else:
+        model_url = BASE_URL + model['endpoint']
 
     async def _get(model_url):
         async with session.get(model_url, raise_for_status=True) as r:
@@ -302,6 +311,32 @@ async def get_available_dirs(session, model):
         list_avail_days = set(
             re.findall(simple_model + '\\.([0-9]{10})', page))
     return list_avail_days
+
+
+@abort_all_on_exception
+async def get_available_gefs_dirs(session, start_after=GEFS_STARTAFTER):
+    params = {
+        'list-type': 2,
+        'delimiter': '/',
+    }
+    if start_after is not None:
+        params['start-after'] = start_after
+    async def _get(session):
+        async with session.get(
+            GEFS_BASE_URL,
+            params=params,
+            raise_for_status=True
+        ) as r:
+            return await r.text()
+    listing = await _get(session)
+    all_dirs = re.findall("gefs\\.([0-9]{8})", listing)
+    if len(all_dirs) < 1000:
+        return all_dirs
+    else:
+        return all_dirs + await get_available_gefs_dirs(
+            session,
+            'gefs.'+all_dirs[-1]
+        )
 
 
 def _process_params(model, init_time):
@@ -371,9 +406,13 @@ async def files_to_retrieve(session, model, modelpath, init_time):
         if filename.exists():
             yield next_params
             continue
-        next_model_url = (CHECK_URL.format(model.get('check_url_name',
-                                                     simple_model))
-                          + next_params['dir'] + '/' + next_params['file'])
+        if simple_model == 'gefs':
+            next_model_url = (GEFS_BASE_URL + next_params['dir']
+                              + '/' + next_params['file'])
+        else:
+            next_model_url = (CHECK_URL.format(model.get('check_url_name',
+                                                         simple_model))
+                              + next_params['dir'] + '/' + next_params['file'])
         while True:
             # is the next file ready?
             try:
@@ -465,8 +504,11 @@ async def fetch_grib_files(session, params, basepath, init_time, chunksize):
     aiohttp.ClientResponseError
         When the HTTP request fails/returns a status code >= 400
     """
-    endpoint = params.pop('endpoint')
-    url = BASE_URL + endpoint
+    if _simple_model(params) == 'gefs':
+        url = GEFS_BASE_URL + params['dir'] + '/' + params['file']
+    else:
+        endpoint = params.pop('endpoint')
+        url = BASE_URL + endpoint
     filename = get_filename(basepath, init_time, params)
     if filename.exists():
         return filename

--- a/solarforecastarbiter/io/fetch/nwp.py
+++ b/solarforecastarbiter/io/fetch/nwp.py
@@ -60,8 +60,8 @@ BASE_URL = 'https://nomads.ncep.noaa.gov/cgi-bin/'
 GEFS_BASE_URL = 'https://noaa-gefs-pds.s3.amazonaws.com'
 
 # When querying aws for directories, start-after is used to paginate.
-# 2020-09-23 is the date the expected folder structure with the atmos
-# dir appears.
+# 2021-01-01 is the date the expected files and folder structure
+# appears.
 GEFS_STARTAFTER = 'gefs.20210101'
 
 GFS_0P25_1HR = {'endpoint': 'filter_gfs_0p25_1hr.pl',
@@ -433,7 +433,6 @@ async def files_to_retrieve(session, model, modelpath, init_time):
                         'Next file not ready yet for %s at %s %s\n%s %s',
                         simple_model, init_time, model.get('member', ''),
                         e.status, e.message)
-                    logger.debug(next_model_url)
                 else:
                     logger.error(
                         'Error checking if next file is ready %s\n'


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #680 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
This moves fetching for GEFS to AWS. It could probably use some reorganization but this works as is. This is quite a bit slower and moves ~10x the data over the network because we need to fetch the full gefs files and then slice within the lat/lon domain of interest instead of having nomads do that slicing for us.

I took a look at #696 and  https://www.weather.gov/media/notification/pdf2/pns20-85ncep_web_access.pdf, and it appears that any of the cli commands that hit nomads are going to contribute to our hitting this rate  limit. So moving at least one of the models off of nomads will help to alleviate some of the strain at the cost of bandwitdth/speed.  We may need to address  #696 separately to handle size 0 responses, but I'm not sure of a good way to throttle the async requests down to a maximum of 60 requests per minute across processes. 