### PR TITLE
datamodel: add `load` as an allowed variable

### DIFF
--- a/docs/source/whatsnew/1.0.14.rst
+++ b/docs/source/whatsnew/1.0.14.rst
@@ -6,6 +6,10 @@
 1.0.14 (TBD)
 --------------------------
 
+Enhancements
+~~~~~~~~~~~~
+* Datamodel now supports ``'load'`` as an allowed variable. (:issue:``) (:pull:``)
+
 Fixed
 ~~~~~~~~~~~~
 * Added table sorting in html reports.

--- a/docs/source/whatsnew/1.0.14.rst
+++ b/docs/source/whatsnew/1.0.14.rst
@@ -8,7 +8,7 @@
 
 Enhancements
 ~~~~~~~~~~~~
-* Datamodel now supports ``'load'`` as an allowed variable. (:issue:``) (:pull:``)
+* Datamodel now supports ``'load'`` as an allowed variable. (:issue:`787`) (:pull:`806`)
 
 Fixed
 ~~~~~~~~~~~~

--- a/solarforecastarbiter/datamodel.py
+++ b/solarforecastarbiter/datamodel.py
@@ -45,6 +45,7 @@ ALLOWED_VARIABLES = {
     'availability': '%',
     'curtailment': 'MW',
     'event': 'boolean',
+    'load': 'MW',
     'net_load': 'MW'
 }
 
@@ -62,6 +63,7 @@ COMMON_NAMES = {
     'availability': 'Availability',
     'curtailment': 'Curtailment',
     'event': 'Event',
+    'load': 'Load',
     'net_load': 'Net Load',
 }
 


### PR DESCRIPTION
  - [x] Closes #787 .
  - [x] I am familiar with the [contributing guidelines](https://solarforecastarbiter-core.readthedocs.io/en/latest/contributing.html).
  - [x] Tests added. **NOTE:** there are no explicit tests for existing variables (including `net_load`), so for now this PR does not add new tests.
  - [x] Updates entries to [`docs/source/api.rst`](https://github.com/SolarArbiter/solarforecastarbiter-core/blob/master/docs/source/api.rst) for API changes. **NOTE:** no API changes
  - [x] Adds descriptions to appropriate "what's new" file in [`docs/source/whatsnew`](https://github.com/SolarArbiter/solarforecastarbiter-core/tree/master/docs/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Add `load` as an allowed variable. Previously the datamodel only supported `net_load` as a variable and therefore made no distinction between (gross) load vs net load. One of the key differences is that load is generally defined as a non-negative measure of energy demand, while net load is the signed measured of energy demand import (positive values) vs export (negative values). This is a subtle but important difference, and supporting both variables (`load` and `net_load`) in the datamodel will enable better defined functionality for users. For example, when validating load data, negative values should be treated as erroroneous. But negative values net load data should be treated as valid.
