### PR TITLE
Add heavy line to separate obs, fx, ref fx in summary table

### DIFF
--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -31,6 +31,16 @@
       width: fit-content;
       font-weight: 700
   }
+  /*Add bold lines between observation/forecast/reference forecast in summary table*/
+  .report-table-wrapper table.summary-stats-table-vert th[colspan="5"]:not(first-child) {
+      border-right: 2px solid black;
+  }
+  .report-table-wrapper table.summary-stats-table-vert tr:nth-child(2) th:nth-child(5n+6) {
+      border-right: 2px solid black;
+  }
+  .report-table-wrapper table.summary-stats-table-vert tr:nth-child(n+1) td:nth-child(5n+6) {
+      border-right: 2px solid black;
+  }
 </style>
 {% block report_title %}
 <h1 id="report-title">{{ report_name }}</h1>


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #724 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
