### PR TITLE
exclude report outage periods

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -554,6 +554,8 @@ Functions for preparing the timeseries data before calculating metrics:
    metrics.preprocessing.filter_resample
    metrics.preprocessing.align
    metrics.preprocessing.process_forecast_observations
+   metrics.preprocessing.get_outage_periods
+   metrics.preprocessing.remove_outage_periods
 
 Deterministic
 -------------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -554,7 +554,7 @@ Functions for preparing the timeseries data before calculating metrics:
    metrics.preprocessing.filter_resample
    metrics.preprocessing.align
    metrics.preprocessing.process_forecast_observations
-   metrics.preprocessing.get_outage_periods
+   metrics.preprocessing.outage_periods
    metrics.preprocessing.remove_outage_periods
 
 Deterministic

--- a/docs/source/whatsnew/1.0.9.rst
+++ b/docs/source/whatsnew/1.0.9.rst
@@ -25,3 +25,8 @@ Enhancements
 ~~~~~~~~~~~~
 * Added handling of outage periods to report preprocessing.
 
+Contributors
+~~~~~~~~~~~~
+
+* Will Holmgren (:ghuser:`wholmgren`)
+* Leland Boeman (:ghuser:`lboeman`)

--- a/docs/source/whatsnew/1.0.9.rst
+++ b/docs/source/whatsnew/1.0.9.rst
@@ -3,7 +3,7 @@
 .. py:currentmodule:: solarforecastarbiter
 
 
-1.0.9 (November 29, 2021)
+1.0.9 (December ??, 2021)
 -------------------------
 
 API Changes

--- a/docs/source/whatsnew/1.0.9.rst
+++ b/docs/source/whatsnew/1.0.9.rst
@@ -8,11 +8,13 @@
 
 API Changes
 ~~~~~~~~~~~
-* Added :py:class:`~solarforecastarbiter.datamodel.TimePeriod` for keeping track of
-  time ranges.
+* Added :py:class:`~solarforecastarbiter.datamodel.TimePeriod` for defining simple time
+  time ranges with a start and end.
 * Added `outages` field to :py:class:`~solaforecastarbiter.datamodel.Report` which
-  represents outages to exclude from a report with a list of
-  :py:class:`~solarforecastarbiter.datamodel.TimePeriod` objects.
+  represents outages to exclude from a report with a tuple of
+  :py:class:`~solarforecastarbiter.datamodel.TimePeriod` objects. For backward
+  compatibility, instantiating a report from existing reports without this field
+  results in an empty tuple.
 * Added optional `outages` argument to the preprocessing functions
   :py:func:`~solarforecastarbiter.metrics.preprocessing.process_forecast_observations`
   and
@@ -21,5 +23,5 @@ API Changes
 
 Enhancements
 ~~~~~~~~~~~~
-* Added outage tracking to preprocessing functions.
+* Added handling of outage periods to report preprocessing.
 

--- a/docs/source/whatsnew/1.0.9.rst
+++ b/docs/source/whatsnew/1.0.9.rst
@@ -1,0 +1,25 @@
+.. _whatsnew_109:
+
+.. py:currentmodule:: solarforecastarbiter
+
+
+1.0.9 (November ??, 2021)
+------------------------
+
+API Changes
+~~~~~~~~~~~
+* Added :py:class:`~solarforecastarbiter.datamodel.TimePeriod` for keeping track of
+  time ranges.
+* Added `outages` field to :py:class:`~solaforecastarbiter.datamodel.Report` which
+  represents outages to exclude from a report with a list of
+  :py:class:`~solarforecastarbiter.datamodel.TimePeriod` objects.
+* Added optional `outages` argument to the preprocessing functions
+  :py:func:`~solarforecastarbiter.metrics.preprocessing.process_forecast_observations`
+  and
+  :py:func:`~solarforecastarbiter.metrics.preprocessing.filter_resample`. Current
+  code will not require an update.
+
+Enhancements
+~~~~~~~~~~~~
+* Added outage tracking to preprocessing functions.
+

--- a/docs/source/whatsnew/index.rst
+++ b/docs/source/whatsnew/index.rst
@@ -9,6 +9,7 @@ These are new features and improvements of note in each release.
 .. toctree::
    :maxdepth: 2
 
+   1.0.9
    1.0.8
    1.0.7
    1.0.6

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ EXTRAS_REQUIRE = {
         'bokeh>=1.4.0, <2',
         'matplotlib',
         'plotly>=4.5.0, <5',
-        'selenium',
+        'selenium<4',
         'jinja2',
     ],
     'doc': ['sphinx<2.0', 'sphinx_rtd_theme']

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1740,11 +1740,29 @@ def report_objects(aggregate, ref_forecast_id):
         forecast_fill_method='forward',
         costs=(cost,)
     )
+
     report = datamodel.Report(
         report_id="56c67770-9832-11e9-a535-f4939feddd82",
         report_parameters=report_params
     )
     return report, observation, forecast_0, forecast_1, aggregate, forecast_agg
+
+
+@pytest.fixture
+def report_objects_with_outages(report_objects):
+    report_outages = (datamodel.TimePeriod(
+        start=pd.Timestamp("20190401T0600Z"),
+        end=pd.Timestamp("20190401T0800Z")
+    ),)
+    new_report = report_objects[0].replace(outages=report_outages)
+    return (
+        new_report,
+        report_objects[1],
+        report_objects[2],
+        report_objects[3],
+        report_objects[4],
+        report_objects[5]
+    )
 
 
 @pytest.fixture

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -4052,9 +4052,9 @@ def outage_preprocessing_result_types(preprocessing_result_types):
 
 
 @pytest.fixture()
-def raw_report(report_objects_with_outages, report_metrics, outage_preprocessing_result_types,
+def raw_report_with_outages(report_objects_with_outages, report_metrics, outage_preprocessing_result_types,
                ref_forecast_id, fail_pdf, constant_cost):
-    report, obs, fx0, fx1, agg, fxagg = report_objects
+    report, obs, fx0, fx1, agg, fxagg = report_objects_with_outages
 
     def gen(with_series):
         def ser(interval_length):
@@ -4168,3 +4168,13 @@ def raw_report(report_objects_with_outages, report_metrics, outage_preprocessing
             processed_forecasts_observations=(fxobs0, fxobs1, fxagg_))
         return raw
     return gen
+
+
+@pytest.fixture()
+def outage_report_with_raw(report_objects_with_outages, raw_report_with_outages):
+    report = report_objects_with_outages[0]
+    report = report.replace(
+        raw_report=raw_report_with_outages(True),
+        status='complete'
+    )
+    return report

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -4052,8 +4052,11 @@ def outage_preprocessing_result_types(preprocessing_result_types):
 
 
 @pytest.fixture()
-def raw_report_with_outages(report_objects_with_outages, report_metrics, outage_preprocessing_result_types,
-               ref_forecast_id, fail_pdf, constant_cost):
+def raw_report_with_outages(
+    report_objects_with_outages, report_metrics,
+    outage_preprocessing_result_types,
+    ref_forecast_id, fail_pdf, constant_cost
+):
     report, obs, fx0, fx1, agg, fxagg = report_objects_with_outages
 
     def gen(with_series):
@@ -4171,7 +4174,9 @@ def raw_report_with_outages(report_objects_with_outages, report_metrics, outage_
 
 
 @pytest.fixture()
-def outage_report_with_raw(report_objects_with_outages, raw_report_with_outages):
+def outage_report_with_raw(
+    report_objects_with_outages, raw_report_with_outages
+):
     report = report_objects_with_outages[0]
     report = report.replace(
         raw_report=raw_report_with_outages(True),

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1994,6 +1994,8 @@ class Report(BaseModel):
         ID of the report in the API
     provider : str, optional
         Provider of the Report information.
+    outages: Tuple[TimePeriod, ...], optional
+        List of report outage periods.
     __version__ : str
         Should be used to version reports to ensure even older
         reports can be properly rendered

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1968,6 +1968,12 @@ class ReportParameters(BaseModel):
 
 
 @dataclass(frozen=True)
+class ReportOutage(BaseModel):
+    start: pd.Timestamp
+    end: pd.Timestamp
+
+
+@dataclass(frozen=True)
 class Report(BaseModel):
     """Class for keeping track of report metadata and the raw report that
     can later be rendered to HTML or PDF. Functions in
@@ -1998,6 +2004,7 @@ class Report(BaseModel):
     status: str = 'pending'
     report_id: str = ''
     provider: str = ''
+    outages: Tuple[ReportOutage, ...] = ()
     __version__: int = 0  # should add version to api
 
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1968,7 +1968,7 @@ class ReportParameters(BaseModel):
 
 
 @dataclass(frozen=True)
-class ReportOutage(BaseModel):
+class TimePeriod(BaseModel):
     start: pd.Timestamp
     end: pd.Timestamp
 
@@ -2004,7 +2004,7 @@ class Report(BaseModel):
     status: str = 'pending'
     report_id: str = ''
     provider: str = ''
-    outages: Tuple[ReportOutage, ...] = ()
+    outages: Tuple[TimePeriod, ...] = ()
     __version__: int = 0  # should add version to api
 
 

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1969,6 +1969,16 @@ class ReportParameters(BaseModel):
 
 @dataclass(frozen=True)
 class TimePeriod(BaseModel):
+    """Class for storing a generic time period. For example, a report
+    outage.
+
+    Parameters
+    ----------
+    start : pandas.Timestamp
+        Start time of the time period.
+    end : pandas.Timestamp
+        End time of the time period.
+    """
     start: pd.Timestamp
     end: pd.Timestamp
 

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -1106,6 +1106,7 @@ class APISession(requests.Session):
             pairs.append(pair)
         rep_params['object_pairs'] = tuple(pairs)
         req_dict['report_parameters'] = rep_params
+        req_dict['outages'] = rep_dict.get('outages', [])
         return datamodel.Report.from_dict(req_dict)
 
     def get_report(self, report_id):

--- a/solarforecastarbiter/io/api.py
+++ b/solarforecastarbiter/io/api.py
@@ -1106,7 +1106,7 @@ class APISession(requests.Session):
             pairs.append(pair)
         rep_params['object_pairs'] = tuple(pairs)
         req_dict['report_parameters'] = rep_params
-        req_dict['outages'] = rep_dict.get('outages', [])
+        req_dict['outages'] = rep_dict.get('outages', ())
         return datamodel.Report.from_dict(req_dict)
 
     def get_report(self, report_id):

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -476,7 +476,7 @@ def filter_resample(
         observation/aggregate data.
     quality_flags : tuple of solarforecastarbiter.datamodel.QualityFlagFilter
         Flags to process and apply as filters during resampling.
-    outages: list of solarforecastarbiter.datamodel.TimePeriod
+    outages: list of :py:class:`solarforecastarbiter.datamodel.TimePeriod`
         Time periods to drop from data prior to filtering or alignment.
 
     Returns
@@ -697,6 +697,9 @@ def process_forecast_observations(forecast_observations, filters,
     costs : tuple of :py:class:`solarforecastarbiter.datamodel.Cost`
         Costs that are referenced by any pairs. Pairs and costs are matched
         by the Cost name.
+    outages : list of :py:class:`solarforecastarbiter.datamodel.TimePeriod`
+        List of time periods during which forecast submissions will be
+        excluded from analysis.
 
     Returns
     -------
@@ -1008,6 +1011,7 @@ def get_outage_periods(forecast, start, end, outages):
     start: pandas.Timestamp
     end: pandas.Timestamp
     outages: list of solarforecastarbiter.datamodel.TimePeriod
+        List of time ranges to check for forecast issue times.
 
     Returns
     -------
@@ -1042,7 +1046,7 @@ def remove_outage_periods(outage_periods, data):
 
     Parameters
     ----------
-    outage_periods: list of solarforecastarbiter.datamodel.TimePeriod
+    outage_periods: list of :py:class:`solarforecastarbiter.datamodel.TimePeriod`
         List of dictionaries with start and end keys. Values should be
         timestamps denoting the start and end of periods to remove.
     data: pandas.DataFrame
@@ -1053,7 +1057,7 @@ def remove_outage_periods(outage_periods, data):
     pandas.DataFrame, int
         The data DataFrame with outage data dropped, and total
         number of points removed.
-    """
+    """  # NOQA
     if len(outage_periods) == 0:
         return data, 0
     dropped_total = 0

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -1033,11 +1033,14 @@ def forecast_report_issue_times(
         # the issue time that contributes the first values within the report
         first_issue_time += forecast.run_length
 
-    # Get all possible issue times that contribute to the report
+    # Get all possible issue times that contribute to the report from the
+    # first issue time, until the lead time of the forecast before the
+    # end of the report.
     issue_times = pd.date_range(
         first_issue_time,
-        end.tz_convert('UTC'),
-        freq=forecast.run_length
+        end.tz_convert('UTC') - forecast.lead_time_to_start,
+        freq=forecast.run_length,
+        closed="left"
     )
     return issue_times
 

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -719,20 +719,23 @@ def process_forecast_observations(forecast_observations, filters,
 
       1. Fill missing forecast data points according to
          ``forecast_fill_method``.
-      2. Fill missing reference forecast data points according to
+      2. Remove any forecast points associated with an outage.
+      3. Fill missing reference forecast data points according to
          ``forecast_fill_method``.
-      3. Remove observation data points with ``quality_flag`` in
+      4. Remove any reference forecast or observation points associated
+         with an outage.
+      5. Remove observation data points with ``quality_flag`` in
          filters. Remaining observation series is discontinuous.
-      4. Resample observations to match forecast intervals. If at least
+      6. Resample observations to match forecast intervals. If at least
          10% of the observation intervals within a forecast interval are
          valid (not missing or matching ``filters``), the interval is
          value is computed from all subintervals. Otherwise the
          resampled observation is NaN.
-      5. Drop NaN observation values.
-      6. Align observations to match forecast times. Observation times
+      7. Drop NaN observation values.
+      8. Align observations to match forecast times. Observation times
          for which there is not a matching forecast time are dropped on
          a forecast by forecast basis.
-      7. Create
+      9. Create
          :py:class:`~solarforecastarbiter.datamodel.ProcessedForecastObservation`
          with resampled, aligned data and metadata.
     """  # NOQA: E501

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 FILL_RESULT_TOTAL_STRING = "Missing {0}Forecast Values {1}"
 DISCARD_DATA_STRING = "{0} Values Discarded by Alignment"
 FORECAST_FILL_CONST_STRING = "Filled with {0}"
+OUTAGE_DISCARD_STRING = "{0} Values Discarded Due To Outage"
 FORECAST_FILL_STRING_MAP = {'drop': "Discarded",
                             'forward': "Forward Filled"}
 
@@ -802,7 +803,7 @@ def process_forecast_observations(forecast_observations, filters,
                 forecast_outage_periods, fx_data, fxobs.forecast.interval_label
             )
             preproc_results.append(datamodel.PreprocessingResult(
-                name="Forecast Values Discarded Due To Outage",
+                name=OUTAGE_DISCARD_STRING.format('Forecast'),
                 count=int(fx_outage_points)))
 
         ref_data = data.get(fxobs.reference_forecast, None)
@@ -827,7 +828,7 @@ def process_forecast_observations(forecast_observations, filters,
                     fxobs.reference_forecast.interval_label
                 )
                 preproc_results.append(datamodel.PreprocessingResult(
-                    name="Reference Forecast Values Discarded Due To Outage",
+                    name=OUTAGE_DISCARD_STRING.format('Reference Forecast')
                     count=int(ref_outage_points))
                 )
 
@@ -852,7 +853,7 @@ def process_forecast_observations(forecast_observations, filters,
                     fxobs.data_object.name)
             else:
                 preproc_results.append(datamodel.PreprocessingResult(
-                    name='Observation Values Discarded Due To Outage',
+                    name=OUTAGE_DISCARD_STRING.format('Observation'),
                     count=int(obs_outage_points_dropped)))
 
         # the total count ultimately shows up in both the validation

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -198,7 +198,7 @@ def _resample_obs(
     fx: datamodel.Forecast,
     obs_data: pd.DataFrame,
     quality_flags: Tuple[datamodel.QualityFlagFilter, ...],
-    outage_periods: List[datamodel.TimePeriod] = []
+    outages: List[datamodel.TimePeriod] = []
 ) -> Tuple[pd.Series, List[datamodel.ValidationResult]]:
     """Resample observations.
 
@@ -213,7 +213,7 @@ def _resample_obs(
         observation/aggregate data.
     quality_flags : tuple of solarforecastarbiter.datamodel.QualityFlagFilter
         Flags to process and apply as filters during resampling.
-    outage_periods : list of solarforecastarbiter.datamode.TimePeriod
+    outages : list of solarforecastarbiter.datamode.TimePeriod
         List of timeperiods to drop from obs_data before resampling.
 
     Returns
@@ -249,7 +249,7 @@ def _resample_obs(
 
     # drop any outage data before preprocessing
     obs_data, outage_point_count = remove_outage_periods(
-        outage_periods, obs_data
+        outages, obs_data
     )
 
     outage_result = datamodel.ValidationResult(
@@ -1040,13 +1040,13 @@ def get_outage_periods(forecast, start, end, outages):
     return outage_periods
 
 
-def remove_outage_periods(outage_periods, data):
+def remove_outage_periods(outages, data):
     """Returns a copy of a dataframe with all values within an outage
     period dropped.
 
     Parameters
     ----------
-    outage_periods: list of :py:class:`solarforecastarbiter.datamodel.TimePeriod`
+    outages: list of :py:class:`solarforecastarbiter.datamodel.TimePeriod`
         List of dictionaries with start and end keys. Values should be
         timestamps denoting the start and end of periods to remove.
     data: pandas.DataFrame
@@ -1058,7 +1058,7 @@ def remove_outage_periods(outage_periods, data):
         The data DataFrame with outage data dropped, and total
         number of points removed.
     """  # NOQA
-    if len(outage_periods) == 0:
+    if len(outages) == 0:
         return data, 0
     dropped_total = 0
 
@@ -1066,7 +1066,7 @@ def remove_outage_periods(outage_periods, data):
     # of loop below
     full_outage_index = None
 
-    for outage in outage_periods:
+    for outage in outages:
         outage_index = (data.index >= outage.start) & (
             data.index <= outage.end)
         if full_outage_index is None:

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -264,7 +264,8 @@ def _resample_obs(
     # determine the points that should be discarded before resampling.
     to_discard_before_resample, val_results = _calc_discard_before_resample(
         obs_flags, quality_flags)
-    val_results = [outage_result] + val_results
+
+    val_results.append(outage_result)
 
     # resample using all of the data except for what was flagged by the
     # discard before resample process.
@@ -530,6 +531,8 @@ def filter_resample(
         obs_resampled, validation_results = _resample_obs(
             obs, fx, obs_data, quality_flags, outages)
 
+    # Remove any forecast data that should have been submitted
+    # during an outage
     fx_data, fx_outage_points = remove_outage_periods(
         outages, fx_data
     )

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -9,7 +9,6 @@ import pandas as pd
 
 
 from solarforecastarbiter import datamodel
-from solarforecastarbiter.io.utils import adjust_start_end_for_interval_label
 from solarforecastarbiter.validation import quality_mapping
 
 
@@ -791,7 +790,7 @@ def process_forecast_observations(forecast_observations, filters,
         preproc_results.append(datamodel.PreprocessingResult(
             name=FILL_RESULT_TOTAL_STRING.format('', forecast_fill_str),
             count=int(count)))
-        
+
         outages_exist = len(outages) > 0
         if outages_exist:
             # Remove any forecast data that would have been submitted
@@ -814,14 +813,15 @@ def process_forecast_observations(forecast_observations, filters,
         if fxobs.reference_forecast is not None:
             ref_data, count = apply_fill(ref_data, fxobs.reference_forecast,
                                          forecast_fill_method, start, end)
-            
+
             preproc_results.append(datamodel.PreprocessingResult(
                 name=FILL_RESULT_TOTAL_STRING.format(
                     "Reference ", forecast_fill_str),
                 count=int(count)))
             if outages_exist:
                 ref_data, ref_outage_points = remove_outage_periods(
-                    forecast_outage_periods, ref_data, fxobs.reference_forecast.interval_label
+                    forecast_outage_periods, ref_data,
+                    fxobs.reference_forecast.interval_label
                 )
                 preproc_results.append(datamodel.PreprocessingResult(
                     name="Reference Forecast Values Discarded Due To Outage",
@@ -844,8 +844,9 @@ def process_forecast_observations(forecast_observations, filters,
                 val_results, 'OUTAGE')
             if obs_outage_points_dropped is None:
                 logger.warning(
-                    'Observation Values Discarded Due To Outage Not Available For '
-                    'Pair (%s, %s)', fxobs.forecast.name, fxobs.data_object.name)
+                    'Observation Values Discarded Due To Outage Not Available '
+                    'For Pair (%s, %s)', fxobs.forecast.name,
+                    fxobs.data_object.name)
             else:
                 preproc_results.append(datamodel.PreprocessingResult(
                     name='Observation Values Discarded Due To Outage',
@@ -1050,7 +1051,6 @@ def get_outage_periods(
         for issue_time in outage_submissions:
             fx_start = issue_time + forecast.lead_time_to_start
             fx_end = fx_start + forecast.run_length
-            
             outage_periods.append(datamodel.TimePeriod(
                 start=fx_start,
                 end=fx_end

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -530,6 +530,9 @@ def filter_resample(
         obs_resampled, validation_results = _resample_obs(
             obs, fx, obs_data, quality_flags, outages)
 
+    fx_data, fx_outage_points = remove_outage_periods(
+        outages, fx_data
+    )
     return fx_data, obs_resampled, validation_results
 
 
@@ -1009,8 +1012,8 @@ def remove_outage_periods(outage_periods, data):
     dropped_total = 0
     new_data = data.copy()
     for outage in outage_periods:
-        outage_index = (new_data.index >= outage['start']) &
-            (new_data.index <= outage['end'])
+        outage_index = (new_data.index >= outage['start']) & (
+            new_data.index <= outage['end'])
         new_data = new_data[~outage_index]
         dropped_total += outage_index.sum()
     return new_data, dropped_total

--- a/solarforecastarbiter/metrics/preprocessing.py
+++ b/solarforecastarbiter/metrics/preprocessing.py
@@ -828,7 +828,7 @@ def process_forecast_observations(forecast_observations, filters,
                     fxobs.reference_forecast.interval_label
                 )
                 preproc_results.append(datamodel.PreprocessingResult(
-                    name=OUTAGE_DISCARD_STRING.format('Reference Forecast')
+                    name=OUTAGE_DISCARD_STRING.format('Reference Forecast'),
                     count=int(ref_outage_points))
                 )
 

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -1803,8 +1803,8 @@ OUTAGE_FORECAST = datamodel.Forecast(
      )
      ),
 ])
-def test_get_forecast_report_issue_times(forecast, start, end, expected):
-    issue_times = preprocessing.get_forecast_report_issue_times(
+def test_forecast_report_issue_times(forecast, start, end, expected):
+    issue_times = preprocessing.forecast_report_issue_times(
         forecast, start, end
     )
     assert (issue_times == expected).all()
@@ -1864,8 +1864,8 @@ def test_get_forecast_report_issue_times(forecast, start, end, expected):
       )
      )
 ])
-def test_get_outage_periods(forecast, start, end, outages, expected):
-    outage_periods = preprocessing.get_outage_periods(
+def test_outage_periods(forecast, start, end, outages, expected):
+    outage_periods = preprocessing.outage_periods(
         forecast, start, end, outages
     )
     assert outage_periods == expected

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -1790,69 +1790,75 @@ OUTAGE_DATA = pd.DataFrame(
 )
 
 
-@pytest.mark.parametrize('outage_periods,data,expected_data,dropped', [
-    (
-     [
-        datamodel.TimePeriod(
-          start=pd.Timestamp('2021-01-01T12:00Z'),
-          end=pd.Timestamp('2021-01-01T14:00Z')
-        )
-      ],
-     OUTAGE_DATA,
-     pd.DataFrame(
-        index=pd.date_range(
-            '2021-01-01T05:00Z',
-            '2021-01-01T11:00Z',
-            freq='1H'
-        ).append(pd.date_range(
-            '2021-01-01T15:00Z',
-            '2021-01-02T05:00Z',
-            freq='1H'
-        )),
-        columns=['value']
+@pytest.mark.parametrize(
+    'outage_periods,interval_label,data,expected_data,dropped',
+    [
+     (
+      [
+         datamodel.TimePeriod(
+           start=pd.Timestamp('2021-01-01T12:00Z'),
+           end=pd.Timestamp('2021-01-01T14:00Z')
+         )
+       ],
+      "beginning",
+      OUTAGE_DATA,
+      pd.DataFrame(
+         index=pd.date_range(
+             '2021-01-01T05:00Z',
+             '2021-01-01T11:00Z',
+             freq='1H'
+         ).append(pd.date_range(
+             '2021-01-01T14:00Z',
+             '2021-01-02T05:00Z',
+             freq='1H'
+         )),
+         columns=['value']
+      ),
+      3
      ),
-     3
-    ),
-    (
-     [
-        datamodel.TimePeriod(
-          start=pd.Timestamp('2021-01-01T07:00Z'),
-          end=pd.Timestamp('2021-01-01T09:00Z')
-        ),
-        datamodel.TimePeriod(
-          start=pd.Timestamp('2021-01-01T13:00Z'),
-          end=pd.Timestamp('2021-01-01T17:00Z')
-        )
-      ],
-     OUTAGE_DATA,
-     pd.DataFrame(
-        index=pd.date_range(
-            '2021-01-01T05:00Z',
-            '2021-01-01T06:00Z',
-            freq='1H'
-        ).append(pd.date_range(
-            '2021-01-01T10:00Z',
-            '2021-01-01T12:00Z',
-            freq='1H'
-        )).append(pd.date_range(
-            '2021-01-01T18:00Z',
-            '2021-01-02T05:00Z',
-            freq='1H'
-        )),
-        columns=['value']
+     (
+      [
+         datamodel.TimePeriod(
+           start=pd.Timestamp('2021-01-01T07:00Z'),
+           end=pd.Timestamp('2021-01-01T09:00Z')
+         ),
+         datamodel.TimePeriod(
+           start=pd.Timestamp('2021-01-01T13:00Z'),
+           end=pd.Timestamp('2021-01-01T17:00Z')
+         )
+       ],
+      "beginning",
+      OUTAGE_DATA,
+      pd.DataFrame(
+         index=pd.date_range(
+             '2021-01-01T05:00Z',
+             '2021-01-01T06:00Z',
+             freq='1H'
+         ).append(pd.date_range(
+             '2021-01-01T09:00Z',
+             '2021-01-01T12:00Z',
+             freq='1H'
+         )).append(pd.date_range(
+             '2021-01-01T17:00Z',
+             '2021-01-02T05:00Z',
+             freq='1H'
+         )),
+         columns=['value']
+      ),
+      6
      ),
-     6
-    ),
-    (
-     [],
-     OUTAGE_DATA,
-     OUTAGE_DATA,
-     0
-    ),
-])
+     (
+      [],
+      "beginning",
+      OUTAGE_DATA,
+      OUTAGE_DATA,
+      0
+     ),
+    ]
+)
 def test_remove_outage_period(
-        outage_periods, data, expected_data, dropped):
+        outage_periods, interval_label, data, expected_data, dropped):
     data_outage_removed, actual_dropped = preprocessing.remove_outage_periods(
-        outage_periods, data
+        outage_periods, data, interval_label
     )
     assert_frame_equal(data_outage_removed, expected_data)

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -4,7 +4,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pandas.testing import assert_index_equal, assert_series_equal
+from pandas.testing import (
+    assert_index_equal,
+    assert_series_equal,
+    assert_frame_equal
+)
 
 from solarforecastarbiter import datamodel
 from solarforecastarbiter.conftest import _site_metadata
@@ -422,6 +426,7 @@ def test_align_prob_constant_value(
                 [1.], index=pd.DatetimeIndex(["20200301T03Z"], freq='1h')),
             (('ISNAN', 1), ('NIGHTTIME', 2), ('USER FLAGGED', 2),
              ('TOTAL DISCARD BEFORE RESAMPLE', 3),
+             ('Outage', 0),
              ('NIGHTTIME OR USER FLAGGED OR ISNAN', 3, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 3, False))
         ),
@@ -433,6 +438,7 @@ def test_align_prob_constant_value(
                 [1.], index=pd.DatetimeIndex(["20200301T03Z"], freq='1h')),
             (('ISNAN', 1), ('NIGHTTIME', 2), ('USER FLAGGED', 2),
              ('TOTAL DISCARD BEFORE RESAMPLE', 3),
+             ('Outage', 0),
              ('NIGHTTIME OR ISNAN', 2, False),
              ('USER FLAGGED OR ISNAN', 3, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 3, False))
@@ -446,6 +452,7 @@ def test_align_prob_constant_value(
                 [14.5], index=pd.DatetimeIndex(["20200301T03Z"], freq='1h')),
             (('ISNAN', 5), ('NIGHTTIME', 3), ('USER FLAGGED', 3),
              ('TOTAL DISCARD BEFORE RESAMPLE', 8),
+             ('Outage', 0),
              ('NIGHTTIME OR USER FLAGGED OR ISNAN', 3, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 3, False))
         ),
@@ -458,6 +465,7 @@ def test_align_prob_constant_value(
             pd.Series([7.5, 11.5, 14.5], index=FOUR_HOUR_SERIES.index[1:]),
             (('ISNAN', 5), ('NIGHTTIME', 3), ('USER FLAGGED', 3),
              ('TOTAL DISCARD BEFORE RESAMPLE', 8),
+             ('Outage', 0),
              ('NIGHTTIME OR USER FLAGGED OR ISNAN', 1, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 1, False))
         ),
@@ -469,6 +477,7 @@ def test_align_prob_constant_value(
                 [14.5], index=pd.DatetimeIndex(["20200301T03Z"], freq='1h')),
             (('ISNAN', 5), ('NIGHTTIME', 3), ('USER FLAGGED', 3),
              ('TOTAL DISCARD BEFORE RESAMPLE', 8),
+             ('Outage', 0),
              ('NIGHTTIME OR ISNAN', 3, False),
              ('USER FLAGGED OR ISNAN', 3, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 3, False))
@@ -483,6 +492,7 @@ def test_align_prob_constant_value(
                 [14.5], index=pd.DatetimeIndex(["20200301T03Z"], freq='1h')),
             (('ISNAN', 5),
              ('TOTAL DISCARD BEFORE RESAMPLE', 5),
+             ('Outage', 0),
              ('NIGHTTIME OR USER FLAGGED OR ISNAN', 3, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 3, False))
         ),
@@ -499,6 +509,7 @@ def test_align_prob_constant_value(
             pd.Series([10.5, 14.5], index=FOUR_HOUR_SERIES.index[2:]),
             (('ISNAN', 5),
              ('TOTAL DISCARD BEFORE RESAMPLE', 5),
+             ('Outage', 0),
              ('NIGHTTIME OR ISNAN', 2, False),
              ('USER FLAGGED OR ISNAN', 2, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 2, False))
@@ -512,6 +523,7 @@ def test_align_prob_constant_value(
             # only first all-nan interval is discarded
             pd.Series([7.0, 10.5, 14.5], index=FOUR_HOUR_SERIES.index[1:]),
             (('ISNAN', 5), ('TOTAL DISCARD BEFORE RESAMPLE', 5),
+             ('Outage', 0),
              ('NIGHTTIME OR USER FLAGGED OR ISNAN', 1, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 1, False))
         ),
@@ -533,6 +545,7 @@ def test_align_prob_constant_value(
                 ),
             (('ISNAN', 5), ('CLEARSKY EXCEEDED', 1),
              ('TOTAL DISCARD BEFORE RESAMPLE', 6),
+             ('Outage', 0),
              ('NIGHTTIME OR USER FLAGGED OR ISNAN', 1, False),
              ('CLEARSKY EXCEEDED OR ISNAN', 3, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 3, False))
@@ -554,6 +567,7 @@ def test_align_prob_constant_value(
                 )
             ),
             (('ISNAN', 0), ('TOTAL DISCARD BEFORE RESAMPLE', 0),
+             ('Outage', 0),
              ('NIGHTTIME OR ISNAN', 1, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 1, False))
         ),
@@ -572,6 +586,7 @@ def test_align_prob_constant_value(
                 )
             ),
             (('ISNAN', 0), ('TOTAL DISCARD BEFORE RESAMPLE', 0),
+             ('Outage', 0),
              ('USER FLAGGED OR ISNAN', 1, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 1, False))
         ),
@@ -592,6 +607,7 @@ def test_align_prob_constant_value(
             (('ISNAN', 0),
              ('USER FLAGGED', 5, True),
              ('TOTAL DISCARD BEFORE RESAMPLE', 5, True),
+             ('Outage', 0),
              ('USER FLAGGED OR ISNAN', 1, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 1, False))
         )
@@ -1666,20 +1682,17 @@ OUTAGE_FORECAST = datamodel.Forecast(
    run_length=pd.Timedelta('12h')
 )
 
-def test_get_outage_periods():
-    assert True
-
 
 @pytest.mark.parametrize("forecast,start,end,expected", [
     (OUTAGE_FORECAST,
      pd.Timestamp('2021-01-01T00:00Z'),
      pd.Timestamp('2021-01-02T00:00Z'),
      pd.date_range(
-        '2020-12-30T05:00Z',
+        '2020-12-31T05:00Z',
         '2021-01-01T17:00Z',
         freq='12h'
      )
-    ),
+     ),
     (OUTAGE_FORECAST.replace(run_length=pd.Timedelta('1H')),
      pd.Timestamp('2021-01-01T00:00Z'),
      pd.Timestamp('2021-01-02T00:00Z'),
@@ -1688,7 +1701,16 @@ def test_get_outage_periods():
         '2021-01-02T00:00Z',
         freq='1h'
      )
-    ),
+     ),
+    (OUTAGE_FORECAST.replace(run_length=pd.Timedelta('24H')),
+     pd.Timestamp('2021-01-01T00:00Z'),
+     pd.Timestamp('2021-01-02T00:00Z'),
+     pd.date_range(
+        '2020-12-30T05:00Z',
+        '2021-01-01T05:00Z',
+        freq='24h'
+     )
+     ),
 ])
 def test_get_forecast_report_issue_times(forecast, start, end, expected):
     issue_times = preprocessing.get_forecast_report_issue_times(
@@ -1697,5 +1719,136 @@ def test_get_forecast_report_issue_times(forecast, start, end, expected):
     assert (issue_times == expected).all()
 
 
-def test_remove_outage_period():
-    assert True
+@pytest.mark.parametrize("forecast,start,end,outages,expected", [
+    (OUTAGE_FORECAST,
+     pd.Timestamp('2021-01-01T00:00Z'),
+     pd.Timestamp('2021-01-02T00:00Z'),
+     [datamodel.TimePeriod(
+        start=pd.Timestamp('2021-01-01T04:00Z'),
+        end=pd.Timestamp('2021-01-01T05:00Z')
+      )],
+     [datamodel.TimePeriod(
+        start=pd.Timestamp('2021-01-01T06:00Z'),
+        end=pd.Timestamp('2021-01-01T18:00Z')
+      )]
+     ),
+    (OUTAGE_FORECAST,
+     pd.Timestamp('2021-01-01T00:00Z'),
+     pd.Timestamp('2021-01-02T00:00Z'),
+     [
+        datamodel.TimePeriod(
+           start=pd.Timestamp('2020-12-31T17:00Z'),
+           end=pd.Timestamp('2020-12-31T19:00Z')
+         )
+     ],
+     [
+        datamodel.TimePeriod(
+           start=pd.Timestamp('2020-12-31T18:00Z'),
+           end=pd.Timestamp('2021-01-01T06:00Z')
+        )
+      ]
+     ),
+    (OUTAGE_FORECAST.replace(run_length=pd.Timedelta('1H')),
+     pd.Timestamp('2021-01-01T00:00Z'),
+     pd.Timestamp('2021-01-02T00:00Z'),
+     [
+        datamodel.TimePeriod(
+          start=pd.Timestamp('2021-01-01T04:00Z'),
+          end=pd.Timestamp('2021-01-01T05:00Z')
+        )
+     ],
+     [
+        datamodel.TimePeriod(
+          start=pd.Timestamp('2021-01-01T05:00Z'),
+          end=pd.Timestamp('2021-01-01T06:00Z')
+        ),
+        datamodel.TimePeriod(
+          start=pd.Timestamp('2021-01-01T06:00Z'),
+          end=pd.Timestamp('2021-01-01T07:00Z')
+        )
+      ]
+     )
+])
+def test_get_outage_periods(forecast, start, end, outages, expected):
+    outage_periods = preprocessing.get_outage_periods(
+        forecast, start, end, outages
+    )
+    assert outage_periods == expected
+
+
+OUTAGE_DATA = pd.DataFrame(
+    index=pd.date_range(
+        '2021-01-01T05:00Z',
+        '2021-01-02T05:00Z',
+        freq='1H'
+    ),
+    columns=['value']
+)
+
+
+@pytest.mark.parametrize('outage_periods,data,expected_data,dropped', [
+    (
+     [
+        datamodel.TimePeriod(
+          start=pd.Timestamp('2021-01-01T12:00Z'),
+          end=pd.Timestamp('2021-01-01T14:00Z')
+        )
+      ],
+     OUTAGE_DATA,
+     pd.DataFrame(
+        index=pd.date_range(
+            '2021-01-01T05:00Z',
+            '2021-01-01T11:00Z',
+            freq='1H'
+        ).append(pd.date_range(
+            '2021-01-01T15:00Z',
+            '2021-01-02T05:00Z',
+            freq='1H'
+        )),
+        columns=['value']
+     ),
+     3
+    ),
+    (
+     [
+        datamodel.TimePeriod(
+          start=pd.Timestamp('2021-01-01T07:00Z'),
+          end=pd.Timestamp('2021-01-01T09:00Z')
+        ),
+        datamodel.TimePeriod(
+          start=pd.Timestamp('2021-01-01T13:00Z'),
+          end=pd.Timestamp('2021-01-01T17:00Z')
+        )
+      ],
+     OUTAGE_DATA,
+     pd.DataFrame(
+        index=pd.date_range(
+            '2021-01-01T05:00Z',
+            '2021-01-01T06:00Z',
+            freq='1H'
+        ).append(pd.date_range(
+            '2021-01-01T10:00Z',
+            '2021-01-01T12:00Z',
+            freq='1H'
+        )).append(pd.date_range(
+            '2021-01-01T18:00Z',
+            '2021-01-02T05:00Z',
+            freq='1H'
+        )),
+        columns=['value']
+     ),
+     6
+    ),
+    (
+     [],
+     OUTAGE_DATA,
+     OUTAGE_DATA,
+     0
+    ),
+])
+def test_remove_outage_period(
+        outage_periods, data, expected_data, dropped):
+    data_outage_removed, actual_dropped = preprocessing.remove_outage_periods(
+        outage_periods, data
+    )
+    assert_frame_equal(data_outage_removed, expected_data)

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -1754,7 +1754,7 @@ OUTAGE_FORECAST = datamodel.Forecast(
      pd.Timestamp('2021-01-02T00:00Z'),
      pd.date_range(
         '2020-12-31T23:00Z',
-        '2021-01-02T00:00Z',
+        '2021-01-01T22:00Z',
         freq='1h'
      )
      ),
@@ -1785,7 +1785,7 @@ OUTAGE_FORECAST = datamodel.Forecast(
      pd.Timestamp('2021-01-02T00:00Z'),
      pd.date_range(
         '2020-12-29T23:00Z',
-        '2021-01-01T23:00Z',
+        '2020-12-30T23:00Z',
         freq='24h'
      )
      ),
@@ -1798,7 +1798,7 @@ OUTAGE_FORECAST = datamodel.Forecast(
      pd.Timestamp('2021-01-02T00:00', tz='America/Phoenix'),
      pd.date_range(
         '2020-12-30T23:00Z',
-        '2021-01-01T23:00Z',
+        '2020-12-31T23:00Z',
         freq='24h'
      )
      ),

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -1789,6 +1789,19 @@ OUTAGE_FORECAST = datamodel.Forecast(
         freq='24h'
      )
      ),
+    (OUTAGE_FORECAST.replace(
+        lead_time_to_start=pd.Timedelta('26H'),
+        run_length=pd.Timedelta('24H'),
+        issue_time_of_day=dt.time(hour=23),
+     ),
+     pd.Timestamp('2021-01-01T00:00', tz='America/Phoenix'),
+     pd.Timestamp('2021-01-02T00:00', tz='America/Phoenix'),
+     pd.date_range(
+        '2020-12-30T23:00Z',
+        '2021-01-01T23:00Z',
+        freq='24h'
+     )
+     ),
 ])
 def test_get_forecast_report_issue_times(forecast, start, end, expected):
     issue_times = preprocessing.get_forecast_report_issue_times(

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -1910,6 +1910,44 @@ OUTAGE_DATA = pd.DataFrame(
       OUTAGE_DATA,
       0
      ),
+     (
+      [],
+      "ending",
+      OUTAGE_DATA,
+      OUTAGE_DATA,
+      0
+     ),
+     (
+      [
+         datamodel.TimePeriod(
+           start=pd.Timestamp('2021-01-01T07:00Z'),
+           end=pd.Timestamp('2021-01-01T09:00Z')
+         ),
+         datamodel.TimePeriod(
+           start=pd.Timestamp('2021-01-01T13:00Z'),
+           end=pd.Timestamp('2021-01-01T17:00Z')
+         )
+       ],
+      "ending",
+      OUTAGE_DATA,
+      pd.DataFrame(
+         index=pd.date_range(
+             '2021-01-01T05:00Z',
+             '2021-01-01T07:00Z',
+             freq='1H'
+         ).append(pd.date_range(
+             '2021-01-01T10:00Z',
+             '2021-01-01T13:00Z',
+             freq='1H'
+         )).append(pd.date_range(
+             '2021-01-01T18:00Z',
+             '2021-01-02T05:00Z',
+             freq='1H'
+         )),
+         columns=['value']
+      ),
+      6
+     ),
     ]
 )
 def test_remove_outage_period(

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -1807,7 +1807,7 @@ def test_forecast_report_issue_times(forecast, start, end, expected):
     issue_times = preprocessing.forecast_report_issue_times(
         forecast, start, end
     )
-    assert (issue_times == expected).all()
+    assert_index_equal(issue_times, expected)
 
 
 @pytest.mark.parametrize("forecast,start,end,outages,expected", [

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -426,7 +426,7 @@ def test_align_prob_constant_value(
                 [1.], index=pd.DatetimeIndex(["20200301T03Z"], freq='1h')),
             (('ISNAN', 1), ('NIGHTTIME', 2), ('USER FLAGGED', 2),
              ('TOTAL DISCARD BEFORE RESAMPLE', 3),
-             ('Outage', 0),
+             ('OUTAGE', 0),
              ('NIGHTTIME OR USER FLAGGED OR ISNAN', 3, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 3, False))
         ),
@@ -438,7 +438,7 @@ def test_align_prob_constant_value(
                 [1.], index=pd.DatetimeIndex(["20200301T03Z"], freq='1h')),
             (('ISNAN', 1), ('NIGHTTIME', 2), ('USER FLAGGED', 2),
              ('TOTAL DISCARD BEFORE RESAMPLE', 3),
-             ('Outage', 0),
+             ('OUTAGE', 0),
              ('NIGHTTIME OR ISNAN', 2, False),
              ('USER FLAGGED OR ISNAN', 3, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 3, False))
@@ -452,7 +452,7 @@ def test_align_prob_constant_value(
                 [14.5], index=pd.DatetimeIndex(["20200301T03Z"], freq='1h')),
             (('ISNAN', 5), ('NIGHTTIME', 3), ('USER FLAGGED', 3),
              ('TOTAL DISCARD BEFORE RESAMPLE', 8),
-             ('Outage', 0),
+             ('OUTAGE', 0),
              ('NIGHTTIME OR USER FLAGGED OR ISNAN', 3, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 3, False))
         ),
@@ -465,7 +465,7 @@ def test_align_prob_constant_value(
             pd.Series([7.5, 11.5, 14.5], index=FOUR_HOUR_SERIES.index[1:]),
             (('ISNAN', 5), ('NIGHTTIME', 3), ('USER FLAGGED', 3),
              ('TOTAL DISCARD BEFORE RESAMPLE', 8),
-             ('Outage', 0),
+             ('OUTAGE', 0),
              ('NIGHTTIME OR USER FLAGGED OR ISNAN', 1, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 1, False))
         ),
@@ -477,7 +477,7 @@ def test_align_prob_constant_value(
                 [14.5], index=pd.DatetimeIndex(["20200301T03Z"], freq='1h')),
             (('ISNAN', 5), ('NIGHTTIME', 3), ('USER FLAGGED', 3),
              ('TOTAL DISCARD BEFORE RESAMPLE', 8),
-             ('Outage', 0),
+             ('OUTAGE', 0),
              ('NIGHTTIME OR ISNAN', 3, False),
              ('USER FLAGGED OR ISNAN', 3, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 3, False))
@@ -492,7 +492,7 @@ def test_align_prob_constant_value(
                 [14.5], index=pd.DatetimeIndex(["20200301T03Z"], freq='1h')),
             (('ISNAN', 5),
              ('TOTAL DISCARD BEFORE RESAMPLE', 5),
-             ('Outage', 0),
+             ('OUTAGE', 0),
              ('NIGHTTIME OR USER FLAGGED OR ISNAN', 3, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 3, False))
         ),
@@ -509,7 +509,7 @@ def test_align_prob_constant_value(
             pd.Series([10.5, 14.5], index=FOUR_HOUR_SERIES.index[2:]),
             (('ISNAN', 5),
              ('TOTAL DISCARD BEFORE RESAMPLE', 5),
-             ('Outage', 0),
+             ('OUTAGE', 0),
              ('NIGHTTIME OR ISNAN', 2, False),
              ('USER FLAGGED OR ISNAN', 2, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 2, False))
@@ -523,7 +523,7 @@ def test_align_prob_constant_value(
             # only first all-nan interval is discarded
             pd.Series([7.0, 10.5, 14.5], index=FOUR_HOUR_SERIES.index[1:]),
             (('ISNAN', 5), ('TOTAL DISCARD BEFORE RESAMPLE', 5),
-             ('Outage', 0),
+             ('OUTAGE', 0),
              ('NIGHTTIME OR USER FLAGGED OR ISNAN', 1, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 1, False))
         ),
@@ -545,7 +545,7 @@ def test_align_prob_constant_value(
                 ),
             (('ISNAN', 5), ('CLEARSKY EXCEEDED', 1),
              ('TOTAL DISCARD BEFORE RESAMPLE', 6),
-             ('Outage', 0),
+             ('OUTAGE', 0),
              ('NIGHTTIME OR USER FLAGGED OR ISNAN', 1, False),
              ('CLEARSKY EXCEEDED OR ISNAN', 3, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 3, False))
@@ -567,7 +567,7 @@ def test_align_prob_constant_value(
                 )
             ),
             (('ISNAN', 0), ('TOTAL DISCARD BEFORE RESAMPLE', 0),
-             ('Outage', 0),
+             ('OUTAGE', 0),
              ('NIGHTTIME OR ISNAN', 1, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 1, False))
         ),
@@ -586,7 +586,7 @@ def test_align_prob_constant_value(
                 )
             ),
             (('ISNAN', 0), ('TOTAL DISCARD BEFORE RESAMPLE', 0),
-             ('Outage', 0),
+             ('OUTAGE', 0),
              ('USER FLAGGED OR ISNAN', 1, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 1, False))
         ),
@@ -607,7 +607,7 @@ def test_align_prob_constant_value(
             (('ISNAN', 0),
              ('USER FLAGGED', 5, True),
              ('TOTAL DISCARD BEFORE RESAMPLE', 5, True),
-             ('Outage', 0),
+             ('OUTAGE', 0),
              ('USER FLAGGED OR ISNAN', 1, False),
              ('TOTAL DISCARD AFTER RESAMPLE', 1, False))
         )
@@ -1723,41 +1723,45 @@ def test_get_forecast_report_issue_times(forecast, start, end, expected):
     (OUTAGE_FORECAST,
      pd.Timestamp('2021-01-01T00:00Z'),
      pd.Timestamp('2021-01-02T00:00Z'),
-     [datamodel.TimePeriod(
-        start=pd.Timestamp('2021-01-01T04:00Z'),
-        end=pd.Timestamp('2021-01-01T05:00Z')
-      )],
-     [datamodel.TimePeriod(
-        start=pd.Timestamp('2021-01-01T06:00Z'),
-        end=pd.Timestamp('2021-01-01T18:00Z')
-      )]
+     (
+        datamodel.TimePeriod(
+            start=pd.Timestamp('2021-01-01T04:00Z'),
+            end=pd.Timestamp('2021-01-01T05:00Z')
+        ),
+      ),
+     (
+        datamodel.TimePeriod(
+            start=pd.Timestamp('2021-01-01T06:00Z'),
+            end=pd.Timestamp('2021-01-01T18:00Z')
+        ),
+      ),
      ),
     (OUTAGE_FORECAST,
      pd.Timestamp('2021-01-01T00:00Z'),
      pd.Timestamp('2021-01-02T00:00Z'),
-     [
+     (
         datamodel.TimePeriod(
            start=pd.Timestamp('2020-12-31T17:00Z'),
            end=pd.Timestamp('2020-12-31T19:00Z')
-         )
-     ],
-     [
+         ),
+     ),
+     (
         datamodel.TimePeriod(
            start=pd.Timestamp('2020-12-31T18:00Z'),
            end=pd.Timestamp('2021-01-01T06:00Z')
-        )
-      ]
+        ),
+      )
      ),
     (OUTAGE_FORECAST.replace(run_length=pd.Timedelta('1H')),
      pd.Timestamp('2021-01-01T00:00Z'),
      pd.Timestamp('2021-01-02T00:00Z'),
-     [
+     (
         datamodel.TimePeriod(
           start=pd.Timestamp('2021-01-01T04:00Z'),
           end=pd.Timestamp('2021-01-01T05:00Z')
-        )
-     ],
-     [
+        ),
+     ),
+     (
         datamodel.TimePeriod(
           start=pd.Timestamp('2021-01-01T05:00Z'),
           end=pd.Timestamp('2021-01-01T06:00Z')
@@ -1765,8 +1769,8 @@ def test_get_forecast_report_issue_times(forecast, start, end, expected):
         datamodel.TimePeriod(
           start=pd.Timestamp('2021-01-01T06:00Z'),
           end=pd.Timestamp('2021-01-01T07:00Z')
-        )
-      ]
+        ),
+      )
      )
 ])
 def test_get_outage_periods(forecast, start, end, outages, expected):

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -1744,7 +1744,7 @@ OUTAGE_FORECAST = datamodel.Forecast(
      pd.Timestamp('2021-01-01T00:00Z'),
      pd.Timestamp('2021-01-02T00:00Z'),
      pd.date_range(
-        '2020-12-31T05:00Z',
+        '2020-12-31T17:00Z',
         '2021-01-01T17:00Z',
         freq='12h'
      )
@@ -1753,7 +1753,7 @@ OUTAGE_FORECAST = datamodel.Forecast(
      pd.Timestamp('2021-01-01T00:00Z'),
      pd.Timestamp('2021-01-02T00:00Z'),
      pd.date_range(
-        '2020-12-31T05:00Z',
+        '2020-12-31T23:00Z',
         '2021-01-02T00:00Z',
         freq='1h'
      )
@@ -1762,8 +1762,30 @@ OUTAGE_FORECAST = datamodel.Forecast(
      pd.Timestamp('2021-01-01T00:00Z'),
      pd.Timestamp('2021-01-02T00:00Z'),
      pd.date_range(
-        '2020-12-30T05:00Z',
+        '2020-12-31T05:00Z',
         '2021-01-01T05:00Z',
+        freq='24h'
+     )
+     ),
+    (OUTAGE_FORECAST,
+     pd.Timestamp('2021-01-01T04:37Z'),
+     pd.Timestamp('2021-01-02T00:00Z'),
+     pd.date_range(
+        '2020-12-31T17:00Z',
+        '2021-01-01T17:00Z',
+        freq='12h'
+     )
+     ),
+    (OUTAGE_FORECAST.replace(
+        lead_time_to_start=pd.Timedelta('26H'),
+        run_length=pd.Timedelta('24H'),
+        issue_time_of_day=dt.time(hour=23),
+     ),
+     pd.Timestamp('2021-01-01T00:00Z'),
+     pd.Timestamp('2021-01-02T00:00Z'),
+     pd.date_range(
+        '2020-12-29T23:00Z',
+        '2021-01-01T23:00Z',
         freq='24h'
      )
      ),

--- a/solarforecastarbiter/metrics/tests/test_preprocessing.py
+++ b/solarforecastarbiter/metrics/tests/test_preprocessing.py
@@ -702,7 +702,7 @@ def test_process_forecast_observations_with_outages(
     report_objects_with_outages, quality_filter,
     timeofdayfilter, mocker
 ):
-    report, observation, forecast_0, forecast_1, aggregate, forecast_agg = report_objects_with_outages  # NOQA
+    report, observation, forecast_0, forecast_1, aggregate, forecast_agg = report_objects_with_outages  # NOQA: E501
     forecast_ref = report.report_parameters.object_pairs[1].reference_forecast
     obs_ser = pd.Series(np.arange(8),
                         index=pd.date_range(start='2019-04-01T00:00:00',

--- a/solarforecastarbiter/reports/main.py
+++ b/solarforecastarbiter/reports/main.py
@@ -186,7 +186,8 @@ def create_raw_report_from_data(report, data):
             report_params.forecast_fill_method,
             report_params.start, report_params.end,
             data, timezone,
-            costs=report_params.costs)
+            costs=report_params.costs,
+            outages=report.outages)
 
         # Calculate metrics
         metrics_list = calculator.calculate_metrics(

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -91,6 +91,11 @@
     <li><a href="#costparams">Cost Parameters</a></li>
   </ul>
   {% endif %}
+  {% if report.report_parameters.outages | length > 0 %}
+  <ul>
+    <li><a href="#outages">Outages</li>
+  </ul>
+  {% endif %}
   <li><a href="#data">Data</a></li>
   <ul>
     <li><a href="#observations-and-forecasts">Observations and Forecasts</a></li>
@@ -156,6 +161,29 @@
   </div>
 </div>
 {% endfor %}
+{% endif %}
+{% set outages = report.outages %}
+{% if outages | length > 0 %}
+<h4 id="outages">Outages</h4>
+<p>
+Forecast submissions that fall within the periods listed below are excluded from analysis.
+</p>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Outage Start</th>
+      <th>Outage End</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for outage in outages %}
+    <tr>
+      <td>{{ outage['start'] }}</td>
+      <td>{{ outage['end'] }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% endif %}
 {% endblock %}
 

--- a/solarforecastarbiter/reports/templates/pdf/base.tex
+++ b/solarforecastarbiter/reports/templates/pdf/base.tex
@@ -67,6 +67,23 @@ This report of forecast accuracy was automatically generated using the
 %- endfor
 %- endif
 
+%- set outages = report.outages
+%- if outages | length > 0
+\subsection{Outages}
+\begin{table}[h]
+  \caption{Table of report outages.}
+  \begin{tabu} to \linewidth {
+      X[l] | ll
+    }
+    Start & End \\
+    \midrule
+    %- for outage in outages HERE
+    \VAR{outage.start} & \VAR{outage.end} \\
+    %- endfor
+  \end{tabu}
+\end{table}
+%- endif
+
 \section{Data}
 
 This report includes forecast and observation data available from

--- a/solarforecastarbiter/reports/templates/pdf/base.tex
+++ b/solarforecastarbiter/reports/templates/pdf/base.tex
@@ -78,7 +78,7 @@ Forecast submissions that fall within the periods listed below are excluded from
     }
     Start & End \\
     \midrule
-    %- for outage in outages HERE
+    %- for outage in outages
     \VAR{outage.start} & \VAR{outage.end} \\
     %- endfor
   \end{tabu}

--- a/solarforecastarbiter/reports/templates/pdf/base.tex
+++ b/solarforecastarbiter/reports/templates/pdf/base.tex
@@ -70,6 +70,7 @@ This report of forecast accuracy was automatically generated using the
 %- set outages = report.outages
 %- if outages | length > 0
 \subsection{Outages}
+Forecast submissions that fall within the periods listed below are excluded from analysis.
 \begin{table}[h]
   \caption{Table of report outages.}
   \begin{tabu} to \linewidth {

--- a/solarforecastarbiter/reports/tests/test_template.py
+++ b/solarforecastarbiter/reports/tests/test_template.py
@@ -512,3 +512,11 @@ def test_render_outage_report_html_full_html(
     assert '<td style="test-align: left">Forecast Values Discarded Due To Outage</td>' in rendered  # NOQA: E501
     assert '<td style="test-align: left">Observation Values Discarded Due To Outage</td>' in rendered  # NOQA: E501
     assert '<td style="test-align: left">Reference Forecast Values Discarded Due To Outage</td>' in rendered  # NOQA: E501
+
+
+def test_render_outage_pdf(outage_report_with_raw, dash_url):
+    if shutil.which('pdflatex') is None:  # pragma: no cover
+        pytest.skip('pdflatex must be on PATH to generate PDF reports')
+    rendered = template.render_pdf(outage_report_with_raw, dash_url)
+    assert "Outage" in rendered
+    assert rendered.startswith(b'%PDF')

--- a/solarforecastarbiter/reports/tests/test_template.py
+++ b/solarforecastarbiter/reports/tests/test_template.py
@@ -490,3 +490,18 @@ def test__get_render_kwargs_with_missing_obs_data(
     assert 'scatter_spec' not in kwargs
     assert 'timeseries_prob_spec' not in kwargs
     assert not kwargs['includes_distribution']
+
+
+def test_render_outage_report_html_full_html(
+    outage_report_with_raw, dash_url, with_series,
+                               mocked_timeseries_plots):
+    rendered = template.render_html(
+        outage_report_with_raw, dash_url, with_series, False)
+    assert '<h4 id="outages">Outages</h4>' in rendered
+    for outage in outage_report_with_raw.outages:
+        fmt = "%Y-%m-%d %H:%M:%S+00:00"
+        assert f'<td>{ outage.start.strftime(fmt) }</td>' in rendered
+        assert f'<td>{ outage.end.strftime(fmt) }</td>' in rendered
+    assert '<td style="test-align: left">Forecast Values Discarded Due To Outage</td>' in rendered  # NOQA: E501
+    assert '<td style="test-align: left">Observation Values Discarded Due To Outage</td>' in rendered  # NOQA: E501
+    assert '<td style="test-align: left">Reference Forecast Values Discarded Due To Outage</td>' in rendered  # NOQA: E501

--- a/solarforecastarbiter/reports/tests/test_template.py
+++ b/solarforecastarbiter/reports/tests/test_template.py
@@ -238,6 +238,12 @@ def test_render_html_full_html(various_report_with_raw, dash_url, with_series,
     rendered = template.render_html(
         various_report_with_raw[0], dash_url, with_series, False)
     assert rendered[:46] == '<!doctype html>\n<html lang="en" class="h-100">'
+    # Ensure outage information is hidden for reports without outages
+    # https://github.com/SolarArbiter/solarforecastarbiter-core/pull/752
+    assert '<h4 id="outages">Outages</h4>' not in rendered
+    assert '<td style="test-align: left">Forecast Values Discarded Due To Outage</td>' not in rendered  # NOQA: E501
+    assert '<td style="test-align: left">Observation Values Discarded Due To Outage</td>' not in rendered  # NOQA: E501
+    assert '<td style="test-align: left">Reference Forecast Values Discarded Due To Outage</td>' not in rendered  # NOQA: E501
 
 
 def test_build_metrics_json(various_report_with_raw):

--- a/solarforecastarbiter/reports/tests/test_template.py
+++ b/solarforecastarbiter/reports/tests/test_template.py
@@ -494,7 +494,8 @@ def test__get_render_kwargs_with_missing_obs_data(
 
 def test_render_outage_report_html_full_html(
     outage_report_with_raw, dash_url, with_series,
-                               mocked_timeseries_plots):
+    mocked_timeseries_plots
+):
     rendered = template.render_html(
         outage_report_with_raw, dash_url, with_series, False)
     assert '<h4 id="outages">Outages</h4>' in rendered

--- a/solarforecastarbiter/reports/tests/test_template.py
+++ b/solarforecastarbiter/reports/tests/test_template.py
@@ -518,5 +518,4 @@ def test_render_outage_pdf(outage_report_with_raw, dash_url):
     if shutil.which('pdflatex') is None:  # pragma: no cover
         pytest.skip('pdflatex must be on PATH to generate PDF reports')
     rendered = template.render_pdf(outage_report_with_raw, dash_url)
-    assert "Outage" in rendered
     assert rendered.startswith(b'%PDF')

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -1136,3 +1136,16 @@ def test_report_parameters_timezone(report_params_dict, report_params):
     rpd = datamodel.ReportParameters.from_dict(report_params_dict)
     rp = report_params.replace(timezone='Etc/GMT+7')
     assert rpd == rp
+
+
+def test_outage_report_roundtrip(report_objects_with_outages):
+    report = report_objects_with_outages[0]
+    serialized = report.to_dict()
+    assert serialized['outages'] == (
+       {
+            "start": "2019-04-01T06:00:00+00:00",
+            "end": "2019-04-01T08:00:00+00:00"
+        },
+    )
+    instantiated = datamodel.Report.from_dict(serialized)
+    assert report == instantiated


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] closes #730 
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Adds handling for excluding outage periods from a report. Counterpart to API PR https://github.com/SolarArbiter/solarforecastarbiter-api/pull/325.

Converts a collection of (start, end) values representing system outages into a collection of (start, end) values that represents the forecast values associated with any forecast submissions that fall within an outage.  Then we use the start, end values to mask out forecast *and* observation values from the report before applying quality flags or other validation. This is so that we don't mistakenly report values that were dropped due to an outage as missing. 