### PR TITLE
Metrics: make CRPS handle obs outside the fx support

### DIFF
--- a/docs/source/whatsnew/1.0.13.rst
+++ b/docs/source/whatsnew/1.0.13.rst
@@ -1,4 +1,4 @@
-.. _whatsnew_1012:
+.. _whatsnew_1013:
 
 .. py:currentmodule:: solarforecastarbiter
 

--- a/docs/source/whatsnew/1.0.13.rst
+++ b/docs/source/whatsnew/1.0.13.rst
@@ -1,0 +1,18 @@
+.. _whatsnew_1012:
+
+.. py:currentmodule:: solarforecastarbiter
+
+
+1.0.13 (February 10, 2022)
+--------------------------
+
+Fixed
+~~~~~~~~~~~~
+* Revised CRPS metric to handle observations outside the forecast support. (:pull:`781`, :issue:`779`)
+
+Contributors
+~~~~~~~~~~~~
+
+* Will Holmgren (:ghuser:`wholmgren`)
+* Leland Boeman (:ghuser:`lboeman`)
+* David Larson (:ghuser:`dplarson`)

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -468,15 +468,19 @@ def sharpness(fx_lower, fx_upper):
 def continuous_ranked_probability_score(obs, fx, fx_prob):
     """Continuous Ranked Probability Score (CRPS).
 
-        CRPS = 1/n sum_{i=1}^n int (F_i - O_i)^2 dx
+    .. math::
 
-    where F_i is the CDF of the forecast at time i and O_i is the CDF
-    associated with the observed value obs_i:
+        \\text{CRPS} = \\frac{1}{n} \\sum_{i=1}^n \\int_{-\\infty}^{\\infty}
+        (F_i(x) - \\mathbf{1} \\{x \\geq y_i \\})^2 dx
 
-        O_{i, j} = 1 if obs_i <= fx_{i, j}, else O_{i, j} = 0
-
-    where obs_i is the observation at time i, and fx_{i, j} is the forecast at
-    time i for CDF interval j.
+    where :math:`F_i(x)` is the CDF of the forecast at time :math:`i`,
+    :math:`y_i` is the observation at time :math:`i`, and :math:`\\mathbf{1}`
+    is the indicator function that transforms the observation into a step
+    function (1 if :math:`x \\geq y`, 0 if :math:`x < y`). In other words, the
+    CRPS measures the difference between the forecast CDF and the empirical CDF
+    of the observation. The CRPS has the same units as the observation and
+    lower CRPS values indicate more accurate forecasts, where a CRPS of 0
+    indicates a perfect forecast. [1]_ [2]_ [3]_
 
     Parameters
     ----------
@@ -492,7 +496,8 @@ def continuous_ranked_probability_score(obs, fx, fx_prob):
     Returns
     -------
     crps : float
-        The Continuous Ranked Probability Score [unitless].
+        The Continuous Ranked Probability Score, with the same units as the
+        observation.
 
     Raises
     ------
@@ -502,22 +507,27 @@ def continuous_ranked_probability_score(obs, fx, fx_prob):
         array with d values or b) the forecasts are given as 2D arrays (n,d)
         but do not contain at least 2 CDF intervals (i.e. d < 2).
 
-    Examples
-    --------
+    Notes
+    -----
+    The CRPS can be calculated analytically when the forecast CDF is of a
+    continuous parametric distribution, e.g., Gaussian distribution. However,
+    since the Solar Forecast Arbiter makes no assumptions regarding how a
+    probabilistic forecast was generated, the CRPS is instead calculated using
+    numerical integration of the discretized forecast PDF. Therefore, the
+    accuracy of the CRPS calculation is limited by the precision of the
+    forecast CDF. In practice, this means the forecast CDF should 1) consist of
+    at least 10 intervals and 2) cover probabilities from 0 to 100%.
 
-    Forecast probabilities of <= 10 MW and <= 20 MW:
-    >>> fx = np.array([[10, 20], [10, 20]])
-    >>> fx_prob = np.array([[30, 50], [65, 100]])
-    >>> obs = np.array([8, 12])
-    >>> continuous_ranked_probability_score(obs, fx, fx_prob)
-    4.5625
-
-    Forecast thresholds for constant probabilities (25%, 75%):
-    >>> fx = np.array([[5, 15], [8, 14]])
-    >>> fx_prob = np.array([[25, 75], [25, 75]])
-    >>> obs = np.array([8, 10])
-    >>> continuous_ranked_probability_score(obs, fx, fx_prob)
-    0.5
+    References
+    ----------
+    .. [1] Matheson and Winkler (1976) "Scoring rules for continuous
+           probability distributions." Management Sciience, vol. 22, pp.
+           1087-1096. doi: 10.1287/mnsc.22.10.1087
+    .. [2] Hersbach (2000) "Decomposition of the continuous ranked probability
+           score for ensemble prediction systems." Weather Forecast, vol. 15,
+           pp. 559-570. doi: 10.1175/1520-0434(2000)015<0559:DOTCRP>2.0.CO;2
+    .. [3] Wilks (2019) "Statistical Methods in the Atmospheric Sciences", 4th
+           ed. Oxford; Waltham, MA; Academic Press.
 
     """
 
@@ -529,19 +539,41 @@ def continuous_ranked_probability_score(obs, fx, fx_prob):
         raise ValueError("forecasts must have d >= 2 CDF intervals "
                          f"(expected >= 2, got {np.shape(fx)[1]})")
     else:
-        obs = np.tile(obs, (fx.shape[1], 1)).T
 
-    # event: 0=did not happen, 1=did happen
-    o = np.where(obs <= fx, 1.0, 0.0)
+        n = len(fx)
 
-    # forecast probabilities [unitless]
-    f = fx_prob / 100.0
+        # extend CDF min to ensure obs within forecast support
+        # (n, d) ==> (n, d + 1)
+        fx = np.hstack([np.minimum(obs, fx[:, [0]]), fx])
+        fx_prob = np.hstack([np.zeros([n, 1]), fx_prob])
 
-    # integrate along each sample, then average all samples
-    integrand = (f - o) ** 2
-    dx = np.diff(fx, axis=1)
-    crps = np.mean(np.sum(integrand[:, :-1] * dx, axis=1))
-    return crps
+        # extend CDF max to ensure obs within forecast support
+        # (n, d + 1) ==> (n, d + 2)
+        idx = (fx[:, -1] < obs)
+        fx = np.hstack([fx, np.maximum(obs, fx[:, [-1]])])
+        fx_prob = np.hstack([fx_prob, np.full([n, 1], 100)])
+
+        # indicator function:
+        # - left of the obs is 0.0
+        # - obs and right of the obs is 1.0
+        o = np.where(fx >= obs, 1.0, 0.0)
+
+        # correct behavior when obs > max fx:
+        # - should be 0 over range: max fx < x < obs
+        o[idx, -1] = 0.0
+
+        # forecast probabilities [unitless]
+        f = fx_prob / 100.0
+
+        # integrate along each sample, then average all samples
+        integrand = (f - o) ** 2
+        dx = fx[:, 1:] - fx[:, :-1]
+        crps = np.mean(np.sum(
+            (integrand[:, 1:] + integrand[:, :-1]) / 2 * dx,  # quadrature rule
+            axis=1
+        ))
+
+        return crps
 
 
 def crps_skill_score(obs, fx, fx_prob, ref, ref_prob):

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -513,10 +513,10 @@ def continuous_ranked_probability_score(obs, fx, fx_prob):
     continuous parametric distribution, e.g., Gaussian distribution. However,
     since the Solar Forecast Arbiter makes no assumptions regarding how a
     probabilistic forecast was generated, the CRPS is instead calculated using
-    numerical integration of the discretized forecast PDF. Therefore, the
+    numerical integration of the discretized forecast CDF. Therefore, the
     accuracy of the CRPS calculation is limited by the precision of the
     forecast CDF. In practice, this means the forecast CDF should 1) consist of
-    at least 10 intervals and 2) cover probabilities from 0 to 100%.
+    at least 10 intervals and 2) cover probabilities from 0% to 100%.
 
     References
     ----------
@@ -566,12 +566,7 @@ def continuous_ranked_probability_score(obs, fx, fx_prob):
         f = fx_prob / 100.0
 
         # integrate along each sample, then average all samples
-        integrand = (f - o) ** 2
-        dx = fx[:, 1:] - fx[:, :-1]
-        crps = np.mean(np.sum(
-            (integrand[:, 1:] + integrand[:, :-1]) / 2 * dx,  # quadrature rule
-            axis=1
-        ))
+        crps = np.mean(np.trapz((f - o) ** 2, x=fx, axis=1))
 
         return crps
 

--- a/solarforecastarbiter/metrics/probabilistic.py
+++ b/solarforecastarbiter/metrics/probabilistic.py
@@ -478,9 +478,9 @@ def continuous_ranked_probability_score(obs, fx, fx_prob):
     is the indicator function that transforms the observation into a step
     function (1 if :math:`x \\geq y`, 0 if :math:`x < y`). In other words, the
     CRPS measures the difference between the forecast CDF and the empirical CDF
-    of the observation. The CRPS has the same units as the observation and
-    lower CRPS values indicate more accurate forecasts, where a CRPS of 0
-    indicates a perfect forecast. [1]_ [2]_ [3]_
+    of the observation. The CRPS has the same units as the observation. Lower
+    CRPS values indicate more accurate forecasts, where a CRPS of 0 indicates a
+    perfect forecast. [1]_ [2]_ [3]_
 
     Parameters
     ----------
@@ -521,7 +521,7 @@ def continuous_ranked_probability_score(obs, fx, fx_prob):
     References
     ----------
     .. [1] Matheson and Winkler (1976) "Scoring rules for continuous
-           probability distributions." Management Sciience, vol. 22, pp.
+           probability distributions." Management Science, vol. 22, pp.
            1087-1096. doi: 10.1287/mnsc.22.10.1087
     .. [2] Hersbach (2000) "Decomposition of the continuous ranked probability
            score for ensemble prediction systems." Weather Forecast, vol. 15,
@@ -542,13 +542,13 @@ def continuous_ranked_probability_score(obs, fx, fx_prob):
     n = len(fx)
 
     # extend CDF min to ensure obs within forecast support
-    # (n, d) ==> (n, d + 1)
+    # fx.shape = (n, d) ==> (n, d + 1)
     fx_min = np.minimum(obs, fx[:, 0])
     fx = np.hstack([fx_min[:, np.newaxis], fx])
     fx_prob = np.hstack([np.zeros([n, 1]), fx_prob])
 
     # extend CDF max to ensure obs within forecast support
-    # (n, d + 1) ==> (n, d + 2)
+    # fx.shape = (n, d + 1) ==> (n, d + 2)
     idx = (fx[:, -1] < obs)
     fx_max = np.maximum(obs, fx[:, -1])
     fx = np.hstack([fx, fx_max[:, np.newaxis]])

--- a/solarforecastarbiter/metrics/tests/test_calculator.py
+++ b/solarforecastarbiter/metrics/tests/test_calculator.py
@@ -361,12 +361,12 @@ def test_calculate_metrics_with_probablistic(single_observation,
                          probabilistic._REQ_DIST)
 
     expected = {
-        0: ('total', 'crps', '0', 17.247),
-        2: ('year', 'crps', '2019', 17.247),
-        4: ('season', 'crps', 'JJA', 17.247),
-        6: ('month', 'crps', 'Aug', 17.247),
-        8: ('hour', 'crps', '0', 19.801000000000002),
-        9: ('hour', 'crps', '1', 19.405)
+        0: ('total', 'crps', '0', 21.41819),
+        2: ('year', 'crps', '2019', 21.41819),
+        4: ('season', 'crps', 'JJA', 21.41819),
+        6: ('month', 'crps', 'Aug', 21.41819),
+        8: ('hour', 'crps', '0', 28.103),
+        9: ('hour', 'crps', '1', 26.634375),
     }
     attr_order = ('category', 'metric', 'index', 'value')
     for k, expected_attrs in expected.items():
@@ -1006,7 +1006,7 @@ def test_apply_deterministic_bad_metric_func():
     ('bs', [], [], [], None, None, np.NaN),
     ('bs', [1, 1, 1], [100, 100, 100], [1, 1, 1], None, None, 0.),
 
-    # Briar Skill Score with no reference
+    # Brier Skill Score with no reference
     ('bss', [1, 1, 1], [100, 100, 100], [0, 0, 0],
         None, None, 1.),
     ('bss', [1, 1, 1], [100, 100, 100], [1, 1, 1],
@@ -1017,11 +1017,11 @@ def test_apply_deterministic_bad_metric_func():
     ('unc', [1, 1, 1], [100, 100, 100], [1, 1, 1], None, None, 0.),
 
     # CRPS single forecast
-    ('crps', [[1, 1]], [[100, 100]], [[0, 0]], None, None, 0.),
+    ('crps', [[1, 1]], [[100, 100]], [0], None, None, 0.5),
     # CRPS mulitple forecasts
     ('crps', [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
              [[100, 100, 100], [100, 100, 100], [100, 100, 100]],
-             [0, 0, 0], None, None, 0.)
+             [0, 0, 0], None, None, 1.)
 ])
 def test_apply_probabilistic_metric_func(metric, fx, fx_prob, obs,
                                          ref_fx, ref_fx_prob, expect,

--- a/solarforecastarbiter/metrics/tests/test_probabilistic.py
+++ b/solarforecastarbiter/metrics/tests/test_probabilistic.py
@@ -254,7 +254,6 @@ def test_crps_shape(fx, fx_prob, obs):
     (np.array([15]), 3.879637),
     (np.array([35]), 13.871621),
     (np.array([39]), 17.871621),  # obs > max fx
-
 ])
 def test_crps_gaussian(fx, fx_prob, obs, value):
     crps = prob.continuous_ranked_probability_score(obs, fx, fx_prob)

--- a/solarforecastarbiter/metrics/tests/test_probabilistic.py
+++ b/solarforecastarbiter/metrics/tests/test_probabilistic.py
@@ -284,6 +284,10 @@ def test_sharpness(fx_lower, fx_upper, value):
         (1.0 ** 2) * 10 + (0.5 ** 2) * 10,
     ),
 
+    # obs outside the forecast support
+    # - obs > forecast max
+    # - obs < forecast min
+
     # fail: only 1 CDF interval
     pytest.param(
         np.array([[10], [20]]),

--- a/solarforecastarbiter/metrics/tests/test_probabilistic.py
+++ b/solarforecastarbiter/metrics/tests/test_probabilistic.py
@@ -297,3 +297,133 @@ def test_crps_perfect_fx(fx, fx_prob, obs, value):
 def test_crps_linear_cdf(fx, fx_prob, obs, value):
     crps = prob.continuous_ranked_probability_score(obs, fx, fx_prob)
     assert_allclose(crps, value, rtol=1e-2)
+
+
+@pytest.mark.parametrize("fx,fx_prob,obs,value", [
+    # obs outside forecast support: obs < min fx
+    (
+        np.array([[10, 20, 30]]),
+        np.array([[0, 60, 100]]),
+        9,
+        7.6,  # 1.0 + 5.8 + 0.8,
+    ),
+    (
+        np.array([[10, 20, 30]]),
+        np.array([[0, 60, 100]]),
+        8,
+        8.6,  # 2.0 + 5.8 + 0.8,
+    ),
+
+    (
+        np.array([[10, 20, 30]]),
+        np.array([[0, 40, 100]]),
+        9,
+        9.6,  # 1.0 + 6.8 + 1.8,
+    ),
+
+    # obs within forecast support
+    (
+        np.array([[10, 20, 30]]),
+        np.array([[0, 60, 100]]),
+        10,
+        6.6,  # 5.8 + 0.8,
+    ),
+    (
+        np.array([[10, 20, 30]]),
+        np.array([[0, 60, 100]]),
+        11,
+        0.8 + 0.8,
+    ),
+    (
+        np.array([[10, 20, 30]]),
+        np.array([[0, 60, 100]]),
+        20,
+        1.6,  # 0.8 + 0.8,
+    ),
+    (
+        np.array([[10, 20, 30]]),
+        np.array([[0, 60, 100]]),
+        21,
+        3.6,  # 1.8 + 1.8,
+    ),
+    (
+        np.array([[10, 20, 30]]),
+        np.array([[0, 60, 100]]),
+        30,
+        3.6,  # 1.8 + 1.8,
+    ),
+
+    (
+        np.array([[10, 20, 30]]),
+        np.array([[0, 40, 100]]),
+        20,
+        3.6,  # 1.8 + 1.8,
+    ),
+    (
+        np.array([[10, 20, 30]]),
+        np.array([[0, 40, 100]]),
+        30,
+        1.6,  # 0.8 + 0.8,
+    ),
+
+    # obs outside forecast support: obs > max fx
+    (
+        np.array([[10, 20, 30]]),
+        np.array([[0, 60, 100]]),
+        31,
+        9.6,  # 1.8 + 6.8 + 1,
+    ),
+
+    # obs outside forecast support: obs > max fx
+    (
+        np.array([[10, 20, 30]]),
+        np.array([[0, 60, 100]]),
+        32,
+        10.6,  # 1.8 + 6.8 + 2,
+    ),
+])
+def test_crps_simple(fx, fx_prob, obs, value):
+    crps = prob.continuous_ranked_probability_score(obs, fx, fx_prob)
+    assert_allclose(crps, value, rtol=1e-2)
+
+
+@pytest.mark.parametrize("fx,fx_prob,ref,ref_prob,obs,value", [
+    # obs inside forecast support
+    (
+        np.array([[10, 20, 30]]),  # fx
+        np.array([[0, 60, 100]]),  # fx_prob
+        np.array([[10, 20, 30]]),  # ref
+        np.array([[0, 40, 100]]),  # ref_prob
+        20,                        # obs
+        1.0 - 1.6 / 3.6,
+    ),
+    (
+        np.array([[10, 20, 30]]),  # fx
+        np.array([[0, 60, 100]]),  # fx_prob
+        np.array([[10, 20, 30]]),  # ref
+        np.array([[0, 60, 100]]),  # ref_prob
+        20,                        # obs
+        0.0,
+    ),
+
+    # obs outside forecast support
+    (
+        np.array([[10, 20, 30]]),  # fx
+        np.array([[0, 60, 100]]),  # fx_prob
+        np.array([[10, 20, 30]]),  # ref
+        np.array([[0, 40, 100]]),  # ref_prob
+        9,                         # obs
+        1.0 - 7.6 / 9.6,
+    ),
+    (
+        np.array([[10, 20, 30]]),  # fx
+        np.array([[0, 40, 100]]),  # fx_prob
+        np.array([[10, 20, 30]]),  # ref
+        np.array([[0, 40, 100]]),  # ref_prob
+        9,                         # obs
+        0.0,
+    ),
+])
+def test_crps_skill_score(fx, fx_prob, ref, ref_prob, obs, value):
+    crpss = prob.crps_skill_score(obs, fx, fx_prob, ref, ref_prob)
+    assert_allclose(crpss, value)

--- a/solarforecastarbiter/metrics/tests/test_probabilistic.py
+++ b/solarforecastarbiter/metrics/tests/test_probabilistic.py
@@ -249,11 +249,11 @@ def test_crps_shape(fx, fx_prob, obs):
 ])
 @pytest.mark.parametrize("obs,value", [
     # true CRPS from analytical function (via the `properscoring` package)
-    (1, 17.871621),  # obs < min fx
-    (5, 13.871621),
-    (15, 3.879637),
-    (35, 13.871621),
-    (39, 17.871621),  # obs > max fx
+    (np.array([1]), 17.871621),  # obs < min fx
+    (np.array([5]), 13.871621),
+    (np.array([15]), 3.879637),
+    (np.array([35]), 13.871621),
+    (np.array([39]), 17.871621),  # obs > max fx
 
 ])
 def test_crps_gaussian(fx, fx_prob, obs, value):
@@ -266,7 +266,7 @@ def test_crps_gaussian(fx, fx_prob, obs, value):
     (
         np.array([np.linspace(0, 10, 101)]),
         np.array([np.concatenate([np.zeros(50), np.ones(51) * 100])]),
-        5,
+        np.array([5]),
         0,
     ),
 
@@ -274,7 +274,7 @@ def test_crps_gaussian(fx, fx_prob, obs, value):
     (
         np.array([np.linspace(0, 10, 101)]),
         np.array([np.ones(101) * 100]),
-        0,
+        np.array([0]),
         0,
     ),
 ])
@@ -291,8 +291,8 @@ def test_crps_perfect_fx(fx, fx_prob, obs, value):
 ])
 @pytest.mark.parametrize("obs,value", [
     # linear CDF from (10, 0%) to (30, 100%)
-    (10, (np.linspace(0, 1, 1001) ** 2).sum() * 20 / 1000),
-    (30, (np.linspace(0, 1, 1001) ** 2).sum() * 20 / 1000),
+    (np.array([10]), (np.linspace(0, 1, 1001) ** 2).sum() * 20 / 1000),
+    (np.array([30]), (np.linspace(0, 1, 1001) ** 2).sum() * 20 / 1000),
 ])
 def test_crps_linear_cdf(fx, fx_prob, obs, value):
     crps = prob.continuous_ranked_probability_score(obs, fx, fx_prob)
@@ -304,20 +304,20 @@ def test_crps_linear_cdf(fx, fx_prob, obs, value):
     (
         np.array([[10, 20, 30]]),
         np.array([[0, 60, 100]]),
-        9,
+        np.array([9]),
         7.6,  # 1.0 + 5.8 + 0.8,
     ),
     (
         np.array([[10, 20, 30]]),
         np.array([[0, 60, 100]]),
-        8,
+        np.array([8]),
         8.6,  # 2.0 + 5.8 + 0.8,
     ),
 
     (
         np.array([[10, 20, 30]]),
         np.array([[0, 40, 100]]),
-        9,
+        np.array([9]),
         9.6,  # 1.0 + 6.8 + 1.8,
     ),
 
@@ -325,44 +325,44 @@ def test_crps_linear_cdf(fx, fx_prob, obs, value):
     (
         np.array([[10, 20, 30]]),
         np.array([[0, 60, 100]]),
-        10,
+        np.array([10]),
         6.6,  # 5.8 + 0.8,
     ),
     (
         np.array([[10, 20, 30]]),
         np.array([[0, 60, 100]]),
-        11,
+        np.array([11]),
         0.8 + 0.8,
     ),
     (
         np.array([[10, 20, 30]]),
         np.array([[0, 60, 100]]),
-        20,
+        np.array([20]),
         1.6,  # 0.8 + 0.8,
     ),
     (
         np.array([[10, 20, 30]]),
         np.array([[0, 60, 100]]),
-        21,
+        np.array([21]),
         3.6,  # 1.8 + 1.8,
     ),
     (
         np.array([[10, 20, 30]]),
         np.array([[0, 60, 100]]),
-        30,
+        np.array([30]),
         3.6,  # 1.8 + 1.8,
     ),
 
     (
         np.array([[10, 20, 30]]),
         np.array([[0, 40, 100]]),
-        20,
+        np.array([20]),
         3.6,  # 1.8 + 1.8,
     ),
     (
         np.array([[10, 20, 30]]),
         np.array([[0, 40, 100]]),
-        30,
+        np.array([30]),
         1.6,  # 0.8 + 0.8,
     ),
 
@@ -370,7 +370,7 @@ def test_crps_linear_cdf(fx, fx_prob, obs, value):
     (
         np.array([[10, 20, 30]]),
         np.array([[0, 60, 100]]),
-        31,
+        np.array([31]),
         9.6,  # 1.8 + 6.8 + 1,
     ),
 
@@ -378,8 +378,16 @@ def test_crps_linear_cdf(fx, fx_prob, obs, value):
     (
         np.array([[10, 20, 30]]),
         np.array([[0, 60, 100]]),
-        32,
+        np.array([32]),
         10.6,  # 1.8 + 6.8 + 2,
+    ),
+
+    # multiple samples
+    (
+        np.array([[10, 20, 30], [10, 20, 30]]),
+        np.array([[0, 60, 100], [0, 60, 100]]),
+        np.array([9, 20]),
+        (7.6 + 1.6) / 2,
     ),
 ])
 def test_crps_simple(fx, fx_prob, obs, value):
@@ -394,7 +402,7 @@ def test_crps_simple(fx, fx_prob, obs, value):
         np.array([[0, 60, 100]]),  # fx_prob
         np.array([[10, 20, 30]]),  # ref
         np.array([[0, 40, 100]]),  # ref_prob
-        20,                        # obs
+        np.array([20]),            # obs
         1.0 - 1.6 / 3.6,
     ),
     (
@@ -402,7 +410,7 @@ def test_crps_simple(fx, fx_prob, obs, value):
         np.array([[0, 60, 100]]),  # fx_prob
         np.array([[10, 20, 30]]),  # ref
         np.array([[0, 60, 100]]),  # ref_prob
-        20,                        # obs
+        np.array([20]),            # obs
         0.0,
     ),
 
@@ -412,7 +420,7 @@ def test_crps_simple(fx, fx_prob, obs, value):
         np.array([[0, 60, 100]]),  # fx_prob
         np.array([[10, 20, 30]]),  # ref
         np.array([[0, 40, 100]]),  # ref_prob
-        9,                         # obs
+        np.array([9]),             # obs
         1.0 - 7.6 / 9.6,
     ),
     (
@@ -420,7 +428,7 @@ def test_crps_simple(fx, fx_prob, obs, value):
         np.array([[0, 40, 100]]),  # fx_prob
         np.array([[10, 20, 30]]),  # ref
         np.array([[0, 40, 100]]),  # ref_prob
-        9,                         # obs
+        np.array([9]),             # obs
         0.0,
     ),
 ])


### PR DESCRIPTION
- [x] Closes #779 .
  - [X] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This PR addresses the issue identified in #779 regarding how the current implementation of the CRPS metric handles cases where the observation is outside the forecast support. For example, if the probabilistic forecasts predicts power values from 1 to 8 MW but the actual power is 10 MW. The core idea is to extend the forecast CDF so covers the observation, whether the observation is less than the minimum forecast (`obs < min fx`) or greater than the maximum forecast (`obs > max fx`).

This PR also updates the CRPS function docstring with improved equation rendering and notes on practical considerations related to calculating CRPS from discrete forecast CDFs.

Lastly, the CRPS calculation has been updated to use trapezoidal numerical integration (instead of rectangular integration). This change does not increase the computational cost of the CRPS calculation, but has lower error (`O(\delta x)` for rectangular vs `O(\delta x^2)` for trapezoidal, where `\delta x` is the spacing between points). In practice, this means the CRPS calculation is now more accurate in cases with lower resolution forecast CDFs (e.g., 0%, 10%, ..., 100%).
