### PR TITLE
Fix headers and indexes of report timeseries downloads

### DIFF
--- a/docs/source/whatsnew/1.0.5.rst
+++ b/docs/source/whatsnew/1.0.5.rst
@@ -17,6 +17,11 @@ Fixed
 * Added missing ``jinja2`` and ``pytz`` dependencies. We got away with
   it because other dependencies pulled in these packages.
   (:issue:`715`, :pull:`720`)
+* Fixed incorrect time indices in CSV downloads for report timeseries
+  for reports including multiple time intervals. Reports now provide
+  one file per observation or forecast. (:issue: `707`, :issue:`713`, :pull: `722`)
+* Removed html line break tags from report timeseries csv headers.
+  (:issue: `706`, :pull: `722`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/docs/source/whatsnew/1.0.5.rst
+++ b/docs/source/whatsnew/1.0.5.rst
@@ -19,9 +19,9 @@ Fixed
   (:issue:`715`, :pull:`720`)
 * Fixed incorrect time indices in CSV downloads for report timeseries
   for reports including multiple time intervals. Reports now provide
-  one file per observation or forecast. (:issue: `707`, :issue:`713`, :pull: `722`)
+  one file per observation or forecast. (:issue:`707`, :issue:`713`, :pull:`722`)
 * Removed html line break tags from report timeseries csv headers.
-  (:issue: `706`, :pull: `722`)
+  (:issue:`706`, :pull:`722`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -132,8 +132,10 @@
   The plots below show the filtered, resampled, and aligned time series of
   observation and forecast data as well as the distribution of forecast vs.
   observation data.
-  This resampled and realigned timeseries data may also be downloaded in
-  <a href="javascript:download_timeseries_data_as_csv('{{ report_name }}')">CSV format</a>.
+  This resampled and realigned timeseries data may also be downloaded below.
+  <details id="timeseries-downloads">
+    <summary style="border-bottom: #dee2e6;">Download Timeseries</summary>
+  </details>
 </p>
 
 <p>Controls to pan, zoom, and save the plot are shown on the

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -152,7 +152,7 @@ right. Clicking on an item in the legend will hide/show it.</p>
 {% endif %}
 
 <script>
-ts_plot = JSON.parse('{{ timeseries_spec | safe }}');
+var ts_plot = JSON.parse('{{ timeseries_spec | safe }}');
 Object.assign(ts_plot,{config: {responsive: true}});
 Plotly.newPlot("timeseries-div", ts_plot);
 </script>

--- a/solarforecastarbiter/reports/templates/html/macros.j2
+++ b/solarforecastarbiter/reports/templates/html/macros.j2
@@ -504,7 +504,9 @@ forecasts/single/{{ forecast.forecast_id }}
     function download_timeseries_data_as_csv(ts_names) {
         const csvdata = extract_plotly_data(ts_plot, ts_names)
         for (const csvname in csvdata){
-          const filename = csvname.replace(/ /g, '_') + '_timeseries.csv'
+          // replace spaces with underscores and remove commonly forbidden
+          // filename characters
+          const filename = csvname.replace(/ /g, '_').replace(/[<>:"/\|?*]/g,'') + '_timeseries.csv'
           const blob = new Blob([csvdata[csvname]], { type: 'text/csv;charset=utf-8;' })
             {{ getblob }}
         }

--- a/solarforecastarbiter/reports/templates/html/macros.j2
+++ b/solarforecastarbiter/reports/templates/html/macros.j2
@@ -377,7 +377,7 @@ forecasts/single/{{ forecast.forecast_id }}
       const lines = [];
 
       for (let j = 0; j < ncolumns; j++) {
-        colnames.push(data[j].legendgroup)
+        colnames.push(data[j].legendgroup.replace(/\<br\>/g, ' '))
       }
       lines.push(colnames.join(','))
 

--- a/solarforecastarbiter/reports/templates/html/macros.j2
+++ b/solarforecastarbiter/reports/templates/html/macros.j2
@@ -368,6 +368,41 @@ forecasts/single/{{ forecast.forecast_id }}
 
 {% macro download_timeseries_script() %}
 <script>
+    function strip_constant_value_from_hovertext(hovertext) {
+        const end = hovertext.indexOf('<br>');
+        const constant_value = hovertext.slice(3, end).trim();
+        return constant_value;
+    }
+
+    function extract_distribution_data(data, distribution_name) {
+        // Collect all of the constant values in a single csv
+        const dist_values = data.filter(column => column.name == distribution_name && !column.showlegend);
+        const dist_percentages = dist_values.map(
+          series => strip_constant_value_from_hovertext(series.hovertemplate)
+        );
+        const index = dist_values[0].x;
+        let lines = [];
+        // push header
+        lines.push("timestamp,"+ dist_percentages.join(','));
+        const nrows = index.length;
+
+        for (let j = 0; j < nrows; j++) {
+            let row = [];
+            row.push(index[j])
+            for (let i = 0; i < dist_percentages.length; i++) {
+              let val = dist_values[i].y[j];
+              if(val == null){
+                val = 'nan';
+              }else{
+                val = val.toString()
+              }
+              row.push(val)
+            }
+            lines.push(row.join(','))
+        }
+        return lines.join('\n').concat('\n')
+    }
+
     function extract_plotly_data(plot, ts_names=null) {
       if (typeof plot === 'undefined') { return ''}
       const data = plot.data;
@@ -396,11 +431,38 @@ forecasts/single/{{ forecast.forecast_id }}
         }
         return lines
       }
-      let col_idxs;
+      // col_idxs is an array of integer indexes we can parse from the plot data
+      // directly
+      let col_idxs = [];
+
+      // dist names is an array of string names that are shared by all
+      // series in a distribution. We will use it to parse out the series
+      // for each constant value in the distribution.
+      let dist_names = [];
+
+      function get_all_indices(to_search, value) {
+        let indices = [];
+        let i = to_search.indexOf(value);
+        while(i >= 0) {
+          indices.push(i);
+          i = to_search.indexOf(value, i+1);
+        }
+        return indices;
+      }
+
       if (ts_names != null) {
         // if a timeseries name was provided, only extract data
         // for that series
-        col_idxs = ts_names.map((ts_name) => colnames.indexOf(ts_name));
+        for (ts_name of ts_names) {
+          let indices = get_all_indices(colnames, ts_name);
+          if (indices.length) {
+            if (indices.length == 1) {
+              col_idxs.push(indices[0]);
+            } else {
+              dist_names.push(ts_name);
+            }
+          }
+        }
       } else {
         col_idxs = colnames;
       }
@@ -413,6 +475,9 @@ forecasts/single/{{ forecast.forecast_id }}
         const lines = get_column_lines(col_idx)
         csvs[colnames[col_idx]] = lines.join('\n').concat('\n');
       } 
+      for (const dist_name of dist_names) {
+        csvs[dist_name] = extract_distribution_data(data, dist_name);
+      }
       return csvs;
     }
 
@@ -444,8 +509,9 @@ forecasts/single/{{ forecast.forecast_id }}
                 ).map(checkbox => checkbox.checked = true);
                 update_file_count();
             }
-
-            let columns = ts_plot.data.map(d => d.name.replace(/\<br\>/g, ' '));
+            let series_names = ts_plot.data.map(d => d.name.replace(/\<br\>/g, ' '));
+            // remove duplicates
+            let columns = series_names.filter((val, idx, arr) => arr.indexOf(val) === idx);
             const table = document.createElement("table");
             table.classList.add("table");
             const thead = document.createElement("thead");

--- a/solarforecastarbiter/reports/templates/html/macros.j2
+++ b/solarforecastarbiter/reports/templates/html/macros.j2
@@ -426,10 +426,23 @@ forecasts/single/{{ forecast.forecast_id }}
         download_container.style.padding = ".5em";
 
         if (download_container) {
+            function update_file_count() {
+                let count = document.querySelectorAll('[name=download-flag]:checked').length;
+                let download_button = document.getElementById("download-timeseries-button");
+                let buttonText = `Download ${count} CSVs`;
+                if (count == 0) {
+                    buttonText = "Select CSVs to download";
+                    download_button.disabled = true;
+                } else {
+                    download_button.disabled = false;
+                }
+                download_button.textContent = buttonText;
+            }
             function select_all_downloads() {
                 Array.from(
                     document.querySelectorAll('[name=download-flag]')
                 ).map(checkbox => checkbox.checked = true);
+                update_file_count();
             }
 
             let columns = ts_plot.data.map(d => d.name.replace(/\<br\>/g, ' '));
@@ -461,6 +474,7 @@ forecasts/single/{{ forecast.forecast_id }}
 
                 const download_td = document.createElement("td");
                 const download_checkbox = document.createElement("input");
+                download_checkbox.onclick = update_file_count;
                 download_checkbox.setAttribute("name", "download-flag");
                 download_checkbox.setAttribute("value", col_name);
                 download_checkbox.setAttribute("type", "checkbox");
@@ -478,7 +492,9 @@ forecasts/single/{{ forecast.forecast_id }}
                 download_timeseries_data_as_csv(selected);
             }
             const download_button = document.createElement("button");
-            download_button.appendChild(document.createTextNode("Download CSVS"));
+            download_button.id = "download-timeseries-button";
+            download_button.disabled = true;
+            download_button.appendChild(document.createTextNode("Select CSVs to download"));
             download_button.classList.add("btn", "btn-sm", "btn-primary");
             download_button.onclick = download_selected;
             download_container.appendChild(download_button);

--- a/solarforecastarbiter/reports/templates/html/macros.j2
+++ b/solarforecastarbiter/reports/templates/html/macros.j2
@@ -371,38 +371,42 @@ forecasts/single/{{ forecast.forecast_id }}
     function extract_plotly_data(plot) {
       if (typeof plot === 'undefined') { return ''}
       const data = plot.data;
-      const ncolumns = data.length;
-      const nrows = data[0].x.length;
-      const colnames = [''];
-      const lines = [];
+      const colnames = data.map(d => d.name.replace(/\<br\>/g, ' '));
+      const indexes = data.map(d => d.x);
+      const values = data.map(d => d.y);
+      const csvs = {};
 
-      for (let j = 0; j < ncolumns; j++) {
-        colnames.push(data[j].legendgroup.replace(/\<br\>/g, ' '))
-      }
-      lines.push(colnames.join(','))
-
-      for (let i = 0; i < nrows; i++) {
-        let row = [];
-        row.push(data[0].x[i])
-        for (let j = 0; j < ncolumns; j++) {
-          let val = data[j].y[i]
+      for (let i = 0; i < data.length; i++) {
+        let lines = [];
+        // push header
+        lines.push("timestamp,"+ colnames[i]);
+        const nrows = indexes[i].length;
+        for (let j = 0; j < nrows; j++) {
+          let row = [];
+          row.push(indexes[i][j])
+          let val = values[i][j];
           if(val == null){
             val = 'nan';
           }else{
             val = val.toString()
           }
           row.push(val)
+          
+          lines.push(row.join(','))
         }
-        lines.push(row.join(','))
-      }
-      return lines.join('\n').concat('\n')
+        csvs[colnames[i]] = lines.join('\n').concat('\n');
+      } 
+      return csvs;
     }
 
     function download_timeseries_data_as_csv(report_name) {
-        const filename = report_name.replace(/ /g, '_') + '_timeseries.csv'
+        
         const csvdata = extract_plotly_data(ts_plot)
-        const blob = new Blob([csvdata], { type: 'text/csv;charset=utf-8;' })
-        {{ getblob }}
+        for (const csvname in csvdata){
+          const filename = csvname.replace(/ /g, '_') + '_timeseries.csv'
+          const blob = new Blob([csvdata[csvname]], { type: 'text/csv;charset=utf-8;' })
+            {{ getblob }}
+        }
     }
 </script>
 {% endmacro %}

--- a/solarforecastarbiter/reports/templates/html/macros.j2
+++ b/solarforecastarbiter/reports/templates/html/macros.j2
@@ -368,7 +368,7 @@ forecasts/single/{{ forecast.forecast_id }}
 
 {% macro download_timeseries_script() %}
 <script>
-    function extract_plotly_data(plot) {
+    function extract_plotly_data(plot, ts_names=null) {
       if (typeof plot === 'undefined') { return ''}
       const data = plot.data;
       const colnames = data.map(d => d.name.replace(/\<br\>/g, ' '));
@@ -376,15 +376,15 @@ forecasts/single/{{ forecast.forecast_id }}
       const values = data.map(d => d.y);
       const csvs = {};
 
-      for (let i = 0; i < data.length; i++) {
+      function get_column_lines(column_index) {
         let lines = [];
         // push header
-        lines.push("timestamp,"+ colnames[i]);
-        const nrows = indexes[i].length;
+        lines.push("timestamp,"+ colnames[column_index]);
+        const nrows = indexes[column_index].length;
         for (let j = 0; j < nrows; j++) {
           let row = [];
-          row.push(indexes[i][j])
-          let val = values[i][j];
+          row.push(indexes[column_index][j])
+          let val = values[column_index][j];
           if(val == null){
             val = 'nan';
           }else{
@@ -394,19 +394,107 @@ forecasts/single/{{ forecast.forecast_id }}
           
           lines.push(row.join(','))
         }
-        csvs[colnames[i]] = lines.join('\n').concat('\n');
+        return lines
+      }
+      let col_idxs;
+      if (ts_names != null) {
+        // if a timeseries name was provided, only extract data
+        // for that series
+        col_idxs = ts_names.map((ts_name) => colnames.indexOf(ts_name));
+      } else {
+        col_idxs = colnames;
+      }
+      for (const col_idx of col_idxs) {
+        if (col_idx < 0) {
+          // if col_idx is negative, a column was provided that does not exist in
+          // the data
+          continue;
+        }
+        const lines = get_column_lines(col_idx)
+        csvs[colnames[col_idx]] = lines.join('\n').concat('\n');
       } 
       return csvs;
     }
 
-    function download_timeseries_data_as_csv(report_name) {
-        
-        const csvdata = extract_plotly_data(ts_plot)
+    function make_download_table() {
+        // Adds a table of timeseries names and download checkboxes
+        // to the collapsible "details" element above the timeseries
+        let download_container = document.getElementById("timeseries-downloads");
+        // css here to include in downloads
+        download_container.style.border = "1px solid #dee2e6";
+        download_container.style["border-radius"] = ".5em";
+        download_container.style.padding = ".5em";
+
+        if (download_container) {
+            function select_all_downloads() {
+                Array.from(
+                    document.querySelectorAll('[name=download-flag]')
+                ).map(checkbox => checkbox.checked = true);
+            }
+
+            let columns = ts_plot.data.map(d => d.name.replace(/\<br\>/g, ' '));
+            const table = document.createElement("table");
+            table.classList.add("table");
+            const thead = document.createElement("thead");
+            const th_row = document.createElement("tr");
+            thead.appendChild(th_row);
+            const name_thead = document.createElement("th");
+            name_thead.appendChild(document.createTextNode("Name"));
+            th_row.appendChild(name_thead);
+            const download_thead = document.createElement("th");
+            download_thead.appendChild(document.createTextNode("Download "));
+            let check_all = document.createElement("button");
+            check_all.classList.add("btn", "btn-sm", "btn-primary");
+            check_all.appendChild(document.createTextNode("check all"));
+            check_all.onclick = select_all_downloads;
+            download_thead.appendChild(check_all);
+            th_row.appendChild(download_thead);
+            thead.appendChild(th_row);
+            table.appendChild(thead);
+            const tbody = document.createElement("tbody");
+
+            for (const col_name of columns) {
+                const tr = document.createElement("tr");
+                const name_td = document.createElement("td");
+                name_td.appendChild(document.createTextNode(col_name));
+                tr.appendChild(name_td);
+
+                const download_td = document.createElement("td");
+                const download_checkbox = document.createElement("input");
+                download_checkbox.setAttribute("name", "download-flag");
+                download_checkbox.setAttribute("value", col_name);
+                download_checkbox.setAttribute("type", "checkbox");
+                download_td.appendChild(download_checkbox);
+                tr.appendChild(download_td);
+                tbody.appendChild(tr);
+            }
+            table.appendChild(tbody);
+            download_container.appendChild(table);
+
+            function download_selected() {
+                const selected = Array.from(
+                    document.querySelectorAll('[name=download-flag]:checked')
+                ).map(x => x.value);
+                download_timeseries_data_as_csv(selected);
+            }
+            const download_button = document.createElement("button");
+            download_button.appendChild(document.createTextNode("Download CSVS"));
+            download_button.classList.add("btn", "btn-sm", "btn-primary");
+            download_button.onclick = download_selected;
+            download_container.appendChild(download_button);
+        }
+    }
+
+    function download_timeseries_data_as_csv(ts_names) {
+        const csvdata = extract_plotly_data(ts_plot, ts_names)
         for (const csvname in csvdata){
           const filename = csvname.replace(/ /g, '_') + '_timeseries.csv'
           const blob = new Blob([csvdata[csvname]], { type: 'text/csv;charset=utf-8;' })
             {{ getblob }}
         }
+    }
+    if (ts_plot) {
+        make_download_table();
     }
 </script>
 {% endmacro %}


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #707, closes #706, closes #713.
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Removes the `<br>` tags included in csv headers for report timeseries downloads, and separates each timeseries into a separate download.  Triggering a bunch of subsequent data downloads is pretty jarring, so perhaps inserting links to download each one individually would be better?
We could use something like [JSZip](https://stuk.github.io/jszip/) to create a zip, but I that is complicated by the need to supply the library in downloaded copies and include it in dashboard rendered reports.

@wholmgren What do you think about adding links to download each timeseries individually?