### PR TITLE
Update nwp.py

### DIFF
--- a/solarforecastarbiter/io/fetch/nwp.py
+++ b/solarforecastarbiter/io/fetch/nwp.py
@@ -140,7 +140,7 @@ HRRR_HOURLY = {
     'var_VGRD': 'on',
     'update_freq': '1h',
     'valid_hr_gen': (
-        lambda x: range(37) if x in (0, 6, 12, 18) else range(19)),
+        lambda x: range(49) if x in (0, 6, 12, 18) else range(19)),
     'time_between_fcst_hrs': 120,
     'delay_to_first_forecast': '45min',
     'avg_max_run_length': '70min',


### PR DESCRIPTION

  - [ ] Closes https://github.com/SolarArbiter/solarforecastarbiter-core/issues/793 .
  - [ ] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [ ] Tests added.
  - [ ] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes.
  - [ ] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

The current NWP fetch process only grabs HRRR (hourly) out to 36 hours (for cycles where it goes out more than 18 hours), but HRRR has forecasts out to 48 hours (https://github.com/SolarArbiter/solarforecastarbiter-core/issues/793). This addresses that issue. 

I would have also addressed the issue with RAP going out to 51 hours for some cycles, but I have not been able to successfully fetch RAP NWP files to test it (see https://github.com/SolarArbiter/solarforecastarbiter-core/issues/699), so I ignored that one. 

I did run some quick tests with the changes to HRRR and I was able to successfully fetch and process grib files out to 48 hours for the relevant cycles. Someone let me know if documentation of that is needed. Similarly, I'm not sure what is needed for the checklist above, so let me know if I need to take other steps for tests, documentation, etc.
