### PR TITLE
Add report step logging

### DIFF
--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -1192,7 +1192,6 @@ def raw_report_plots(report, metrics):
     metrics_df = construct_metrics_dataframe(metrics, rename=abbreviate)
     # Create initial bar figures
     figure_dict = {}
-    logging.info("Creating Plotly plots.")
     # Components for other metrics
     for category in report.report_parameters.categories:
         for metric in report.report_parameters.metrics:
@@ -1205,7 +1204,6 @@ def raw_report_plots(report, metrics):
                     figure_dict[f'{category}::{metric}::{name}'] = fig
     mplots = []
 
-    logging.info("Creating plot pdfs and creating PlotlyReportFigures.")
     for k, v in figure_dict.items():
         cat, met, name = k.split('::', 2)
         figure_spec = v.to_json()

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -1192,6 +1192,7 @@ def raw_report_plots(report, metrics):
     metrics_df = construct_metrics_dataframe(metrics, rename=abbreviate)
     # Create initial bar figures
     figure_dict = {}
+    logging.info("Creating Plotly plots.")
     # Components for other metrics
     for category in report.report_parameters.categories:
         for metric in report.report_parameters.metrics:
@@ -1204,6 +1205,7 @@ def raw_report_plots(report, metrics):
                     figure_dict[f'{category}::{metric}::{name}'] = fig
     mplots = []
 
+    logging.info("Creating plot pdfs and creating PlotlyReportFigures.")
     for k, v in figure_dict.items():
         cat, met, name = k.split('::', 2)
         figure_spec = v.to_json()

--- a/solarforecastarbiter/reports/main.py
+++ b/solarforecastarbiter/reports/main.py
@@ -64,10 +64,6 @@ from solarforecastarbiter.reports.figures import plotly_figures
 from solarforecastarbiter.utils import hijack_loggers
 from solarforecastarbiter.validation.tasks import apply_validation
 
-logging.basicConfig(
-    format='%(asctime)s %(levelname)s %(message)s',
-    level=logging.INFO
-)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Adds report step logging to help identify hangups and slow downs in the report process. Currently there are only logs from workers beginning and ending report computation jobs.