### PR TITLE
Don't print result of outage append call in jinja template

### DIFF
--- a/docs/source/whatsnew/1.0.9.rst
+++ b/docs/source/whatsnew/1.0.9.rst
@@ -15,6 +15,9 @@ API Changes
   :py:class:`~solarforecastarbiter.datamodel.TimePeriod` objects. For backward
   compatibility, instantiating a report from existing reports without this field
   results in an empty tuple.
+* Added `outages` field to :py:class:`~solarforecastarbiter.datamodel.RawReport` which
+  reflects report outages at the time the report was computed. Defaults to an empty
+  tuple.
 * Added optional `outages` argument to the preprocessing functions
   :py:func:`~solarforecastarbiter.metrics.preprocessing.process_forecast_observations`
   and

--- a/solarforecastarbiter/reports/template.py
+++ b/solarforecastarbiter/reports/template.py
@@ -303,7 +303,8 @@ def get_template_and_kwargs(report, dash_url, with_timeseries, body_only):
         ]),
         autoescape=select_autoescape(['html', 'xml']),
         lstrip_blocks=True,
-        trim_blocks=True
+        trim_blocks=True,
+        extensions=['jinja2.ext.do']
     )
     env.filters['pretty_json'] = _pretty_json
     env.filters['figure_name_filter'] = _figure_name_filter

--- a/solarforecastarbiter/reports/templates/html/body.html
+++ b/solarforecastarbiter/reports/templates/html/body.html
@@ -127,10 +127,10 @@
 {% set messages = (report.raw_report.messages | map(attribute="message") | list) + (templating_messages | default([]))%}
 
 {% if report.outages != report.raw_report.outages %}
-  {{ messages.append(
+  {% do messages.append(
     "Outages have been modified since the report was last computed. "
     "Recompute to use the updated outages.")
-   }}
+   %}
 {% endif %}
 
 {% if messages | length > 0 %}


### PR DESCRIPTION
Incorportates jinja expression statement which allows use of `{% do <statement> %}` instead of `{{ <statement> }}` the latter of which prints the result of the expression. In the case of the list.append function, this was causing `None` to be printed to the page whenever the outage update warning was printed.
