### PR TITLE
Orca cleanup

### DIFF
--- a/docs/source/whatsnew/1.0.11.rst
+++ b/docs/source/whatsnew/1.0.11.rst
@@ -1,0 +1,22 @@
+.. _whatsnew_1011:
+
+.. py:currentmodule:: solarforecastarbiter
+
+
+1.0.11 (December 13, 2021)
+--------------------------
+
+Enhancements
+~~~~~~~~~~~~
+* Updated Plotly version to 4.9 which uses Kaleido for pdf plot
+  rendering. Use of Kaleido removes the need for starting an Orca
+  server when generating reports and is available as a pip installable
+  package with no other dependencies. This update also improves
+  performance and reliability of the report computation process.
+  (:pull:`765`)
+
+Contributors
+~~~~~~~~~~~~
+
+* Will Holmgren (:ghuser:`wholmgren`)
+* Leland Boeman (:ghuser:`lboeman`)

--- a/docs/source/whatsnew/index.rst
+++ b/docs/source/whatsnew/index.rst
@@ -9,6 +9,7 @@ These are new features and improvements of note in each release.
 .. toctree::
    :maxdepth: 2
 
+   1.0.11
    1.0.10
    1.0.9
    1.0.8

--- a/solarforecastarbiter/cli.py
+++ b/solarforecastarbiter/cli.py
@@ -445,17 +445,12 @@ def referencenwp(verbose, user, password, base_url, run_time,
     '--serialization-roundtrip', is_flag=True,
     help='Run the raw report through a mock API with serialization'
 )
-@click.option(
-    '--orca-server-url', help=(
-        'URL to the plotly orca server to generate PDF images if '
-        'orca is not installed locally')
-)
 @click.argument(
     'report-file', type=click.Path(exists=True, resolve_path=True))
 @click.argument(
     'output-file', type=click.Path(resolve_path=True))
 def report(verbose, user, password, base_url, report_file, output_file,
-           format, serialization_roundtrip, orca_server_url):
+           format, serialization_roundtrip):
     """
     Make a report. See API documentation's POST reports section for
     REPORT_FILE requirements.
@@ -468,9 +463,6 @@ def report(verbose, user, password, base_url, report_file, output_file,
         metadata = json.load(f)
     session = APISession(token, base_url=base_url)
     report = session.process_report_dict(metadata)
-    if orca_server_url is not None:
-        import plotly.io as pio
-        pio.orca.config.server_url = orca_server_url
     if serialization_roundtrip:
         with mock_raw_report_endpoints(base_url):
             session.create_report(report)

--- a/solarforecastarbiter/conftest.py
+++ b/solarforecastarbiter/conftest.py
@@ -3843,13 +3843,6 @@ def raw_report_dict_with_prob(fail_pdf):
     }
 
 
-@pytest.fixture(scope='function')
-def remove_orca():
-    # otherwise generating all pdfs for tests can take ages
-    import plotly.io as pio
-    pio.orca.config.executable = '/dev/null'
-
-
 @pytest.fixture()
 def constant_cost():
     return datamodel.ConstantCost(

--- a/solarforecastarbiter/reports/figures/plotly_figures.py
+++ b/solarforecastarbiter/reports/figures/plotly_figures.py
@@ -1120,12 +1120,6 @@ def output_svg(fig):
     Returns
     -------
     svg : str
-
-    Notes
-    -----
-    Requires `Orca <https://plot.ly/python/orca-management/>`_ for generating
-    svgs. If orca is not installed, an svg with an error message will be
-    returned.
     """
     try:
         svg = fig.to_image(format='svg').decode('utf-8')
@@ -1157,12 +1151,6 @@ def output_pdf(fig):
     -------
     pdf : str
        An ASCII-85 encoded PDF
-
-    Notes
-    -----
-    Requires `Orca <https://plot.ly/python/orca-management/>`_ for generating
-    pdfs. If orca is not installed, an pdf with an error message will be
-    returned.
     """
     # If height is explicitly set on the plot, remove it before generating
     # a pdf. Needs to be reset at the end of the function.

--- a/solarforecastarbiter/reports/tests/test_reports_main.py
+++ b/solarforecastarbiter/reports/tests/test_reports_main.py
@@ -19,7 +19,7 @@ EMPTY_DF = pd.DataFrame(columns=['value', 'quality_flag'],
 
 
 @pytest.fixture()
-def _test_data(report_objects, ref_forecast_id, remove_orca):
+def _test_data(report_objects, ref_forecast_id):
     report, observation, forecast_0, forecast_1, aggregate, forecast_agg = \
         report_objects
     base = Path(__file__).resolve().parent
@@ -82,7 +82,7 @@ def test_get_data_for_report(mock_data, report_objects, mocker):
 
 
 @pytest.fixture()
-def _test_event_data(event_report_objects, remove_orca):
+def _test_event_data(event_report_objects):
     report, observation, forecast_0, forecast_1 = event_report_objects
 
     tz = "US/Pacific"


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

  - Follow up of #765 
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!--
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Removes orca fixtures, doctstring notes, and cli.

Tested in dev by cloning the report Bondville IL report (https://dashboard.solarforecastarbiter.org/reports/cfdd7674-49f2-11ea-8b7f-0a580a8002e1) and adjusting the time range to 2020-01-01 00:00:00-06:00 - 2020-03-07 00:00:00-06:00. Recomputing 5 times, the Orca process took an average of 20 seconds for plot generation, and Kaleido took 5.