### PR TITLE
Kaleido

### DIFF
--- a/.github/Minimum
+++ b/.github/Minimum
@@ -1,5 +1,5 @@
 bokeh==1.4.0
 numpy==1.18.2
 pandas==1.0.3
-plotly==4.5.0
+plotly==4.9.0
 pvlib==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ loky==2.9.0
 netCDF4==1.5.3
 numpy==1.18.2
 pandas==1.0.3
-plotly==4.5.3
+plotly==4.9
 psutil==5.7.0
 pvlib==0.8.0
 python-dateutil==2.8.1
@@ -20,3 +20,4 @@ selenium==3.141.0
 matplotlib==3.2.2
 jinja2==3.0.1
 pytz==2021.1
+kaleido==0.2.1

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,10 @@ EXTRAS_REQUIRE = {
     'plotting': [
         'bokeh>=1.4.0, <2',
         'matplotlib',
-        'plotly>=4.5.0, <5',
+        'plotly>=4.9.0, <5',
         'selenium<4',
         'jinja2',
+        'kaleido'
     ],
     'doc': ['sphinx<2.0', 'sphinx_rtd_theme']
 }

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -1164,6 +1164,12 @@ def output_pdf(fig):
     pdfs. If orca is not installed, an pdf with an error message will be
     returned.
     """
+    # If height is explicitly set on the plot, remove it before generating a pdf.
+    # To be reset at the end of the function
+    height = None
+    if fig.layout.height is not None:
+        fig.layout.pop('height')
+
     try:
         pdf = base64.a85encode(fig.to_image(format='pdf')).decode('utf-8')
     except Exception:
@@ -1174,6 +1180,10 @@ def output_pdf(fig):
         logger.error('Could not generate PDF for figure %s', name)
         # should have same text as fail SVG
         pdf = fail_pdf
+
+    # replace height if removed
+    if height is not None:
+       fig.layout.height = height
     return pdf
 
 

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -1165,10 +1165,10 @@ def output_pdf(fig):
     returned.
     """
     # If height is explicitly set on the plot, remove it before generating
-    #a pdf. Needs to be reset at the end of the function.
+    # a pdf. Needs to be reset at the end of the function.
     height = None
     if fig.layout.height is not None:
-        fig.layout.pop('height')
+        height = fig.layout.pop('height')
 
     try:
         pdf = base64.a85encode(

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -1164,14 +1164,16 @@ def output_pdf(fig):
     pdfs. If orca is not installed, an pdf with an error message will be
     returned.
     """
-    # If height is explicitly set on the plot, remove it before generating a pdf.
-    # To be reset at the end of the function
+    # If height is explicitly set on the plot, remove it before generating
+    #a pdf. Needs to be reset at the end of the function.
     height = None
     if fig.layout.height is not None:
         fig.layout.pop('height')
 
     try:
-        pdf = base64.a85encode(fig.to_image(format='pdf')).decode('utf-8')
+        pdf = base64.a85encode(
+            fig.to_image(format='pdf')
+        ).decode('utf-8')
     except Exception:
         try:
             name = fig.layout.title['text'][3:-4]
@@ -1183,7 +1185,7 @@ def output_pdf(fig):
 
     # replace height if removed
     if height is not None:
-       fig.layout.height = height
+        fig.layout.height = height
     return pdf
 
 

--- a/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
@@ -1,6 +1,5 @@
 import base64
 import json
-import shutil
 
 import pytest
 

--- a/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/tests/test_plotly_figures.py
@@ -198,10 +198,6 @@ def test_raw_report_plots(no_stats_report):
 def test_output_svg_with_plotly_figure(mocker):
     logger = mocker.patch(
         'solarforecastarbiter.reports.figures.plotly_figures.logger')
-    if shutil.which('orca') is None:  # pragma: no cover
-        pytest.skip('orca must be on PATH to make SVGs')
-    if shutil.which('xvfb-run') is None:  # pragma: no cover
-        pytest.skip('xvfb-run must be on PATH to make SVGs')
     values = list(range(5))
     fig = graph_objects.Figure(data=graph_objects.Scatter(x=values, y=values))
     svg = figures.output_svg(fig)
@@ -213,10 +209,6 @@ def test_output_svg_with_plotly_figure(mocker):
 def test_output_pdf_with_plotly_figure(mocker):
     logger = mocker.patch(
         'solarforecastarbiter.reports.figures.plotly_figures.logger')
-    if shutil.which('orca') is None:  # pragma: no cover
-        pytest.skip('orca must be on PATH to make PDFs')
-    if shutil.which('xvfb-run') is None:  # pragma: no cover
-        pytest.skip('xvfb-run must be on PATH to make PDFs')
     values = list(range(5))
     fig = graph_objects.Figure(data=graph_objects.Scatter(x=values, y=values))
     pdf = figures.output_pdf(fig)
@@ -224,30 +216,6 @@ def test_output_pdf_with_plotly_figure(mocker):
     assert pdf_bytes.startswith(b'%PDF-')
     assert pdf_bytes.rstrip(b'\n').endswith(b'%%EOF')
     assert not logger.error.called
-
-
-def test_output_svg_with_plotly_figure_no_orca(mocker, remove_orca):
-    logger = mocker.patch(
-        'solarforecastarbiter.reports.figures.plotly_figures.logger')
-    values = list(range(5))
-    fig = graph_objects.Figure(data=graph_objects.Scatter(x=values, y=values))
-    svg = figures.output_svg(fig)
-    assert svg.startswith('<svg')
-    assert 'Unable' in svg
-    assert svg.endswith('</svg>')
-    assert logger.error.called
-
-
-def test_output_pdf_with_plotly_figure_no_orca(mocker, remove_orca):
-    logger = mocker.patch(
-        'solarforecastarbiter.reports.figures.plotly_figures.logger')
-    values = list(range(5))
-    fig = graph_objects.Figure(data=graph_objects.Scatter(x=values, y=values))
-    pdf = figures.output_pdf(fig)
-    pdf_bytes = base64.a85decode(pdf)
-    assert pdf_bytes.startswith(b'%PDF-')
-    assert pdf_bytes.rstrip(b'\n').endswith(b'%%EOF')
-    assert logger.error.called
 
 
 @pytest.fixture()


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - [x] Closes #527 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Bumps the plotly version to 4.9 and adds kaleido as a requirement. 4.9 is the minimum plotly version where kaleido is the default static image export engine, and updating these dependencies should be all we need to make this function. I'm leaving the kaleido version unpinned since it is <v1 and I think we'd want to keep up with releases and only pin if tests start to fail.

If we decide to go this way we should:

- [ ] Update tests that skip if orca is not present
- [ ] Remove orca server cli command
- [ ] See if we can update further to plotly 5.
- [ ] Remove discussion of orca throughout codebase.