### PR TITLE
Outage Tweaks

### DIFF
--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1750,13 +1750,9 @@ def report_objects(aggregate, ref_forecast_id):
 
 @pytest.fixture
 def report_objects_with_outages(report_objects):
-    created_at = report_objects[0].report_parameters.start
-    modified_at = created_at
     report_outages = (datamodel.TimePeriod(
         start=pd.Timestamp("20190401T0600Z"),
-        end=pd.Timestamp("20190401T0800Z"),
-        created_at=created_at,
-        modified_at=modified_at
+        end=pd.Timestamp("20190401T0800Z")
     ),)
     new_report = report_objects[0].replace(outages=report_outages)
     return (
@@ -4182,8 +4178,10 @@ def outage_report_with_raw(
     report_objects_with_outages, raw_report_with_outages
 ):
     report = report_objects_with_outages[0]
+    raw = raw_report_with_outages(True)
+    raw = raw.replace(outages=report.outages)
     report = report.replace(
-        raw_report=raw_report_with_outages(True),
+        raw_report=raw,
         status='complete'
     )
     return report

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -1750,9 +1750,13 @@ def report_objects(aggregate, ref_forecast_id):
 
 @pytest.fixture
 def report_objects_with_outages(report_objects):
+    created_at = report_objects[0].report_parameters.start
+    modified_at = created_at
     report_outages = (datamodel.TimePeriod(
         start=pd.Timestamp("20190401T0600Z"),
-        end=pd.Timestamp("20190401T0800Z")
+        end=pd.Timestamp("20190401T0800Z"),
+        created_at=created_at,
+        modified_at=modified_at
     ),)
     new_report = report_objects[0].replace(outages=report_outages)
     return (

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1867,6 +1867,22 @@ class ReportMessage(BaseModel):
 
 
 @dataclass(frozen=True)
+class TimePeriod(BaseModel):
+    """Class for storing a generic time period. For example, a report
+    outage.
+
+    Parameters
+    ----------
+    start : pandas.Timestamp
+        Start time of the time period.
+    end : pandas.Timestamp
+        End time of the time period.
+    """
+    start: pd.Timestamp
+    end: pd.Timestamp
+
+
+@dataclass(frozen=True)
 class RawReport(BaseModel):
     """Class for holding the result of processing a report request
     including some metadata, the calculated metrics, plots, the
@@ -1890,7 +1906,8 @@ class RawReport(BaseModel):
     messages: tuple of :py:class:`solarforecastarbiter.datamodel.ReportMessage`
     data_checksum: str or None
         SHA-256 checksum of the raw data used in the report.
-
+    outages: Tuple[TimePeriod, ...], optional
+        List of report outage periods used when this raw report was generated.
     """  # NOQA
     generated_at: pd.Timestamp
     timezone: str
@@ -1900,6 +1917,7 @@ class RawReport(BaseModel):
     processed_forecasts_observations: Tuple[ProcessedForecastObservation, ...]
     messages: Tuple[ReportMessage, ...] = ()
     data_checksum: Union[str, None] = None
+    outages: Tuple[TimePeriod, ...] = ()
 
 
 def __check_cost_consistency__(object_pairs, available_costs):
@@ -1965,28 +1983,6 @@ class ReportParameters(BaseModel):
         # ensure that categories are valid
         __check_categories__(self.categories)
         __check_cost_consistency__(self.object_pairs, self.costs)
-
-
-@dataclass(frozen=True)
-class TimePeriod(BaseModel):
-    """Class for storing a generic time period. For example, a report
-    outage.
-
-    Parameters
-    ----------
-    start : pandas.Timestamp
-        Start time of the time period.
-    end : pandas.Timestamp
-        End time of the time period.
-    created_at: pandas.Timestamp, optional
-        When the timeperiod was created.
-    modified_at: pandas.Timestamp, optional
-        When the timeperiod was last modified.
-    """
-    start: pd.Timestamp
-    end: pd.Timestamp
-    created_at: Union[None, pd.Timestamp] = None
-    modified_at: Union[None, pd.Timestamp] = None
 
 
 @dataclass(frozen=True)

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -1978,9 +1978,15 @@ class TimePeriod(BaseModel):
         Start time of the time period.
     end : pandas.Timestamp
         End time of the time period.
+    created_at: pandas.Timestamp, optional
+        When the timeperiod was created.
+    modified_at: pandas.Timestamp, optional
+        When the timeperiod was last modified.
     """
     start: pd.Timestamp
     end: pd.Timestamp
+    created_at: Union[None, pd.Timestamp] = None
+    modified_at: Union[None, pd.Timestamp] = None
 
 
 @dataclass(frozen=True)

--- a/solarforecastarbiter/reports/main.py
+++ b/solarforecastarbiter/reports/main.py
@@ -203,7 +203,7 @@ def create_raw_report_from_data(report, data):
         generated_at=generated_at, timezone=timezone, versions=versions,
         plots=report_plots, metrics=tuple(metrics_list + summary_stats),
         processed_forecasts_observations=tuple(processed_fxobs),
-        messages=messages)
+        messages=messages, outages=report.outages)
     return raw_report
 
 

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -1,7 +1,8 @@
 {% extends base_template %}
 {% import "macros.j2" as macros with context %}
 {% set report_name = report.report_parameters.name %}
-
+{# only display outages that existed before last compute #}
+{% set report_outages = report.outages | selectattr("created_at", "le", report.raw_report.generated_at) |list  %}
 {% block body %}
 <style type="text/css" scoped>
   .report-table-wrapper{
@@ -91,7 +92,7 @@
     <li><a href="#costparams">Cost Parameters</a></li>
   </ul>
   {% endif %}
-  {% if report.report_parameters.outages | length > 0 %}
+  {% if report_outages | length > 0 %}
   <ul>
     <li><a href="#outages">Outages</li>
   </ul>
@@ -162,8 +163,7 @@
 </div>
 {% endfor %}
 {% endif %}
-{% set outages = report.outages %}
-{% if outages | length > 0 %}
+{% if report_outages | length > 0 %}
 <h4 id="outages">Outages</h4>
 <p>
 Forecast submissions that fall within the periods listed below are excluded from analysis.
@@ -176,7 +176,7 @@ Forecast submissions that fall within the periods listed below are excluded from
     </tr>
   </thead>
   <tbody>
-    {% for outage in outages %}
+    {% for outage in report_outages %}
     <tr>
       <td>{{ outage['start'] }}</td>
       <td>{{ outage['end'] }}</td>

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -128,8 +128,8 @@
 
 {% if report.outages != report.raw_report.outages %}
   {{ messages.append(
-    "Outages have been added since the report was last computed. "
-    "Recompute to use the new outages.")
+    "Outages have been modified since the report was last computed. "
+    "Recompute to use the updated outages.")
    }}
 {% endif %}
 

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -127,6 +127,14 @@
 
 {% block errors %}
 {% set messages = (report.raw_report.messages | map(attribute="message") | list) + (templating_messages | default([]))%}
+
+{% if report_outages | length < report.outages | length %}
+  {{ messages.append(
+    "Outages have been added since the report was last computed. "
+    "Recompute to use the new outages.")
+   }}
+{% endif %}
+
 {% if messages | length > 0 %}
 <div class="alert alert-warning">
   {% for mesg in messages %}

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -1,7 +1,6 @@
 {% extends base_template %}
 {% import "macros.j2" as macros with context %}
 {% set report_name = report.report_parameters.name %}
-{# only display outages that existed before last compute #}
 {% block body %}
 <style type="text/css" scoped>
   .report-table-wrapper{

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -2,7 +2,7 @@
 {% import "macros.j2" as macros with context %}
 {% set report_name = report.report_parameters.name %}
 {# only display outages that existed before last compute #}
-{% set report_outages = report.outages | selectattr("created_at", "le", report.raw_report.generated_at) |list  %}
+{% set report_outages = report.outages | rejectattr("created_at", "none") |selectattr("created_at", "le", report.raw_report.generated_at) |list  %}
 {% block body %}
 <style type="text/css" scoped>
   .report-table-wrapper{

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -2,7 +2,6 @@
 {% import "macros.j2" as macros with context %}
 {% set report_name = report.report_parameters.name %}
 {# only display outages that existed before last compute #}
-{% set report_outages = report.outages | rejectattr("created_at", "none") |selectattr("created_at", "le", report.raw_report.generated_at) |list  %}
 {% block body %}
 <style type="text/css" scoped>
   .report-table-wrapper{
@@ -92,7 +91,7 @@
     <li><a href="#costparams">Cost Parameters</a></li>
   </ul>
   {% endif %}
-  {% if report_outages | length > 0 %}
+  {% if report.raw_report.outages | length > 0 %}
   <ul>
     <li><a href="#outages">Outages</li>
   </ul>
@@ -128,7 +127,7 @@
 {% block errors %}
 {% set messages = (report.raw_report.messages | map(attribute="message") | list) + (templating_messages | default([]))%}
 
-{% if report_outages | length < report.outages | length %}
+{% if report.outages != report.raw_report.outages %}
   {{ messages.append(
     "Outages have been added since the report was last computed. "
     "Recompute to use the new outages.")
@@ -171,7 +170,7 @@
 </div>
 {% endfor %}
 {% endif %}
-{% if report_outages | length > 0 %}
+{% if report.raw_report.outages | length > 0 %}
 <h4 id="outages">Outages</h4>
 <p>
 Forecast submissions that fall within the periods listed below are excluded from analysis.
@@ -184,7 +183,7 @@ Forecast submissions that fall within the periods listed below are excluded from
     </tr>
   </thead>
   <tbody>
-    {% for outage in report_outages %}
+    {% for outage in report.raw_report.outages %}
     <tr>
       <td>{{ outage['start'] }}</td>
       <td>{{ outage['end'] }}</td>

--- a/solarforecastarbiter/reports/templates/pdf/base.tex
+++ b/solarforecastarbiter/reports/templates/pdf/base.tex
@@ -67,7 +67,7 @@ This report of forecast accuracy was automatically generated using the
 %- endfor
 %- endif
 
-%- set outages = report.outages
+%- set outages = report.outages | selectattr("created_at", "le", report.raw_report.generated_at) | list
 %- if outages | length > 0
 \subsection{Outages}
 Forecast submissions that fall within the periods listed below are excluded from analysis.

--- a/solarforecastarbiter/reports/templates/pdf/base.tex
+++ b/solarforecastarbiter/reports/templates/pdf/base.tex
@@ -67,7 +67,7 @@ This report of forecast accuracy was automatically generated using the
 %- endfor
 %- endif
 
-%- set outages = report.outages | selectattr("created_at", "le", report.raw_report.generated_at) | list
+%- set outages = report.outages | rejectattr("created_at", "none") | selectattr("created_at", "le", report.raw_report.generated_at) | list
 %- if outages | length > 0
 \subsection{Outages}
 Forecast submissions that fall within the periods listed below are excluded from analysis.

--- a/solarforecastarbiter/reports/templates/pdf/base.tex
+++ b/solarforecastarbiter/reports/templates/pdf/base.tex
@@ -67,7 +67,7 @@ This report of forecast accuracy was automatically generated using the
 %- endfor
 %- endif
 
-%- set outages = report.outages | rejectattr("created_at", "none") | selectattr("created_at", "le", report.raw_report.generated_at) | list
+%- set outages = report.raw_report.outages
 %- if outages | length > 0
 \subsection{Outages}
 Forecast submissions that fall within the periods listed below are excluded from analysis.

--- a/solarforecastarbiter/reports/tests/test_template.py
+++ b/solarforecastarbiter/reports/tests/test_template.py
@@ -518,17 +518,14 @@ def test_render_outage_report_html_new_outage_warning(
     outage_report_with_raw, dash_url, with_series,
     mocked_timeseries_plots
 ):
-    generated_at = outage_report_with_raw.raw_report.generated_at
     the_report = outage_report_with_raw.replace(
         outages=(datamodel.TimePeriod(
            start=pd.Timestamp('2021-01-01T00:00Z'),
            end=pd.Timestamp('2021-01-02T00:00Z'),
-           created_at=generated_at+pd.Timedelta('1H')
         ),)
     )
     rendered = template.render_html(
         the_report, dash_url, with_series, False)
-    assert '<h4 id="outages">Outages</h4>' not in rendered
     assert ("Outages have been added since the report was "
             "last computed.") in rendered
 

--- a/solarforecastarbiter/reports/tests/test_template.py
+++ b/solarforecastarbiter/reports/tests/test_template.py
@@ -526,7 +526,7 @@ def test_render_outage_report_html_new_outage_warning(
     )
     rendered = template.render_html(
         the_report, dash_url, with_series, False)
-    assert ("Outages have been added since the report was "
+    assert ("Outages have been modified since the report was "
             "last computed.") in rendered
 
 

--- a/solarforecastarbiter/reports/tests/test_template.py
+++ b/solarforecastarbiter/reports/tests/test_template.py
@@ -514,6 +514,25 @@ def test_render_outage_report_html_full_html(
     assert '<td style="test-align: left">Reference Forecast Values Discarded Due To Outage</td>' in rendered  # NOQA: E501
 
 
+def test_render_outage_report_html_new_outage_warning(
+    outage_report_with_raw, dash_url, with_series,
+    mocked_timeseries_plots
+):
+    generated_at = outage_report_with_raw.raw_report.generated_at
+    the_report = outage_report_with_raw.replace(
+        outages=(datamodel.TimePeriod(
+           start=pd.Timestamp('2021-01-01T00:00Z'),
+           end=pd.Timestamp('2021-01-02T00:00Z'),
+           created_at=generated_at+pd.Timedelta('1H')
+        ),)
+    )
+    rendered = template.render_html(
+        the_report, dash_url, with_series, False)
+    assert '<h4 id="outages">Outages</h4>' not in rendered
+    assert ("Outages have been added since the report was "
+            "last computed.") in rendered
+
+
 def test_render_outage_pdf(outage_report_with_raw, dash_url):
     if shutil.which('pdflatex') is None:  # pragma: no cover
         pytest.skip('pdflatex must be on PATH to generate PDF reports')

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -1145,8 +1145,6 @@ def test_outage_report_roundtrip(report_objects_with_outages):
        {
             "start": "2019-04-01T06:00:00+00:00",
             "end": "2019-04-01T08:00:00+00:00",
-            "created_at": "2019-04-01T00:00:00-07:00",
-            "modified_at": "2019-04-01T00:00:00-07:00",
         },
     )
     instantiated = datamodel.Report.from_dict(serialized)

--- a/solarforecastarbiter/tests/test_datamodel.py
+++ b/solarforecastarbiter/tests/test_datamodel.py
@@ -1144,7 +1144,9 @@ def test_outage_report_roundtrip(report_objects_with_outages):
     assert serialized['outages'] == (
        {
             "start": "2019-04-01T06:00:00+00:00",
-            "end": "2019-04-01T08:00:00+00:00"
+            "end": "2019-04-01T08:00:00+00:00",
+            "created_at": "2019-04-01T00:00:00-07:00",
+            "modified_at": "2019-04-01T00:00:00-07:00",
         },
     )
     instantiated = datamodel.Report.from_dict(serialized)


### PR DESCRIPTION
…ed before last computation

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->
  - Follow up to #752  for fixing bugs before committing to a release
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Fixes an issue where newly added outages show up in the table of outage data before they are actually used in the computed report. Limits outages shown on in the table to those created before the raw report was generated. I've done this by adding the optional `created_at` and `modified_at` properties to the TimePeriod field. But perhaps it's better to add `outages` to the raw report?
<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
